### PR TITLE
ci: add Octo issue/PR feed workflows

### DIFF
--- a/.github/workflows/octo-issue-feed.yml
+++ b/.github/workflows/octo-issue-feed.yml
@@ -1,0 +1,20 @@
+name: Octo Issue Feed
+
+on:
+  issues:
+    types: [opened, closed, reopened, labeled]
+
+jobs:
+  notify:
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-issue-feed.yml@main
+    with:
+      repo_name: ${{ github.event.repository.name }}
+      issue_number: ${{ github.event.issue.number }}
+      issue_title: ${{ github.event.issue.title }}
+      issue_url: ${{ github.event.issue.html_url }}
+      issue_author: ${{ github.event.issue.user.login }}
+      issue_labels: ${{ toJson(github.event.issue.labels.*.name) }}
+      event_action: ${{ github.event.action }}
+      project_group_id: 288154967f614d7ca1faac21b5f2f8f0
+    secrets:
+      OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}

--- a/.github/workflows/octo-pr-feed.yml
+++ b/.github/workflows/octo-pr-feed.yml
@@ -1,0 +1,23 @@
+name: Octo PR Feed
+
+on:
+  pull_request:
+    types: [opened, closed, reopened, ready_for_review, review_requested]
+
+jobs:
+  notify:
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-feed.yml@main
+    with:
+      repo_name: ${{ github.event.repository.name }}
+      pr_number: ${{ github.event.pull_request.number }}
+      pr_title: ${{ github.event.pull_request.title }}
+      pr_url: ${{ github.event.pull_request.html_url }}
+      pr_author: ${{ github.event.pull_request.user.login }}
+      pr_merged: ${{ github.event.pull_request.merged }}
+      pr_additions: ${{ github.event.pull_request.additions }}
+      pr_deletions: ${{ github.event.pull_request.deletions }}
+      pr_changed_files: ${{ github.event.pull_request.changed_files }}
+      event_action: ${{ github.event.action }}
+      project_group_id: 288154967f614d7ca1faac21b5f2f8f0
+    secrets:
+      OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}


### PR DESCRIPTION
Add real-time GitHub event notification to Octo IM channels via GitHub Actions.

- `octo-issue-feed.yml`: pushes Issue events (opened/closed/reopened/labeled) to Octo 🛠️ issue-feed and the repo's project channel
- `octo-pr-feed.yml`: pushes PR events (opened/closed/merged/etc.) to Octo 🛠️ pr-feed and the repo's project channel