### PR TITLE
feat: add Docker Compose one-shot deployment stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Docker Compose local env (contains real passwords — never commit)
+docker/.env
+
 # Never commit real Secret files. Templates use the *-secret.example.yaml suffix
 # and are tracked; the populated copies must stay local.
 kustomize/**/*-secret.yaml

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,93 @@
+# -----------------------------------------------------------------------------
+# OCTO Server · docker stack environment
+# -----------------------------------------------------------------------------
+# Copy this file to `.env` and adjust the values for your deployment:
+#
+#     cp docker/.env.example docker/.env
+#
+# At minimum you MUST change:
+#   - MYSQL_ROOT_PASSWORD
+#   - MINIO_ROOT_PASSWORD
+#   - OCTO_MASTER_KEY  (generate with `openssl rand -hex 16`)
+#
+# Everything else has sane defaults for a single-host dev deployment.
+# -----------------------------------------------------------------------------
+
+# --- Domain & host --------------------------------------------------------
+OCTO_DOMAIN=octo.local
+OCTO_EXTERNAL_IP=127.0.0.1
+
+# --- Port mapping (host side) ---------------------------------------------
+OCTO_HTTP_PORT=28080
+OCTO_HTTPS_PORT=28443
+OCTO_SERVER_PORT=28081
+OCTO_ADMIN_PORT=28082
+OCTO_WEB_PORT=28083
+OCTO_MATTER_PORT=28086
+OCTO_SUMMARY_API_PORT=28087
+OCTO_WK_API_PORT=25001
+OCTO_WK_TCP_PORT=25100
+OCTO_WK_WS_PORT=25200
+OCTO_WK_MONITOR_PORT=25300
+OCTO_MYSQL_PORT=23306
+OCTO_REDIS_PORT=26379
+OCTO_MINIO_API_PORT=29000
+OCTO_MINIO_CONSOLE_PORT=29001
+
+# --- Docker network -------------------------------------------------------
+OCTO_NETWORK_SUBNET=172.28.0.0/16
+
+# --- Timezone -------------------------------------------------------------
+TZ=UTC
+
+# --- MySQL ----------------------------------------------------------------
+MYSQL_ROOT_PASSWORD=CHANGE_ME_MYSQL_PASSWORD
+MYSQL_DATABASE=octo
+
+# --- MinIO (S3-compatible object storage) ---------------------------------
+MINIO_ROOT_USER=octoadmin
+MINIO_ROOT_PASSWORD=CHANGE_ME_MINIO_PASSWORD
+MINIO_SERVER_URL=http://localhost:29000
+MINIO_BROWSER_REDIRECT_URL=http://localhost:29001
+
+# --- WuKongIM -------------------------------------------------------------
+# debug | release | bench
+WK_MODE=debug
+
+# WuKongIM advertised endpoints.
+# Local dev:   OCTO_WK_WS_ADDR=ws://octo.local:28080/ws
+# LAN:         OCTO_WK_WS_ADDR=ws://192.168.1.42:28080/ws
+# TLS in prod: OCTO_WK_WSS_ADDR=wss://octo.example.com/ws
+OCTO_WK_WS_ADDR=ws://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}/ws
+OCTO_WK_WSS_ADDR=
+OCTO_WK_TCP_ADDR=
+
+# --- OCTO Server ----------------------------------------------------------
+# Must be exactly 32 bytes. Generate with: openssl rand -hex 16
+OCTO_MASTER_KEY=CHANGE_ME_32_BYTES_octo_master_k
+
+# Optional HMAC-SHA256 shared secret for inbound webhooks.
+OCTO_WEBHOOK_SECRET_KEY=
+
+# --- Side services: matter, smart-summary --------------------------------
+# Generate with: openssl rand -hex 16
+OCTO_NOTIFY_INTERNAL_TOKEN=CHANGE_ME_notify_internal_token
+
+OCTO_MATTER_DB_PASSWORD=matter
+OCTO_SUMMARY_DB_PASSWORD=summary
+OCTO_SUMMARY_READER_PASSWORD=summary_reader
+
+OCTO_SUMMARY_API_URL=http://summary-api:8080
+
+# LLM used by octo-matter + octo-smart-summary.
+LLM_API_URL=https://api.example.com/v1
+LLM_API_KEY=
+LLM_MODEL=claude-sonnet-4-6
+
+# --- Image overrides -------------------------------------------------------
+# OCTO_SERVER_IMAGE=mininglamposs/octo-server:latest
+# OCTO_WEB_IMAGE=mininglamposs/octo-web:latest
+# OCTO_ADMIN_IMAGE=mininglamposs/octo-admin:latest
+# OCTO_MATTER_IMAGE=mininglamposs/octo-matter:latest
+# OCTO_SUMMARY_API_IMAGE=mininglamposs/octo-smart-summary-api:latest
+# OCTO_SUMMARY_WORKER_IMAGE=mininglamposs/octo-smart-summary-worker:latest

--- a/docker/configs/octo-server.yaml
+++ b/docker/configs/octo-server.yaml
@@ -1,0 +1,48 @@
+# -----------------------------------------------------------------------------
+# OCTO Server runtime config — minimal single-host deployment.
+# -----------------------------------------------------------------------------
+# Values shared with MySQL / Redis / MinIO / WuKongIM match the service
+# names (not ports) on the `octo-net` bridge network declared in
+# docker-compose.yaml. Do not change those strings unless you also rename
+# the corresponding compose services.
+#
+# Credentials with CHANGE_ME_* placeholders are overridden at runtime by
+# Viper's AutomaticEnv (prefix TS_) from the .env file. OSS users only
+# need to edit .env — not this file.
+# -----------------------------------------------------------------------------
+
+# Runtime mode: debug | release
+mode: "release"
+
+external:
+  ip: "127.0.0.1"
+  baseURL: "http://octo.local:28080"
+  # webLoginURL: "http://octo.local:28080/"
+
+# Test-only SMS verification code. Ignored in release mode.
+smsCode: ""
+
+db:
+  mysqlAddr: "root:CHANGE_ME_MYSQL_PASSWORD@tcp(mysql:3306)/octo?charset=utf8mb4&parseTime=true&loc=Local"
+  redisAddr: "redis:6379"
+  redisPass: ""
+
+wukongIM:
+  apiURL: "http://wukongim:5001"
+  managerToken: ""
+
+fileService: "minio"
+minio:
+  url: "http://minio:9000"
+  accessKeyID: "octoadmin"
+  secretAccessKey: "CHANGE_ME_MINIO_PASSWORD"
+
+logger:
+  level: 2
+  dir: "./logs"
+  lineNum: false
+
+register:
+  off: true
+  onlyChina: false
+  emailOn: false

--- a/docker/configs/wk.yaml
+++ b/docker/configs/wk.yaml
@@ -1,0 +1,27 @@
+# -----------------------------------------------------------------------------
+# WuKongIM configuration for the OCTO stack.
+# Mounted at /root/wukongim/wk.yaml inside the octo-wukongim container.
+# -----------------------------------------------------------------------------
+
+# debug | release | bench
+mode: "debug"
+
+tokenAuthOn: true
+
+# External addresses advertised to clients on GET /route.
+# Override via .env → OCTO_EXTERNAL_IP / OCTO_WK_WS_ADDR / OCTO_WK_WSS_ADDR.
+external:
+  ip: "127.0.0.1"
+  tcpAddr: ""
+  wsAddr: ""
+  wssAddr: ""
+
+monitor:
+  on: true
+  addr: "0.0.0.0:5300"
+
+webhook:
+  grpcAddr: "octo-server:6979"
+
+conversation:
+  on: true

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,333 @@
+# -----------------------------------------------------------------------------
+# OCTO Server · one-shot deployment stack (OSS)
+# -----------------------------------------------------------------------------
+# Brings up OCTO Server + all required dependencies behind an nginx reverse
+# proxy that serves a user-chosen domain (default: octo.local). Everything is
+# scoped under a dedicated Docker bridge so it does not collide with other
+# stacks on the host.
+#
+# Quick start:
+#
+#     cp docker/.env.example docker/.env
+#     # edit docker/.env — at minimum change passwords + OCTO_MASTER_KEY
+#     cd docker
+#     docker compose up -d
+#     # when healthy, visit http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}/api/v1/health
+#
+# Tear-down (removes volumes too):
+#
+#     docker compose down -v
+#
+# See docker/README.md for the full walkthrough.
+# -----------------------------------------------------------------------------
+
+name: octo
+
+networks:
+  octo-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: ${OCTO_NETWORK_SUBNET:-172.28.0.0/16}
+
+volumes:
+  mysql-data:
+  redis-data:
+  minio-data:
+  wukongim-data:
+  server-logs:
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: octo-mysql
+    restart: unless-stopped
+    command:
+      - --default-authentication-plugin=mysql_native_password
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_general_ci
+    environment:
+      TZ: ${TZ:-UTC}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-octo}
+      OCTO_MATTER_DB_PASSWORD: ${OCTO_MATTER_DB_PASSWORD:-matter}
+      OCTO_SUMMARY_DB_PASSWORD: ${OCTO_SUMMARY_DB_PASSWORD:-summary}
+      OCTO_SUMMARY_READER_PASSWORD: ${OCTO_SUMMARY_READER_PASSWORD:-summary_reader}
+    ports:
+      - "${OCTO_MYSQL_PORT:-23306}:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+      - ./scripts/init-extra-dbs.sh:/docker-entrypoint-initdb.d/01-extra-dbs.sh:ro
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+    networks:
+      - octo-net
+
+  redis:
+    image: redis:7-alpine
+    container_name: octo-redis
+    restart: unless-stopped
+    command: ["redis-server", "--save", "60", "1", "--loglevel", "warning"]
+    ports:
+      - "${OCTO_REDIS_PORT:-26379}:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    networks:
+      - octo-net
+
+  minio:
+    image: minio/minio:latest
+    container_name: octo-minio
+    restart: unless-stopped
+    command: ["server", "/data", "--console-address", ":9001"]
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-octoadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+      MINIO_SERVER_URL: ${MINIO_SERVER_URL:-http://localhost:29000}
+      MINIO_BROWSER_REDIRECT_URL: ${MINIO_BROWSER_REDIRECT_URL:-http://localhost:29001}
+    ports:
+      - "${OCTO_MINIO_API_PORT:-29000}:9000"
+      - "${OCTO_MINIO_CONSOLE_PORT:-29001}:9001"
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    networks:
+      - octo-net
+
+  wukongim:
+    image: wukongim/wukongim:latest
+    container_name: octo-wukongim
+    restart: unless-stopped
+    environment:
+      WK_MODE: ${WK_MODE:-debug}
+      WK_EXTERNAL_IP: ${OCTO_EXTERNAL_IP:-127.0.0.1}
+      WK_EXTERNAL_TCPADDR: ${OCTO_WK_TCP_ADDR:-}
+      WK_EXTERNAL_WSADDR:  ${OCTO_WK_WS_ADDR:-}
+      WK_EXTERNAL_WSSADDR: ${OCTO_WK_WSS_ADDR:-}
+    ports:
+      - "${OCTO_WK_API_PORT:-25001}:5001"
+      - "${OCTO_WK_TCP_PORT:-25100}:5100"
+      - "${OCTO_WK_WS_PORT:-25200}:5200"
+      - "${OCTO_WK_MONITOR_PORT:-25300}:5300"
+    volumes:
+      - wukongim-data:/root/wukongim
+      - ./configs/wk.yaml:/root/wukongim/wk.yaml:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost:5001/health >/dev/null 2>&1 || wget -q -O - http://localhost:5001/varz >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    networks:
+      - octo-net
+
+  octo-server:
+    image: ${OCTO_SERVER_IMAGE:-mininglamposs/octo-server:latest}
+    container_name: octo-server
+    restart: unless-stopped
+    command: ["api"]
+    environment:
+      TZ: ${TZ:-UTC}
+      OCTO_MASTER_KEY: ${OCTO_MASTER_KEY}
+      DMWORK_MASTER_KEY: ${OCTO_MASTER_KEY}
+      TS_WEBHOOK_SECRET_KEY: ${OCTO_WEBHOOK_SECRET_KEY:-}
+      TS_DB_MYSQLADDR: "root:${MYSQL_ROOT_PASSWORD}@tcp(mysql:3306)/${MYSQL_DATABASE:-octo}?charset=utf8mb4&parseTime=true&loc=Local"
+      TS_DB_REDISADDR: "redis:6379"
+      TS_MINIO_ACCESSKEYID: "${MINIO_ROOT_USER:-octoadmin}"
+      TS_MINIO_SECRETACCESSKEY: "${MINIO_ROOT_PASSWORD}"
+      NOTIFY_INTERNAL_TOKEN: ${OCTO_NOTIFY_INTERNAL_TOKEN:-}
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      wukongim:
+        condition: service_started
+      minio:
+        condition: service_healthy
+    ports:
+      - "${OCTO_SERVER_PORT:-28081}:8090"
+    volumes:
+      - ./configs/octo-server.yaml:/home/configs/tsdd.yaml:ro
+      - server-logs:/home/logs
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost:8090/v1/ping >/dev/null 2>&1 || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
+    networks:
+      - octo-net
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: octo-nginx
+    restart: unless-stopped
+    depends_on:
+      octo-server:
+        condition: service_healthy
+    environment:
+      OCTO_DOMAIN: ${OCTO_DOMAIN:-octo.local}
+    ports:
+      - "${OCTO_HTTP_PORT:-28080}:80"
+      # - "${OCTO_HTTPS_PORT:-28443}:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d:/etc/nginx/templates:ro
+      - ./nginx/empty-default.conf:/etc/nginx/conf.d/default.conf:ro
+      # - ./nginx/certs:/etc/nginx/certs:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost/_nginx_up >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    networks:
+      - octo-net
+
+  # ---------------------------------------------------------------------------
+  # Frontend: octo-web
+  # ---------------------------------------------------------------------------
+  web:
+    image: ${OCTO_WEB_IMAGE:-mininglamposs/octo-web:latest}
+    container_name: octo-web
+    restart: unless-stopped
+    depends_on:
+      octo-server:
+        condition: service_healthy
+    environment:
+      API_URL: http://octo-server:8090
+      SUMMARY_API_URL: ${OCTO_SUMMARY_API_URL:-http://summary-api:8080}
+    ports:
+      - "${OCTO_WEB_PORT:-28083}:80"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    networks:
+      - octo-net
+
+  # ---------------------------------------------------------------------------
+  # Admin console: octo-admin
+  # ---------------------------------------------------------------------------
+  admin:
+    image: ${OCTO_ADMIN_IMAGE:-mininglamposs/octo-admin:latest}
+    container_name: octo-admin
+    restart: unless-stopped
+    depends_on:
+      octo-server:
+        condition: service_healthy
+    environment:
+      API_BACKEND: octo-server:8090
+    ports:
+      - "${OCTO_ADMIN_PORT:-28082}:80"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1/admin/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    networks:
+      - octo-net
+
+  # ---------------------------------------------------------------------------
+  # Matter service (tasks / todos)
+  # ---------------------------------------------------------------------------
+  matter:
+    image: ${OCTO_MATTER_IMAGE:-mininglamposs/octo-matter:latest}
+    container_name: octo-matter
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+      octo-server:
+        condition: service_started
+    environment:
+      APP_ENV: ${MATTER_APP_ENV:-prod}
+      MYSQL_DSN: "matter:${OCTO_MATTER_DB_PASSWORD:-matter}@tcp(mysql:3306)/octo_matter?charset=utf8mb4&parseTime=true"
+      OCTO_IM_URL: http://octo-server:8090
+      SERVER_PORT: "8080"
+      NOTIFY_INTERNAL_TOKEN: ${OCTO_NOTIFY_INTERNAL_TOKEN}
+      LLM_API_URL: ${LLM_API_URL:-https://api.example.com/v1}
+      LLM_API_KEY: ${LLM_API_KEY:-}
+      LLM_MODEL: ${LLM_MODEL:-claude-sonnet-4-6}
+      LLM_TIMEOUT: "30"
+    ports:
+      - "${OCTO_MATTER_PORT:-28086}:8080"
+    networks:
+      - octo-net
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  # ---------------------------------------------------------------------------
+  # Smart summary API + worker
+  # ---------------------------------------------------------------------------
+  summary-api:
+    image: ${OCTO_SUMMARY_API_IMAGE:-mininglamposs/octo-smart-summary-api:latest}
+    container_name: octo-summary-api
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      MYSQL_DSN:    "summary:${OCTO_SUMMARY_DB_PASSWORD:-summary}@tcp(mysql:3306)/octo_summary?charset=utf8mb4&parseTime=true"
+      IM_MYSQL_DSN: "summary_reader:${OCTO_SUMMARY_READER_PASSWORD:-summary_reader}@tcp(mysql:3306)/${MYSQL_DATABASE:-octo}?charset=utf8mb4&parseTime=true"
+      OCTO_API_URL: http://octo-server:8090
+      LLM_API_URL:  ${LLM_API_URL:-https://api.example.com/v1}
+      LLM_API_KEY:  ${LLM_API_KEY:-}
+      LLM_MODEL:    ${LLM_MODEL:-claude-sonnet-4-6}
+      API_PORT:          "8080"
+      API_INTERNAL_PORT: "8081"
+      WORKER_TRIGGER_URL:      http://summary-worker:8082/trigger
+      WORKER_API_CALLBACK_URL: http://summary-api:8081
+    ports:
+      - "${OCTO_SUMMARY_API_PORT:-28087}:8080"
+    networks:
+      - octo-net
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  summary-worker:
+    image: ${OCTO_SUMMARY_WORKER_IMAGE:-mininglamposs/octo-smart-summary-worker:latest}
+    container_name: octo-summary-worker
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+      summary-api:
+        condition: service_started
+    environment:
+      MYSQL_DSN:    "summary:${OCTO_SUMMARY_DB_PASSWORD:-summary}@tcp(mysql:3306)/octo_summary?charset=utf8mb4&parseTime=true"
+      IM_MYSQL_DSN: "summary_reader:${OCTO_SUMMARY_READER_PASSWORD:-summary_reader}@tcp(mysql:3306)/${MYSQL_DATABASE:-octo}?charset=utf8mb4&parseTime=true"
+      OCTO_API_URL: http://octo-server:8090
+      LLM_API_URL:  ${LLM_API_URL:-https://api.example.com/v1}
+      LLM_API_KEY:  ${LLM_API_KEY:-}
+      LLM_MODEL:    ${LLM_MODEL:-claude-sonnet-4-6}
+      WORKER_INTERNAL_PORT:    "8082"
+      WORKER_API_CALLBACK_URL: http://summary-api:8081
+    networks:
+      - octo-net

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -1,0 +1,153 @@
+upstream octo_api {
+    server octo-server:8090;
+    keepalive 16;
+}
+
+upstream octo_ws {
+    server wukongim:5200;
+    keepalive 8;
+}
+
+upstream octo_minio_api {
+    server minio:9000;
+    keepalive 8;
+}
+
+upstream octo_minio_console {
+    server minio:9001;
+    keepalive 8;
+}
+
+server {
+    listen       80 default_server;
+    listen       [::]:80 default_server;
+    server_name  ${OCTO_DOMAIN} localhost _;
+
+    client_max_body_size    1000m;
+    client_body_buffer_size 8m;
+
+    location = /_nginx_up {
+        access_log off;
+        default_type text/plain;
+        return 200 "ok\n";
+    }
+
+    location /api/ {
+        proxy_pass         http://octo_api/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Connection        "";
+        proxy_read_timeout 600s;
+    }
+
+    location /ws {
+        proxy_pass          http://octo_ws;
+        proxy_http_version  1.1;
+        proxy_set_header    Upgrade           $http_upgrade;
+        proxy_set_header    Connection        "upgrade";
+        proxy_set_header    Host              $host;
+        proxy_set_header    X-Real-IP         $remote_addr;
+        proxy_set_header    X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header    X-Forwarded-Proto $scheme;
+        proxy_read_timeout  3600s;
+        proxy_send_timeout  3600s;
+    }
+
+    location /minio/ {
+        proxy_pass         http://octo_minio_api/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Connection        "";
+        proxy_read_timeout 600s;
+        proxy_request_buffering off;
+    }
+
+    location /minio-console/ {
+        proxy_pass         http://octo_minio_console/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location = /admin {
+        return 301 /admin/;
+    }
+    location /admin/ {
+        proxy_pass         http://admin/admin/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location /matter/ {
+        proxy_pass         http://matter:8080/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location /summary/ {
+        proxy_pass         http://summary-api:8080/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location = /_octo_up {
+        default_type text/html;
+        return 200 '<!doctype html>
+<html><head><meta charset="utf-8"><title>OCTO Server</title>
+<style>body{font-family:system-ui,sans-serif;max-width:640px;margin:3rem auto;padding:0 1rem;color:#222}h1{margin-bottom:.25rem}code{background:#f4f4f7;padding:2px 6px;border-radius:4px}ul{line-height:1.9}</style></head>
+<body><h1>OCTO Server</h1><p>The stack is up. Quick links:</p>
+<ul>
+<li><a href="/">Web (SPA)</a></li>
+<li><a href="/admin/">Admin console</a></li>
+<li><a href="/api/v1/ping">REST · <code>/api/v1/ping</code></a></li>
+<li><a href="/api/v1/health">REST · <code>/api/v1/health</code></a></li>
+<li><a href="/matter/health">Matter · <code>/matter/health</code></a></li>
+<li><a href="/summary/health">Smart-summary · <code>/summary/health</code></a></li>
+<li><a href="/minio-console/">MinIO console</a></li>
+</ul>
+<p>See <code>docker/.env.example</code> for configuration.</p></body></html>
+';
+    }
+
+    location / {
+        proxy_pass         http://web/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}
+
+# -----------------------------------------------------------------------------
+# HTTPS listener (disabled by default).
+# Enable by: uncommenting the 443 port in docker-compose.yaml, placing certs
+# under ./nginx/certs/, and uncommenting the block below.
+# -----------------------------------------------------------------------------
+# server {
+#     listen       443 ssl http2;
+#     listen       [::]:443 ssl http2;
+#     server_name  ${OCTO_DOMAIN};
+#     ssl_certificate      /etc/nginx/certs/fullchain.pem;
+#     ssl_certificate_key  /etc/nginx/certs/privkey.pem;
+#     ssl_protocols        TLSv1.2 TLSv1.3;
+#     ssl_ciphers          HIGH:!aNULL:!MD5;
+#     # paste the same location blocks as the HTTP listener above
+# }

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,0 +1,34 @@
+user  nginx;
+worker_processes  auto;
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    gzip  on;
+    gzip_min_length  1k;
+    gzip_vary        on;
+    gzip_proxied     any;
+    gzip_comp_level  2;
+    gzip_buffers     16 8k;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css application/json application/javascript
+               text/xml application/xml application/xml+rss text/javascript;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/docker/scripts/init-extra-dbs.sh
+++ b/docker/scripts/init-extra-dbs.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+# Extra databases for OCTO side-services.
+# Loaded ONCE on first MySQL container start via docker-entrypoint-initdb.d.
+#
+# This is a .sh (not .sql) so the mysql entrypoint executes it with a live
+# environment — letting the passwords and schema name come from .env instead
+# of being hard-coded. When the OCTO_*_DB_PASSWORD vars are unset, the
+# fallback values reproduce the pre-YUJ-446 behaviour.
+#
+# Side services (octo-matter, octo-smart-summary) run their own embedded
+# gorp migrations on boot, so we only create schemas + users here.
+#
+# Security model:
+#   - Passwords and db names are NOT interpolated into an SQL string
+#     unsafely. They are first validated against a strict allowlist so we
+#     can safely inline them (MySQL CREATE USER / GRANT do not accept
+#     prepared-statement parameters, so literal interpolation is the only
+#     option — validation makes that interpolation safe).
+#   - The allowlist is [A-Za-z0-9._-] for passwords and [A-Za-z0-9_] for
+#     db names. Anything outside causes this script to abort before
+#     touching MySQL. Users who need different characters should stop
+#     this container, fix the .env value, and re-init (or hand-run SQL
+#     against the running MySQL after quoting it themselves).
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+
+: "${OCTO_MATTER_DB_PASSWORD:=matter}"
+: "${OCTO_SUMMARY_DB_PASSWORD:=summary}"
+: "${OCTO_SUMMARY_READER_PASSWORD:=summary_reader}"
+: "${MYSQL_DATABASE:=octo}"
+
+validate_password() {
+  local name="$1"
+  local value="$2"
+  if [ -z "$value" ]; then
+    echo "[init-extra-dbs] FATAL: $name is empty" >&2
+    exit 1
+  fi
+  case "$value" in
+    *[!A-Za-z0-9._-]*)
+      echo "[init-extra-dbs] FATAL: $name contains characters outside [A-Za-z0-9._-]" >&2
+      echo "[init-extra-dbs]        ${name} must match that regex so this script can safely" >&2
+      echo "[init-extra-dbs]        inline it into the CREATE USER / GRANT statements." >&2
+      exit 1
+      ;;
+  esac
+}
+
+validate_identifier() {
+  local name="$1"
+  local value="$2"
+  if [ -z "$value" ]; then
+    echo "[init-extra-dbs] FATAL: $name is empty" >&2
+    exit 1
+  fi
+  case "$value" in
+    *[!A-Za-z0-9_]*)
+      echo "[init-extra-dbs] FATAL: $name contains characters outside [A-Za-z0-9_]" >&2
+      exit 1
+      ;;
+  esac
+}
+
+validate_password  OCTO_MATTER_DB_PASSWORD       "$OCTO_MATTER_DB_PASSWORD"
+validate_password  OCTO_SUMMARY_DB_PASSWORD      "$OCTO_SUMMARY_DB_PASSWORD"
+validate_password  OCTO_SUMMARY_READER_PASSWORD  "$OCTO_SUMMARY_READER_PASSWORD"
+validate_identifier MYSQL_DATABASE               "$MYSQL_DATABASE"
+
+mysql -u root -p"${MYSQL_ROOT_PASSWORD}" <<SQL
+-- Schemas ---------------------------------------------------------------------
+CREATE DATABASE IF NOT EXISTS octo_matter  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+CREATE DATABASE IF NOT EXISTS octo_summary CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+-- Service-scoped read-write accounts -----------------------------------------
+CREATE USER IF NOT EXISTS 'matter'@'%'  IDENTIFIED BY '${OCTO_MATTER_DB_PASSWORD}';
+CREATE USER IF NOT EXISTS 'summary'@'%' IDENTIFIED BY '${OCTO_SUMMARY_DB_PASSWORD}';
+
+-- Read-only account used by summary services to scan the IM schema -----------
+-- Principle of least privilege: smart-summary only needs SELECT on the IM
+-- schema, so we hand it a narrow account instead of the MySQL root
+-- credentials.
+CREATE USER IF NOT EXISTS 'summary_reader'@'%' IDENTIFIED BY '${OCTO_SUMMARY_READER_PASSWORD}';
+
+GRANT ALL PRIVILEGES ON octo_matter.*      TO 'matter'@'%';
+GRANT ALL PRIVILEGES ON octo_summary.*     TO 'summary'@'%';
+GRANT SELECT         ON \`${MYSQL_DATABASE}\`.* TO 'summary_reader'@'%';
+FLUSH PRIVILEGES;
+SQL
+
+echo "[init-extra-dbs] created octo_matter + octo_summary + service users (scoped to \`${MYSQL_DATABASE}\`)"


### PR DESCRIPTION
## Summary

- Add `docker/` directory with a full Docker Compose stack that brings up all OCTO services with a single `docker compose up -d`
- All images default to the public `mininglamposs/*` registry; each can be overridden via the corresponding `OCTO_*_IMAGE` env var
- Add `docker/.env` to `.gitignore` to prevent accidental credential leaks

## Files

| File | Description |
|------|-------------|
| `docker/docker-compose.yaml` | Full service orchestration (11 services) |
| `docker/.env.example` | Annotated environment variable template |
| `docker/configs/octo-server.yaml` | OCTO Server runtime config |
| `docker/configs/wk.yaml` | WuKongIM config |
| `docker/nginx/nginx.conf` | nginx main config |
| `docker/nginx/conf.d/octo.conf.template` | Virtual-host routing template (envsubst) |
| `docker/nginx/empty-default.conf` | Overrides nginx built-in default.conf to avoid routing conflicts |
| `docker/scripts/init-extra-dbs.sh` | Bootstraps matter / summary databases and users |

## Quick start

```bash
cp docker/.env.example docker/.env
# Edit docker/.env — at minimum set MYSQL_ROOT_PASSWORD, MINIO_ROOT_PASSWORD, OCTO_MASTER_KEY
cd docker
docker compose up -d
# Visit http://octo.local:28080/
```

## Test plan

- [x] `docker compose config` syntax validation passes
- [x] Infrastructure services (MySQL / Redis / MinIO / WuKongIM) all healthy
- [x] octo-server healthy; `/v1/ping` and `/v1/health` return expected responses
- [x] nginx routing: `/_nginx_up`, `/api/v1/health`, `/matter/health`, `/summary/health`, `/` (200) all pass
- [x] octo-web, octo-admin, matter, summary-api all healthy
- [x] `docker/.env` is gitignored and not tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)