### PR TITLE
ci: add auto-add-to-project caller (delegates to org reusable)

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,0 +1,17 @@
+# Caller: delegates to the org-level reusable workflow.
+# Adds every newly opened Issue and PR to Octo Project Board #2.
+name: Auto-add to Octo Board
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  add:
+    uses: Mininglamp-OSS/.github/.github/workflows/auto-add-to-project.yml@main
+    secrets:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## What

Deploys a lightweight caller for the org-level `auto-add-to-project` reusable workflow.

Every newly opened Issue or PR in this repo will be automatically added to [Octo Project Board #2](https://github.com/orgs/Mininglamp-OSS/projects/2).

## How it works

```
issues.opened / pull_request_target.opened
    → this caller
    → Mininglamp-OSS/.github / auto-add-to-project.yml (reusable)
    → actions/add-to-project@v1.0.2
    → Project Board #2
```

## Merge order

**Depends on** `Mininglamp-OSS/.github#4` (the reusable workflow) being merged to `main` first. This PR is safe to merge any time after that.