### PR TITLE
feat(docker): one-shot Docker Compose deployment stack (supersedes #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ kustomize/overlays/**
 !kustomize/overlays/dev/**
 !kustomize/overlays/prod/
 !kustomize/overlays/prod/**
+
+# nginx TLS material — keep certificates / keys out of the repo. The
+# `docker/nginx/certs/` mount is commented out in docker-compose.yaml
+# until an operator wires HTTPS, but the path is gitignored anyway so
+# `cp` / `mv` accidents do not commit a real cert.
+docker/nginx/certs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Docker Compose local env (contains real passwords — never commit)
+docker/.env
+
 # Never commit real Secret files. Templates use the *-secret.example.yaml suffix
 # and are tracked; the populated copies must stay local.
 kustomize/**/*-secret.yaml

--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ See [LICENSE](./LICENSE) for the full Apache 2.0 license terms.
 
 > 中文版：[README.zh.md](./README.zh.md)
 >
-> For a single-node Docker Compose trial use [`Mininglamp-OSS/octo-server`](https://github.com/Mininglamp-OSS/octo-server)'s `docker/octo/` stack — it is upstream-maintained and self-contained. This repository focuses on multi-node Kubernetes deployment.
+> For a **single-node Docker Compose** trial, use [`docker/`](./docker/) in
+> this repository — it brings up the full OCTO stack (server + admin + web +
+> matter + smart-summary + WuKongIM + MySQL + Redis + MinIO + nginx) with one
+> `docker compose up -d`. See [`docker/README.md`](./docker/README.md) for the
+> walkthrough. This `kustomize/` tree remains the canonical reference for
+> multi-node Kubernetes deployment.
 
 ## Components
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -170,10 +170,13 @@ OCTO_MINIO_APP_USER=octo-app
 OCTO_MINIO_APP_PASSWORD=CHANGE_ME_MINIO_APP_PASSWORD
 
 # These are intentionally absent from .env: docker-compose.yaml composes
-# MINIO_SERVER_URL from OCTO_DOMAIN + OCTO_HTTP_PORT so the public S3
-# endpoint matches the nginx /minio/ passthrough proxy. To point at a
-# different external URL, uncomment and set a literal value:
-# MINIO_SERVER_URL=https://octo.example.com/minio
+# MINIO_SERVER_URL from OCTO_DOMAIN + OCTO_MINIO_API_PORT so the public
+# S3 endpoint matches what octo-server tells clients in TS_MINIO_DOWNLOADURL
+# (presigned-URL host:port). SigV4 signatures cannot survive an nginx
+# `/minio/` path rewrite, so MinIO must advertise the same bare host:port
+# it is signed against. To point at a different external URL, uncomment
+# and set a literal value:
+# MINIO_SERVER_URL=https://octo.example.com:29000
 #
 # MINIO_BROWSER_REDIRECT_URL is left blank by default so MinIO renders
 # the console at whatever URL the request arrived on — the right
@@ -298,4 +301,5 @@ LLM_MODEL=claude-sonnet-4-6
 # OCTO_SUMMARY_API_IMAGE=mininglamposs/octo-smart-summary-api:latest
 # OCTO_SUMMARY_WORKER_IMAGE=mininglamposs/octo-smart-summary-worker:latest
 # OCTO_WK_IMAGE=wukongim/wukongim:v2.2.4-20260313
+# OCTO_MINIO_IMAGE=minio/minio:RELEASE.2025-04-22T22-12-26Z
 # OCTO_MINIO_MC_IMAGE=minio/mc:RELEASE.2025-04-16T18-13-26Z

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -7,9 +7,28 @@
 #
 # At minimum you MUST change:
 #   - MYSQL_ROOT_PASSWORD
+#       Use ONLY characters from [A-Za-z0-9._-]. Other characters (e.g.
+#       `@`, `#`, `!`, `$`, `&`, `:`, `/`) are not URL-safe in the Go
+#       MySQL DSN and break TS_DB_MYSQLADDR / DM_MYSQL_DSN parsing
+#       silently. `init-extra-dbs.sh` enforces this allowlist on first
+#       MySQL volume init. `openssl rand -hex 16` produces a value that
+#       always fits.
 #   - MINIO_ROOT_PASSWORD
+#       MinIO requires ≥8 characters; the placeholder below is 7 chars
+#       so an unrotated value also trips MinIO's own length validation
+#       at boot. The `minio-init` one-shot ALSO aborts the stack when
+#       this value (or OCTO_MINIO_APP_PASSWORD) still matches a
+#       `CHANGE_ME_*` / `CHG_ME*` placeholder pattern, so neither the
+#       MinIO API on 0.0.0.0:29000 nor the nginx-proxied MinIO console
+#       is reachable with a known-default credential.
 #   - OCTO_MINIO_APP_PASSWORD  (separate from MINIO_ROOT_PASSWORD;
 #     octo-server uses this scoped IAM credential, not root)
+#   - OCTO_MATTER_DB_PASSWORD / OCTO_SUMMARY_DB_PASSWORD /
+#     OCTO_SUMMARY_READER_PASSWORD  (MySQL service accounts; loopback-
+#     only by default but the `summary_reader` account holds SELECT on
+#     the OCTO IM schema, so a stack widening OCTO_MYSQL_BIND without
+#     rotating these hands an unauthenticated read snapshot to anyone
+#     who reaches :23306)
 #   - OCTO_MASTER_KEY  (generate with `openssl rand -hex 16`)
 #   - OCTO_NOTIFY_INTERNAL_TOKEN  (generate with `openssl rand -hex 32`)
 #   - OCTO_WUKONGIM_MANAGER_TOKEN (generate with `openssl rand -hex 32`)
@@ -33,6 +52,11 @@ OCTO_EXTERNAL_IP=127.0.0.1
 
 # --- Port mapping (host side) ---------------------------------------------
 OCTO_HTTP_PORT=28080
+# OCTO_HTTPS_PORT is read only when you uncomment the 443 publish line in
+# docker-compose.yaml (and the matching HTTPS server block in
+# nginx/conf.d/octo.conf.template). Leaving it set with HTTPS not wired
+# is harmless but does not enable TLS — see "Hardening checklist" in
+# docker/README.md for the steps.
 OCTO_HTTPS_PORT=28443
 OCTO_SERVER_PORT=28081
 OCTO_ADMIN_PORT=28082
@@ -57,16 +81,27 @@ OCTO_MINIO_CONSOLE_PORT=29001
 # OCTO server / admin / web / nginx / WuKongIM stay bound to 0.0.0.0
 # because they are meant to be reachable.
 #
+# IMPORTANT: Redis runs without authentication in this stack
+# (`docker-compose.yaml` does not set `--requirepass`). Widening
+# OCTO_REDIS_BIND to 0.0.0.0 therefore exposes an UNAUTHENTICATED Redis
+# instance to the internet — read AND write of the cache, including
+# session keys. Before flipping the bind, either:
+#   - keep Redis on the loopback / private interface only, or
+#   - add `--requirepass <secret>` to the redis service `command:` AND
+#     wire the same secret into TS_DB_REDISPASS / DM_REDIS_PASS on the
+#     octo-server service, so the application keeps reaching cache.
+# See `docker/README.md` "Hardening checklist" for the full procedure.
+#
 # MinIO API (OCTO_MINIO_API_BIND) is the asymmetric case: it defaults
 # to 0.0.0.0 because octo-server hands browser clients presigned
-# (SigV4) URLs that point at this port directly. nginx cannot proxy
-# those URLs without breaking the signature (the SigV4 canonical path
-# is signed), so the port has to be reachable from the same hosts that
-# hit the web UI. The application-scoped IAM credentials
-# (OCTO_MINIO_APP_*) and the presigned URL's short TTL — not the port
-# being closed — are what protect the data. Narrow back to 127.0.0.1
-# only for single-host evaluation deployments where every client also
-# lives on loopback.
+# (SigV4) URLs that point at the public host:port directly. nginx
+# cannot proxy those URLs without breaking the signature (the SigV4
+# canonical path is signed), so the port has to be reachable from the
+# same hosts that hit the web UI. The application-scoped IAM
+# credentials (OCTO_MINIO_APP_*) and the presigned URL's short TTL —
+# not the port being closed — are what protect the data. Narrow back
+# to 127.0.0.1 only for single-host evaluation deployments where every
+# client also lives on loopback.
 OCTO_MYSQL_BIND=127.0.0.1
 OCTO_REDIS_BIND=127.0.0.1
 OCTO_MINIO_API_BIND=0.0.0.0
@@ -82,12 +117,25 @@ OCTO_NETWORK_SUBNET=172.28.0.0/24
 TZ=UTC
 
 # --- MySQL ----------------------------------------------------------------
+# MUST be rotated before bringing the stack up. Use only characters from
+# [A-Za-z0-9._-] — `init-extra-dbs.sh` enforces that allowlist on first
+# volume init AND the same characters are URL-safe inside the Go MySQL
+# DSN that compose builds for octo-server / matter / summary
+# (TS_DB_MYSQLADDR, MYSQL_DSN, IM_MYSQL_DSN). Special characters such as
+# `@`, `#`, `!`, `$`, `&`, `:`, `/` will silently break DSN parsing.
+# `openssl rand -hex 16` produces a safe value.
 MYSQL_ROOT_PASSWORD=CHANGE_ME_MYSQL_PASSWORD
 MYSQL_DATABASE=octo
 
 # --- MinIO (S3-compatible object storage) ---------------------------------
 MINIO_ROOT_USER=octoadmin
-MINIO_ROOT_PASSWORD=CHANGE_ME_MINIO_PASSWORD
+# MinIO requires ≥8 characters for MINIO_ROOT_PASSWORD. The 7-char
+# placeholder below is intentional: it trips MinIO's own length check at
+# boot, so an unrotated `.env` cannot stand up the stack — defense in
+# depth on top of the `minio-init` placeholder check (see
+# docker-compose.yaml `minio-init` service) which also aborts on any
+# `CHANGE_ME_*` / `CHG_ME*` value. Generate with `openssl rand -hex 16`.
+MINIO_ROOT_PASSWORD=CHG_ME!
 
 # Application-scoped IAM user. The `minio-init` one-shot service creates
 # this user on first boot and attaches a policy that grants read/write/
@@ -104,10 +152,17 @@ OCTO_MINIO_APP_USER=octo-app
 OCTO_MINIO_APP_PASSWORD=CHANGE_ME_MINIO_APP_PASSWORD
 
 # These are intentionally absent from .env: docker-compose.yaml composes
-# them from OCTO_DOMAIN + OCTO_HTTP_PORT so the MinIO console redirect
-# works correctly when accessed via the nginx /minio-console/ route. To
-# point at a different external URL, uncomment and set a literal value:
+# MINIO_SERVER_URL from OCTO_DOMAIN + OCTO_HTTP_PORT so the public S3
+# endpoint matches the nginx /minio/ passthrough proxy. To point at a
+# different external URL, uncomment and set a literal value:
 # MINIO_SERVER_URL=https://octo.example.com/minio
+#
+# MINIO_BROWSER_REDIRECT_URL is left blank by default so MinIO renders
+# the console at whatever URL the request arrived on — the right
+# behaviour for the SSH-tunnel access path documented in
+# `docker/README.md` "Network surface". Set a literal value only if you
+# re-enable the nginx /minio-console/ route or front the console with a
+# different proxy:
 # MINIO_BROWSER_REDIRECT_URL=https://octo.example.com/minio-console/
 
 # --- WuKongIM -------------------------------------------------------------
@@ -151,15 +206,36 @@ OCTO_WUKONGIM_MANAGER_TOKEN=CHANGE_ME_wukongim_manager_token
 
 # --- Side services: matter, smart-summary --------------------------------
 # These three feed scripts/init-extra-dbs.sh, which runs ONLY on first
-# MySQL volume init. To rotate after the fact:
+# MySQL volume init.
+#
+# MUST be rotated before exposing the stack. MySQL is loopback-only by
+# default (OCTO_MYSQL_BIND=127.0.0.1), but the `summary_reader` account
+# below holds SELECT on the OCTO IM schema (see init-extra-dbs.sh GRANT
+# block) — flipping OCTO_MYSQL_BIND to 0.0.0.0 without rotating these
+# values hands an unauthenticated read snapshot of the IM schema to
+# anything that reaches `:23306`, and full DML on octo_matter /
+# octo_summary to anyone who guesses `matter` / `summary`.
+#
+# To rotate after the fact (the init script is one-shot and does NOT
+# re-run on subsequent boots):
 #   1. docker compose exec mysql mysql -uroot -p"$MYSQL_ROOT_PASSWORD" \
-#      -e "ALTER USER 'matter'@'%' IDENTIFIED BY '<new>'; FLUSH PRIVILEGES;"
-#   2. update OCTO_MATTER_DB_PASSWORD here
-#   3. docker compose up -d  (re-renders the matter container with the new DSN)
+#      -e "ALTER USER 'matter'@'%' IDENTIFIED BY '<new>'; \
+#          ALTER USER 'summary'@'%' IDENTIFIED BY '<new>'; \
+#          ALTER USER 'summary_reader'@'%' IDENTIFIED BY '<new>'; \
+#          FLUSH PRIVILEGES;"
+#   2. update OCTO_*_DB_PASSWORD here
+#   3. docker compose up -d  (re-renders the matter / summary containers
+#      with the new DSNs)
+#
+# Use only characters from [A-Za-z0-9._-]; `init-extra-dbs.sh` validates
+# the allowlist before inlining into CREATE USER / ALTER USER.
 OCTO_MATTER_DB_PASSWORD=matter
 OCTO_SUMMARY_DB_PASSWORD=summary
 OCTO_SUMMARY_READER_PASSWORD=summary_reader
 
+# Internal Docker DNS name; reachable only from inside the octo-net
+# bridge. Browser / SSR clients hit /summary/ via nginx instead. Override
+# only if you split summary-api onto a different network or deploy.
 OCTO_SUMMARY_API_URL=http://summary-api:8080
 
 # LLM used by octo-matter + octo-smart-summary.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -8,11 +8,15 @@
 # At minimum you MUST change:
 #   - MYSQL_ROOT_PASSWORD
 #   - MINIO_ROOT_PASSWORD
+#   - OCTO_MINIO_APP_PASSWORD  (separate from MINIO_ROOT_PASSWORD;
+#     octo-server uses this scoped IAM credential, not root)
 #   - OCTO_MASTER_KEY  (generate with `openssl rand -hex 16`)
 #   - OCTO_NOTIFY_INTERNAL_TOKEN  (generate with `openssl rand -hex 32`)
 #   - OCTO_WUKONGIM_MANAGER_TOKEN (generate with `openssl rand -hex 32`)
-#   - LLM_API_KEY  (only if you exercise matter / smart-summary —
-#     leave blank for an empty-stack smoke test)
+#   - LLM_API_KEY  (only if you exercise matter / smart-summary; the
+#     summary-worker boots with a placeholder key and stays "(healthy)"
+#     for an empty-stack smoke test, but every summarization call will
+#     fail until you set a real value)
 #
 # Everything else has sane defaults for a single-host dev deployment.
 #
@@ -58,10 +62,11 @@ OCTO_MINIO_CONSOLE_PORT=29001
 # (SigV4) URLs that point at this port directly. nginx cannot proxy
 # those URLs without breaking the signature (the SigV4 canonical path
 # is signed), so the port has to be reachable from the same hosts that
-# hit the web UI. Access keys (MINIO_ROOT_*) and the presigned URL's
-# short TTL — not the port being closed — are what protect the data.
-# Narrow back to 127.0.0.1 only for single-host evaluation deployments
-# where every client also lives on loopback.
+# hit the web UI. The application-scoped IAM credentials
+# (OCTO_MINIO_APP_*) and the presigned URL's short TTL — not the port
+# being closed — are what protect the data. Narrow back to 127.0.0.1
+# only for single-host evaluation deployments where every client also
+# lives on loopback.
 OCTO_MYSQL_BIND=127.0.0.1
 OCTO_REDIS_BIND=127.0.0.1
 OCTO_MINIO_API_BIND=0.0.0.0
@@ -83,6 +88,21 @@ MYSQL_DATABASE=octo
 # --- MinIO (S3-compatible object storage) ---------------------------------
 MINIO_ROOT_USER=octoadmin
 MINIO_ROOT_PASSWORD=CHANGE_ME_MINIO_PASSWORD
+
+# Application-scoped IAM user. The `minio-init` one-shot service creates
+# this user on first boot and attaches a policy that grants read/write/
+# delete on the bucket whitelist octo-server uses (file, chat, moment,
+# sticker, report, chatbg, common, download, group, avatar) — and
+# nothing else. octo-server signs presigned URLs with THIS pair, so a
+# leak of these credentials does NOT hand over `mc admin` / console /
+# IAM control the way leaking MINIO_ROOT_* would.
+#
+# Rotate by changing OCTO_MINIO_APP_PASSWORD and re-running
+# `docker compose up -d` — the init service re-applies the password and
+# leaves the policy in place.
+OCTO_MINIO_APP_USER=octo-app
+OCTO_MINIO_APP_PASSWORD=CHANGE_ME_MINIO_APP_PASSWORD
+
 # These are intentionally absent from .env: docker-compose.yaml composes
 # them from OCTO_DOMAIN + OCTO_HTTP_PORT so the MinIO console redirect
 # works correctly when accessed via the nginx /minio-console/ route. To
@@ -118,9 +138,14 @@ OCTO_WEBHOOK_SECRET_KEY=
 # authenticate internal callbacks. Generate with: openssl rand -hex 32
 OCTO_NOTIFY_INTERNAL_TOKEN=CHANGE_ME_notify_internal_token
 
-# WuKongIM admin token. Set on BOTH WuKongIM (WK_TOKEN, picked up by
-# wk.yaml's tokenAuthOn) AND octo-server (WUKONGIM_MANAGER_TOKEN). They
-# come from the same .env value so they cannot drift.
+# WuKongIM admin token. Set on BOTH WuKongIM (env var WK_MANAGERTOKEN —
+# Viper auto-binds it to the `managerToken` YAML key) AND octo-server
+# (TS_WUKONGIM_MANAGERTOKEN). They come from the same .env value below
+# so they cannot drift. wk.yaml ships with `tokenAuthOn: true`, and the
+# wukongim image is pinned to a release that honours that — leaving
+# this empty means BOTH ends short-circuit token comparison and accept
+# any string, so admin endpoints are reachable AND USABLE without
+# credentials. Set a real value before exposing the stack.
 # Generate with: openssl rand -hex 32
 OCTO_WUKONGIM_MANAGER_TOKEN=CHANGE_ME_wukongim_manager_token
 
@@ -139,9 +164,16 @@ OCTO_SUMMARY_API_URL=http://summary-api:8080
 
 # LLM used by octo-matter + octo-smart-summary.
 LLM_API_URL=https://api.example.com/v1
-# Required when exercising matter / smart-summary — both services treat
-# an empty key as a misconfig at first call. Leave blank only for an
-# empty-stack smoke test that never invokes LLM features.
+# Required when actually using matter / smart-summary features. Leaving
+# this blank is supported for an empty-stack smoke test:
+#   - octo-matter and summary-api treat an empty key as a misconfig at
+#     first LLM call (services still boot and reach (healthy)).
+#   - summary-worker (cmd/summary-worker/main.go) calls
+#     config.ValidateRequired on LLM_API_KEY and exits the process when
+#     it's empty. The compose file therefore falls back to a fake
+#     placeholder so the worker still boots — see the summary-worker
+#     `environment:` block. It will reach (healthy) but every actual
+#     summarization call will fail until a real key is set here.
 LLM_API_KEY=
 LLM_MODEL=claude-sonnet-4-6
 
@@ -160,3 +192,5 @@ LLM_MODEL=claude-sonnet-4-6
 # OCTO_MATTER_IMAGE=mininglamposs/octo-matter:latest
 # OCTO_SUMMARY_API_IMAGE=mininglamposs/octo-smart-summary-api:latest
 # OCTO_SUMMARY_WORKER_IMAGE=mininglamposs/octo-smart-summary-worker:latest
+# OCTO_WK_IMAGE=wukongim/wukongim:v2.2.4-20260313
+# OCTO_MINIO_MC_IMAGE=minio/mc:RELEASE.2025-04-16T18-13-26Z

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -78,8 +78,18 @@ OCTO_MINIO_CONSOLE_PORT=29001
 # expose a public-facing service. Override to 0.0.0.0 only after
 # rotating credentials and placing the host behind a firewall.
 #
-# OCTO server / admin / web / nginx / WuKongIM stay bound to 0.0.0.0
-# because they are meant to be reachable.
+# OCTO web / admin / nginx stay bound to 0.0.0.0 because they are the
+# user-facing entrypoints. WuKongIM API/TCP/WS publish on 0.0.0.0 too
+# (chat clients dial them); only the WuKongIM monitor port is loopback
+# by default — it is an admin / observability surface, not a transport.
+#
+# octo-server / matter / summary-api have direct host ports for
+# operator smoke tests. Production traffic for those services flows
+# through nginx (`/api/`, `/v1/`, `/matter/`, `/summary/`) where the
+# octo_api / octo_auth rate-limit zones (nginx.conf:31-32) apply. The
+# direct ports skip those limits, so they are loopback-only by default.
+# Flip the matching OCTO_*_BIND var to 0.0.0.0 only when an operator
+# needs the bypass and accepts the loss of rate-limiting.
 #
 # IMPORTANT: Redis runs without authentication in this stack
 # (`docker-compose.yaml` does not set `--requirepass`). Widening
@@ -106,6 +116,10 @@ OCTO_MYSQL_BIND=127.0.0.1
 OCTO_REDIS_BIND=127.0.0.1
 OCTO_MINIO_API_BIND=0.0.0.0
 OCTO_MINIO_CONSOLE_BIND=127.0.0.1
+OCTO_WK_MONITOR_BIND=127.0.0.1
+OCTO_SERVER_BIND=127.0.0.1
+OCTO_MATTER_BIND=127.0.0.1
+OCTO_SUMMARY_API_BIND=127.0.0.1
 
 # --- Docker network -------------------------------------------------------
 # /24 is enough for the full stack (~12 containers); narrower than the
@@ -124,6 +138,10 @@ TZ=UTC
 # (TS_DB_MYSQLADDR, MYSQL_DSN, IM_MYSQL_DSN). Special characters such as
 # `@`, `#`, `!`, `$`, `&`, `:`, `/` will silently break DSN parsing.
 # `openssl rand -hex 16` produces a safe value.
+#
+# `init-extra-dbs.sh` also refuses any `CHANGE_ME_*` / `CHG_ME*` casing
+# for this value, so an unrotated `.env` cannot complete the first
+# MySQL volume init.
 MYSQL_ROOT_PASSWORD=CHANGE_ME_MYSQL_PASSWORD
 MYSQL_DATABASE=octo
 
@@ -191,6 +209,12 @@ OCTO_WEBHOOK_SECRET_KEY=
 # --- Inter-service auth ---------------------------------------------------
 # Shared HMAC secret octo-server <-> octo-matter / smart-summary use to
 # authenticate internal callbacks. Generate with: openssl rand -hex 32
+#
+# The `preflight` one-shot service refuses any `CHANGE_ME_*` / `CHG_ME*`
+# casing for this value, so an unrotated `.env` cannot bring the stack
+# up. octo-server's `NOTIFY_INTERNAL_TOKEN` env entry has no `:-`
+# default, so a missing / empty value also surfaces as a compose
+# warning at render time.
 OCTO_NOTIFY_INTERNAL_TOKEN=CHANGE_ME_notify_internal_token
 
 # WuKongIM admin token. Set on BOTH WuKongIM (env var WK_MANAGERTOKEN —
@@ -202,6 +226,8 @@ OCTO_NOTIFY_INTERNAL_TOKEN=CHANGE_ME_notify_internal_token
 # any string, so admin endpoints are reachable AND USABLE without
 # credentials. Set a real value before exposing the stack.
 # Generate with: openssl rand -hex 32
+#
+# `preflight` also refuses any `CHANGE_ME_*` / `CHG_ME*` casing here.
 OCTO_WUKONGIM_MANAGER_TOKEN=CHANGE_ME_wukongim_manager_token
 
 # --- Side services: matter, smart-summary --------------------------------
@@ -228,7 +254,10 @@ OCTO_WUKONGIM_MANAGER_TOKEN=CHANGE_ME_wukongim_manager_token
 #      with the new DSNs)
 #
 # Use only characters from [A-Za-z0-9._-]; `init-extra-dbs.sh` validates
-# the allowlist before inlining into CREATE USER / ALTER USER.
+# the allowlist before inlining into CREATE USER / ALTER USER. The
+# script also rejects the literal-string defaults below (`matter`,
+# `summary`, `summary_reader`) — leaving any of them unrotated
+# fails the first MySQL volume init with a clear error.
 OCTO_MATTER_DB_PASSWORD=matter
 OCTO_SUMMARY_DB_PASSWORD=summary
 OCTO_SUMMARY_READER_PASSWORD=summary_reader

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -45,16 +45,26 @@ OCTO_MINIO_API_PORT=29000
 OCTO_MINIO_CONSOLE_PORT=29001
 
 # --- Backing-service host bindings ---------------------------------------
-# MySQL / Redis / MinIO are bound to 127.0.0.1 by default so a missed-config
-# moment (placeholder passwords still in place) does NOT expose a public-
-# facing service. Override to 0.0.0.0 only after rotating credentials and
-# placing the host behind a firewall.
+# MySQL / Redis / MinIO console are bound to 127.0.0.1 by default so a
+# missed-config moment (placeholder passwords still in place) does NOT
+# expose a public-facing service. Override to 0.0.0.0 only after
+# rotating credentials and placing the host behind a firewall.
 #
-# OCTO server / admin / web / nginx / WuKongIM stay bound to 0.0.0.0 because
-# they are meant to be reachable.
+# OCTO server / admin / web / nginx / WuKongIM stay bound to 0.0.0.0
+# because they are meant to be reachable.
+#
+# MinIO API (OCTO_MINIO_API_BIND) is the asymmetric case: it defaults
+# to 0.0.0.0 because octo-server hands browser clients presigned
+# (SigV4) URLs that point at this port directly. nginx cannot proxy
+# those URLs without breaking the signature (the SigV4 canonical path
+# is signed), so the port has to be reachable from the same hosts that
+# hit the web UI. Access keys (MINIO_ROOT_*) and the presigned URL's
+# short TTL — not the port being closed — are what protect the data.
+# Narrow back to 127.0.0.1 only for single-host evaluation deployments
+# where every client also lives on loopback.
 OCTO_MYSQL_BIND=127.0.0.1
 OCTO_REDIS_BIND=127.0.0.1
-OCTO_MINIO_API_BIND=127.0.0.1
+OCTO_MINIO_API_BIND=0.0.0.0
 OCTO_MINIO_CONSOLE_BIND=127.0.0.1
 
 # --- Docker network -------------------------------------------------------

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,139 @@
+# -----------------------------------------------------------------------------
+# OCTO Server · docker stack environment
+# -----------------------------------------------------------------------------
+# Copy this file to `.env` and adjust the values for your deployment:
+#
+#     cp docker/.env.example docker/.env
+#
+# At minimum you MUST change:
+#   - MYSQL_ROOT_PASSWORD
+#   - MINIO_ROOT_PASSWORD
+#   - OCTO_MASTER_KEY  (generate with `openssl rand -hex 16`)
+#   - OCTO_NOTIFY_INTERNAL_TOKEN  (generate with `openssl rand -hex 32`)
+#   - OCTO_WUKONGIM_MANAGER_TOKEN (generate with `openssl rand -hex 32`)
+#
+# Everything else has sane defaults for a single-host dev deployment.
+#
+# Note on `${...}` inside .env values:
+#   Compose interpolates `.env` values exactly once into the YAML; values
+#   that themselves contain `${...}` are NOT recursively expanded. Keep
+#   `.env` values literal — composition (e.g. building WuKongIM ws addr or
+#   MinIO redirect URLs from the domain + port) lives in docker-compose.yaml.
+# -----------------------------------------------------------------------------
+
+# --- Domain & host --------------------------------------------------------
+OCTO_DOMAIN=octo.local
+OCTO_EXTERNAL_IP=127.0.0.1
+
+# --- Port mapping (host side) ---------------------------------------------
+OCTO_HTTP_PORT=28080
+OCTO_HTTPS_PORT=28443
+OCTO_SERVER_PORT=28081
+OCTO_ADMIN_PORT=28082
+OCTO_WEB_PORT=28083
+OCTO_MATTER_PORT=28086
+OCTO_SUMMARY_API_PORT=28087
+OCTO_WK_API_PORT=25001
+OCTO_WK_TCP_PORT=25100
+OCTO_WK_WS_PORT=25200
+OCTO_WK_MONITOR_PORT=25300
+OCTO_MYSQL_PORT=23306
+OCTO_REDIS_PORT=26379
+OCTO_MINIO_API_PORT=29000
+OCTO_MINIO_CONSOLE_PORT=29001
+
+# --- Backing-service host bindings ---------------------------------------
+# MySQL / Redis / MinIO are bound to 127.0.0.1 by default so a missed-config
+# moment (placeholder passwords still in place) does NOT expose a public-
+# facing service. Override to 0.0.0.0 only after rotating credentials and
+# placing the host behind a firewall.
+#
+# OCTO server / admin / web / nginx / WuKongIM stay bound to 0.0.0.0 because
+# they are meant to be reachable.
+OCTO_MYSQL_BIND=127.0.0.1
+OCTO_REDIS_BIND=127.0.0.1
+OCTO_MINIO_API_BIND=127.0.0.1
+OCTO_MINIO_CONSOLE_BIND=127.0.0.1
+
+# --- Docker network -------------------------------------------------------
+# /24 is enough for the full stack (~12 containers); narrower than the
+# original /16 so it is less likely to collide with corporate VPN / VPC
+# ranges. Widen if you plan to colocate other compose stacks on octo-net.
+OCTO_NETWORK_SUBNET=172.28.0.0/24
+
+# --- Timezone -------------------------------------------------------------
+TZ=UTC
+
+# --- MySQL ----------------------------------------------------------------
+MYSQL_ROOT_PASSWORD=CHANGE_ME_MYSQL_PASSWORD
+MYSQL_DATABASE=octo
+
+# --- MinIO (S3-compatible object storage) ---------------------------------
+MINIO_ROOT_USER=octoadmin
+MINIO_ROOT_PASSWORD=CHANGE_ME_MINIO_PASSWORD
+# These are intentionally absent from .env: docker-compose.yaml composes
+# them from OCTO_DOMAIN + OCTO_HTTP_PORT so the MinIO console redirect
+# works correctly when accessed via the nginx /minio-console/ route. To
+# point at a different external URL, uncomment and set a literal value:
+# MINIO_SERVER_URL=https://octo.example.com/minio
+# MINIO_BROWSER_REDIRECT_URL=https://octo.example.com/minio-console/
+
+# --- WuKongIM -------------------------------------------------------------
+# debug | release | bench
+WK_MODE=debug
+
+# WuKongIM advertised endpoints. LEAVE BLANK for the OOTB default
+# (compose builds ws://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}/ws). Set a literal
+# value if you front the stack with TLS or a different hostname:
+#   OCTO_WK_WS_ADDR=ws://192.168.1.42:28080/ws
+#   OCTO_WK_WSS_ADDR=wss://octo.example.com/ws
+OCTO_WK_WS_ADDR=
+OCTO_WK_WSS_ADDR=
+OCTO_WK_TCP_ADDR=
+
+# --- OCTO Server ----------------------------------------------------------
+# Must be exactly 32 bytes. Generate with: openssl rand -hex 16
+# The placeholder below is intentionally 31 chars so that octo-server
+# rejects an unconfigured key on startup instead of booting with a known
+# weak default.
+OCTO_MASTER_KEY=CHANGE_ME_32_BYTES_octo_master_
+
+# Optional HMAC-SHA256 shared secret for inbound webhooks.
+OCTO_WEBHOOK_SECRET_KEY=
+
+# --- Inter-service auth ---------------------------------------------------
+# Shared HMAC secret octo-server <-> octo-matter / smart-summary use to
+# authenticate internal callbacks. Generate with: openssl rand -hex 32
+OCTO_NOTIFY_INTERNAL_TOKEN=CHANGE_ME_notify_internal_token
+
+# WuKongIM admin token. Set on BOTH WuKongIM (WK_TOKEN, picked up by
+# wk.yaml's tokenAuthOn) AND octo-server (WUKONGIM_MANAGER_TOKEN). They
+# come from the same .env value so they cannot drift.
+# Generate with: openssl rand -hex 32
+OCTO_WUKONGIM_MANAGER_TOKEN=CHANGE_ME_wukongim_manager_token
+
+# --- Side services: matter, smart-summary --------------------------------
+# These three feed scripts/init-extra-dbs.sh, which runs ONLY on first
+# MySQL volume init. To rotate after the fact:
+#   1. docker compose exec mysql mysql -uroot -p"$MYSQL_ROOT_PASSWORD" \
+#      -e "ALTER USER 'matter'@'%' IDENTIFIED BY '<new>'; FLUSH PRIVILEGES;"
+#   2. update OCTO_MATTER_DB_PASSWORD here
+#   3. docker compose up -d  (re-renders the matter container with the new DSN)
+OCTO_MATTER_DB_PASSWORD=matter
+OCTO_SUMMARY_DB_PASSWORD=summary
+OCTO_SUMMARY_READER_PASSWORD=summary_reader
+
+OCTO_SUMMARY_API_URL=http://summary-api:8080
+
+# LLM used by octo-matter + octo-smart-summary.
+LLM_API_URL=https://api.example.com/v1
+LLM_API_KEY=
+LLM_MODEL=claude-sonnet-4-6
+
+# --- Image overrides -------------------------------------------------------
+# OCTO_SERVER_IMAGE=mininglamposs/octo-server:latest
+# OCTO_WEB_IMAGE=mininglamposs/octo-web:latest
+# OCTO_ADMIN_IMAGE=mininglamposs/octo-admin:latest
+# OCTO_MATTER_IMAGE=mininglamposs/octo-matter:latest
+# OCTO_SUMMARY_API_IMAGE=mininglamposs/octo-smart-summary-api:latest
+# OCTO_SUMMARY_WORKER_IMAGE=mininglamposs/octo-smart-summary-worker:latest

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -11,6 +11,8 @@
 #   - OCTO_MASTER_KEY  (generate with `openssl rand -hex 16`)
 #   - OCTO_NOTIFY_INTERNAL_TOKEN  (generate with `openssl rand -hex 32`)
 #   - OCTO_WUKONGIM_MANAGER_TOKEN (generate with `openssl rand -hex 32`)
+#   - LLM_API_KEY  (only if you exercise matter / smart-summary —
+#     leave blank for an empty-stack smoke test)
 #
 # Everything else has sane defaults for a single-host dev deployment.
 #
@@ -127,8 +129,19 @@ OCTO_SUMMARY_API_URL=http://summary-api:8080
 
 # LLM used by octo-matter + octo-smart-summary.
 LLM_API_URL=https://api.example.com/v1
+# Required when exercising matter / smart-summary — both services treat
+# an empty key as a misconfig at first call. Leave blank only for an
+# empty-stack smoke test that never invokes LLM features.
 LLM_API_KEY=
 LLM_MODEL=claude-sonnet-4-6
+
+# --- First-admin bootstrap (optional) -------------------------------------
+# When set AND the docker-compose.yaml octo-server service has the
+# matching `TS_ADMINPWD: ${OCTO_ADMIN_PWD:-}` line uncommented,
+# octo-server will seed a superAdmin row on first start (username
+# "superAdmin", password = bcrypt of this value). See
+# docker/README.md → "First-admin bootstrap" before enabling.
+# OCTO_ADMIN_PWD=
 
 # --- Image overrides -------------------------------------------------------
 # OCTO_SERVER_IMAGE=mininglamposs/octo-server:latest

--- a/docker/README.md
+++ b/docker/README.md
@@ -24,8 +24,8 @@ cd octo-deployment
 
 cp docker/.env.example docker/.env
 # Edit docker/.env — at minimum change the placeholders flagged in the file:
-#   MYSQL_ROOT_PASSWORD, MINIO_ROOT_PASSWORD, OCTO_MASTER_KEY,
-#   OCTO_NOTIFY_INTERNAL_TOKEN, OCTO_WUKONGIM_MANAGER_TOKEN
+#   MYSQL_ROOT_PASSWORD, MINIO_ROOT_PASSWORD, OCTO_MINIO_APP_PASSWORD,
+#   OCTO_MASTER_KEY, OCTO_NOTIFY_INTERNAL_TOKEN, OCTO_WUKONGIM_MANAGER_TOKEN
 
 cd docker
 docker compose config            # validate before starting
@@ -54,11 +54,12 @@ backing-service guards in `init-extra-dbs.sh`.
 | Variable | What it is | How to generate |
 | --- | --- | --- |
 | `MYSQL_ROOT_PASSWORD` | MySQL `root` password (also embedded in `TS_DB_MYSQLADDR` / `DM_MYSQL_DSN`) | `openssl rand -hex 16` |
-| `MINIO_ROOT_PASSWORD` | MinIO root credential | `openssl rand -hex 16` |
+| `MINIO_ROOT_PASSWORD` | MinIO root credential — used by `mc admin`, the MinIO console, and the `minio-init` bootstrap. NOT used by octo-server. | `openssl rand -hex 16` |
+| `OCTO_MINIO_APP_PASSWORD` | Application-scoped IAM secret. octo-server signs presigned URLs with this credential pair (NOT the root pair). The `minio-init` service creates the user and attaches the bucket-scoped policy on first boot. | `openssl rand -hex 24` |
 | `OCTO_MASTER_KEY` | 32-byte server master key | `openssl rand -hex 16` |
 | `OCTO_NOTIFY_INTERNAL_TOKEN` | HMAC secret octo-server ↔ matter / smart-summary share | `openssl rand -hex 32` |
-| `OCTO_WUKONGIM_MANAGER_TOKEN` | WuKongIM admin token, also used by octo-server | `openssl rand -hex 32` |
-| `LLM_API_KEY` | LLM provider key consumed by matter + smart-summary (required for those features; leave blank for a smoke-test stack) | from your provider |
+| `OCTO_WUKONGIM_MANAGER_TOKEN` | WuKongIM admin token. Bound on WuKongIM via `WK_MANAGERTOKEN` (Viper auto-binds to YAML `managerToken`) and on octo-server via `TS_WUKONGIM_MANAGERTOKEN`. Leaving it empty makes WuKongIM's manager API reachable AND USABLE without auth — set a real value before exposing the stack. | `openssl rand -hex 32` |
+| `LLM_API_KEY` | LLM provider key consumed by matter + smart-summary. Required for those features. The compose file falls back to a fake placeholder for `summary-worker` so the OOTB stack still reaches `(healthy)` — actual summarization calls fail until this is set. | from your provider |
 
 Everything else has sane defaults documented inline in
 [`docker/.env.example`](.env.example).
@@ -111,8 +112,12 @@ path prefix) in `docker-compose.yaml`.
 
 The data is protected by:
 
-- the MinIO root credentials (`MINIO_ROOT_*`) — never sent over the
-  wire by the server,
+- the **application-scoped IAM credentials** (`OCTO_MINIO_APP_*`) that
+  octo-server signs with — provisioned by the one-shot `minio-init`
+  service (see "MinIO bootstrap & credential scoping" below). These
+  credentials grant read/write/delete on the bucket whitelist and
+  nothing else; they do NOT grant `mc admin` / IAM / console rights,
+  and the MinIO root pair never reaches octo-server's environment.
 - the **short TTL** of every presigned URL (minutes, not days),
 - octo-server's authorisation layer in front of `/api/v1/file/*`.
 
@@ -123,6 +128,49 @@ range that can reach `28080` — do not block it.
 If you absolutely need every public port to live behind nginx, you'd
 need a SigV4-aware proxy (e.g. one that re-signs each request) — that
 is out of scope for this compose stack.
+
+---
+
+## MinIO bootstrap & credential scoping
+
+The stack ships with an `octo-server` MinIO client that is **not** the
+MinIO root user. On first start the `minio-init` one-shot service
+runs after `minio` becomes healthy and:
+
+1. Creates the IAM user named in `OCTO_MINIO_APP_USER` (default
+   `octo-app`) with the password from `OCTO_MINIO_APP_PASSWORD`.
+2. (Re)installs the `octo-app` policy from
+   [`docker/configs/minio-octo-app-policy.json`](configs/minio-octo-app-policy.json),
+   which grants `s3:GetObject`/`PutObject`/`DeleteObject`/multipart
+   actions plus `s3:ListBucket` on the bucket whitelist octo-server
+   uses (`file`, `chat`, `moment`, `sticker`, `report`, `chatbg`,
+   `common`, `download`, `group`, `avatar`). Notably absent:
+   `s3:CreateBucket`, `mc admin` rights, console access, IAM control.
+3. Attaches the policy to `octo-app`.
+4. Pre-creates each whitelisted bucket so the first
+   `/api/v1/file/upload` call does not depend on the app user holding
+   bucket admin privileges.
+
+`octo-server` then runs with the app credentials only — root credentials
+live exclusively in the `minio-init` job, the `mc` CLI path, and the
+console. A leak of `octo-server`'s environment / config-map / log
+spillage gives an attacker bucket-level data access at most, not the
+ability to add users, change root, or take over the cluster.
+
+To rotate the app password:
+
+```bash
+# 1. set new value in docker/.env
+sed -i 's/^OCTO_MINIO_APP_PASSWORD=.*/OCTO_MINIO_APP_PASSWORD=<new>/' docker/.env
+# 2. re-run the stack — minio-init is idempotent, will reset the secret,
+#    octo-server picks it up on its next env render
+docker compose up -d
+```
+
+To rotate the policy itself, edit
+`docker/configs/minio-octo-app-policy.json` and re-run `docker compose
+up -d` — `minio-init` calls `mc admin policy update` whenever the
+policy already exists.
 
 ---
 
@@ -228,8 +276,17 @@ Before exposing the stack beyond a developer laptop:
 - Narrow `OCTO_NETWORK_SUBNET` further (already defaults to `/24`) if
   it overlaps an existing VPN / VPC range.
 - Set a real `OCTO_WUKONGIM_MANAGER_TOKEN`. WuKongIM's `tokenAuthOn`
-  is true in `wk.yaml`; an empty token means admin endpoints are
-  reachable but unusable.
+  is `true` in `wk.yaml`, but the token is bound from the env var
+  `WK_MANAGERTOKEN` (Viper auto-binds upper-case `WK_<KEY>` to the
+  YAML key). When that env var is empty, BOTH WuKongIM and
+  octo-server short-circuit token comparison and accept any string,
+  so the manager API stays reachable AND USABLE without auth — the
+  opposite of the safe-by-default behaviour the wording on this line
+  used to imply. The wukongim image is pinned to a specific release
+  (`v2.2.4-20260313`) precisely so the env-var contract is stable;
+  if you bump `OCTO_WK_IMAGE`, re-validate that
+  `WK_MANAGERTOKEN` still binds and that `tokenAuthOn: true` is not
+  rejected at startup on the new tag.
 - Set `OCTO_WEBHOOK_SECRET_KEY` if you accept inbound webhooks.
 - Switch `OCTO_DOMAIN` to a real hostname and front the stack with TLS
   (uncomment the `443` block in `docker-compose.yaml` and the HTTPS
@@ -330,6 +387,25 @@ for p in /_nginx_up /api/v1/health /matter/health /summary/health /; do
 done
 ```
 
+The `summary-worker` container has no public route — it serves
+`/internal/healthz` on port `8082` inside the `octo-net` network only.
+The route covered by the docker healthcheck above is not reachable from
+the host. To verify the worker explicitly (covers `LLM_API_KEY` /
+`MYSQL_DSN` validation, which would otherwise show up only as a stuck
+`(starting)` state):
+
+```bash
+docker compose exec summary-worker \
+  wget -qO- http://localhost:8082/internal/healthz
+docker compose ps summary-worker   # expect (healthy)
+```
+
+If the container is stuck `(unhealthy)` / restarting, inspect
+`docker compose logs summary-worker | tail -50` for `required environment
+variables not set` — the most common OOTB cause is an empty
+`LLM_API_KEY` paired with an `OCTO_SUMMARY_WORKER_IMAGE` pin that
+predates the placeholder fallback in `docker-compose.yaml`.
+
 ---
 
 ## Layout
@@ -341,7 +417,8 @@ docker/
 ├── README.md                 # this file
 ├── configs/
 │   ├── octo-server.yaml      # mounted at /home/configs/tsdd.yaml
-│   └── wk.yaml               # WuKongIM runtime config
+│   ├── wk.yaml               # WuKongIM runtime config
+│   └── minio-octo-app-policy.json  # IAM policy installed by minio-init
 ├── nginx/
 │   ├── nginx.conf            # gzip + main http block
 │   ├── empty-default.conf    # silences the stock nginx welcome vhost

--- a/docker/README.md
+++ b/docker/README.md
@@ -53,26 +53,30 @@ These MUST be changed before bringing the stack up. Defaults are
 placeholder values designed to fail fast: `OCTO_MASTER_KEY` is one byte
 short of octo-server's length check, `MINIO_ROOT_PASSWORD` is 7 chars
 (MinIO requires ≥8) so the `minio` container refuses to boot, the
-`minio-init` one-shot aborts on any `CHANGE_ME_*` / `CHG_ME*` value for
-the MinIO root or app credentials, and `init-extra-dbs.sh` aborts when
-any service-account password contains characters outside
-`[A-Za-z0-9._-]` or when `MYSQL_ROOT_PASSWORD` does. The
-service-account defaults below (`matter` / `summary` /
-`summary_reader`) are the one weak spot — they DO let the stack come
-up unrotated, which is why they are first-class entries in this table
-and called out in the Hardening checklist.
+`minio-init` one-shot aborts on any `CHANGE_ME_*` / `CHG_ME*` value
+(case-insensitive) for the MinIO root or app credentials, the
+`preflight` one-shot aborts on any `CHANGE_ME_*` / `CHG_ME*` value for
+`OCTO_NOTIFY_INTERNAL_TOKEN` and `OCTO_WUKONGIM_MANAGER_TOKEN`, and
+`init-extra-dbs.sh` aborts when `MYSQL_ROOT_PASSWORD` is still a
+`CHANGE_ME_*` / `CHG_ME*` placeholder, when any service-account
+password contains characters outside `[A-Za-z0-9._-]`, or when
+`OCTO_MATTER_DB_PASSWORD` / `OCTO_SUMMARY_DB_PASSWORD` /
+`OCTO_SUMMARY_READER_PASSWORD` is left at the literal-string defaults
+(`matter` / `summary` / `summary_reader`). Together these checks mean
+the OOTB stack cannot reach `(healthy)` with any of the placeholder
+values still in place.
 
 | Variable | What it is | How to generate |
 | --- | --- | --- |
-| `MYSQL_ROOT_PASSWORD` | MySQL `root` password (also embedded in `TS_DB_MYSQLADDR` / `DM_MYSQL_DSN` and validated against `[A-Za-z0-9._-]` by `init-extra-dbs.sh` so the Go MySQL DSN parser does not silently misread the user/host boundary) | `openssl rand -hex 16` |
-| `MINIO_ROOT_PASSWORD` | MinIO root credential — used by `mc admin`, the MinIO console, and the `minio-init` bootstrap. NOT used by octo-server. The 7-char placeholder shipped in `.env.example` trips MinIO's own ≥8-char length check; `minio-init` then independently aborts on any `CHANGE_ME_*` / `CHG_ME*` value as defense in depth. | `openssl rand -hex 16` |
-| `OCTO_MINIO_APP_PASSWORD` | Application-scoped IAM secret. octo-server signs presigned URLs with this credential pair (NOT the root pair). The `minio-init` service creates the user, attaches the bucket-scoped policy on first boot, AND aborts with a clear error when this value is empty or still a `CHANGE_ME_*` / `CHG_ME*` placeholder. | `openssl rand -hex 24` |
-| `OCTO_MATTER_DB_PASSWORD` | MySQL service account `matter` (full DML on `octo_matter`). MySQL is loopback-only by default, but a stack that widens `OCTO_MYSQL_BIND` without rotating this hands write access on the matter schema to anyone who reaches `:23306` and guesses the literal default `matter`. | `openssl rand -hex 16` |
-| `OCTO_SUMMARY_DB_PASSWORD` | MySQL service account `summary` (full DML on `octo_summary`). Same widen-bind risk profile as `OCTO_MATTER_DB_PASSWORD`. | `openssl rand -hex 16` |
-| `OCTO_SUMMARY_READER_PASSWORD` | MySQL service account `summary_reader` (`SELECT` on the OCTO IM schema — see the `GRANT` block in `init-extra-dbs.sh`). Without rotation, widening `OCTO_MYSQL_BIND` exposes a read snapshot of every conversation in the IM schema to the network. | `openssl rand -hex 16` |
+| `MYSQL_ROOT_PASSWORD` | MySQL `root` password (also embedded in `TS_DB_MYSQLADDR` / `DM_MYSQL_DSN` and validated against `[A-Za-z0-9._-]` by `init-extra-dbs.sh` so the Go MySQL DSN parser does not silently misread the user/host boundary; the script also refuses any `CHANGE_ME_*` / `CHG_ME*` casing) | `openssl rand -hex 16` |
+| `MINIO_ROOT_PASSWORD` | MinIO root credential — used by `mc admin`, the MinIO console, and the `minio-init` bootstrap. NOT used by octo-server. The 7-char placeholder shipped in `.env.example` trips MinIO's own ≥8-char length check; `minio-init` then independently aborts on any `CHANGE_ME_*` / `CHG_ME*` value (case-insensitive) as defense in depth. | `openssl rand -hex 16` |
+| `OCTO_MINIO_APP_PASSWORD` | Application-scoped IAM secret. octo-server signs presigned URLs with this credential pair (NOT the root pair). The `minio-init` service creates the user, attaches the bucket-scoped policy on first boot, AND aborts with a clear error when this value is empty or still a `CHANGE_ME_*` / `CHG_ME*` placeholder (case-insensitive). | `openssl rand -hex 24` |
+| `OCTO_MATTER_DB_PASSWORD` | MySQL service account `matter` (full DML on `octo_matter`). `init-extra-dbs.sh` refuses the literal default `matter` so the OOTB stack cannot bring MySQL up with a guess-once credential. | `openssl rand -hex 16` |
+| `OCTO_SUMMARY_DB_PASSWORD` | MySQL service account `summary` (full DML on `octo_summary`). `init-extra-dbs.sh` refuses the literal default `summary`. | `openssl rand -hex 16` |
+| `OCTO_SUMMARY_READER_PASSWORD` | MySQL service account `summary_reader` (`SELECT` on the OCTO IM schema — see the `GRANT` block in `init-extra-dbs.sh`). `init-extra-dbs.sh` refuses the literal default `summary_reader`. | `openssl rand -hex 16` |
 | `OCTO_MASTER_KEY` | 32-byte server master key | `openssl rand -hex 16` |
-| `OCTO_NOTIFY_INTERNAL_TOKEN` | HMAC secret octo-server ↔ matter / smart-summary share | `openssl rand -hex 32` |
-| `OCTO_WUKONGIM_MANAGER_TOKEN` | WuKongIM admin token. Bound on WuKongIM via `WK_MANAGERTOKEN` (Viper auto-binds to YAML `managerToken`) and on octo-server via `TS_WUKONGIM_MANAGERTOKEN`. Leaving it empty makes WuKongIM's manager API reachable AND USABLE without auth — set a real value before exposing the stack. | `openssl rand -hex 32` |
+| `OCTO_NOTIFY_INTERNAL_TOKEN` | HMAC secret octo-server ↔ matter / smart-summary share. The `preflight` one-shot service refuses any `CHANGE_ME_*` / `CHG_ME*` casing. | `openssl rand -hex 32` |
+| `OCTO_WUKONGIM_MANAGER_TOKEN` | WuKongIM admin token. Bound on WuKongIM via `WK_MANAGERTOKEN` (Viper auto-binds to YAML `managerToken`) and on octo-server via `TS_WUKONGIM_MANAGERTOKEN`. Leaving it empty makes WuKongIM's manager API reachable AND USABLE without auth — `preflight` refuses any `CHANGE_ME_*` / `CHG_ME*` casing as well. | `openssl rand -hex 32` |
 | `LLM_API_KEY` | LLM provider key consumed by matter + smart-summary. Required for those features. The compose file falls back to a fake placeholder for `summary-worker` so the OOTB stack still reaches `(healthy)` — actual summarization calls fail until this is set. | from your provider |
 
 Everything else has sane defaults documented inline in
@@ -87,6 +91,17 @@ loopback**. The nginx-proxied paths (`/`, `/api/`, `/v1/`, `/admin/`,
 `/matter/`, `/summary/`, `/ws`, `/minio/`) remain public — note that
 `/minio-console/` is **not** in that list (see "Network surface"
 below).
+
+The same loopback default applies to the direct ports for
+`octo-server` (`OCTO_SERVER_BIND`), `octo-matter` (`OCTO_MATTER_BIND`),
+`smart-summary API` (`OCTO_SUMMARY_API_BIND`), and the WuKongIM
+monitor port (`OCTO_WK_MONITOR_BIND`). The first three skip the
+`octo_api` / `octo_auth` rate-limit zones the nginx vhost applies to
+`/api/`, `/v1/`, `/matter/`, and `/summary/`, so leaving them
+loopback-only keeps an operator-debug port from becoming a
+rate-limit-free production path. The WuKongIM monitor port is an
+admin surface, not a chat transport — chat clients reach WuKongIM via
+the user-facing API/TCP/WS ports, which stay on `0.0.0.0`.
 
 `OCTO_MINIO_API_BIND` is the asymmetric case — see "Network surface"
 below for the rationale.
@@ -107,12 +122,13 @@ know which is which before changing any `OCTO_*_BIND` value.
 | Service | Port (default) | Default bind | Why |
 | --- | --- | --- | --- |
 | nginx (HTTP) | `28080` | `0.0.0.0` | user-facing entrypoint |
-| octo-server REST | `28081` | `0.0.0.0` | exposed for direct API smoke tests |
+| octo-server REST | `28081` | `127.0.0.1` | direct REST port for operator smoke tests; production traffic uses nginx `/api/` + `/v1/` (rate-limited via `octo_api`/`octo_auth` zones in `nginx.conf`). Override `OCTO_SERVER_BIND` to widen. |
 | octo-admin | `28082` | `0.0.0.0` | admin SPA (also reachable via `/admin/`) |
 | octo-web | `28083` | `0.0.0.0` | user SPA (also reachable via `/`) |
-| octo-matter | `28086` | `0.0.0.0` | task service |
-| smart-summary API | `28087` | `0.0.0.0` | summary service |
-| WuKongIM API / TCP / WS / monitor | `25001` / `25100` / `25200` / `25300` | `0.0.0.0` | IM endpoints |
+| octo-matter | `28086` | `127.0.0.1` | direct matter port for operator smoke tests; production traffic uses nginx `/matter/`. Override `OCTO_MATTER_BIND` to widen. |
+| smart-summary API | `28087` | `127.0.0.1` | direct summary-api port for operator smoke tests; production traffic uses nginx `/summary/`. Override `OCTO_SUMMARY_API_BIND` to widen. |
+| WuKongIM API / TCP / WS | `25001` / `25100` / `25200` | `0.0.0.0` | chat client transports |
+| WuKongIM monitor | `25300` | `127.0.0.1` | observability / `/route` admin surface — not a user-facing transport. Override `OCTO_WK_MONITOR_BIND` for cross-host operator access. |
 | **MinIO API** | **`29000`** | **`0.0.0.0`** | **presigned URLs — see below** |
 | MinIO console | `29001` | `127.0.0.1` | admin only; reach via SSH tunnel (see below) |
 | MySQL | `23306` | `127.0.0.1` | backing service |
@@ -306,13 +322,18 @@ Before exposing the stack beyond a developer laptop:
   an unrotated config fails octo-server's length check;
   `MINIO_ROOT_PASSWORD` ships at 7 chars so it trips MinIO's own ≥8-
   char minimum at boot; the `minio-init` one-shot independently aborts
-  on any `CHANGE_ME_*` / `CHG_ME*` value for either MinIO credential
-  pair; and `init-extra-dbs.sh` aborts on first MySQL volume init when
-  `MYSQL_ROOT_PASSWORD` (or any of the service-account passwords)
-  contains characters outside `[A-Za-z0-9._-]`. The MySQL service
-  accounts (`OCTO_MATTER_DB_PASSWORD`, `OCTO_SUMMARY_DB_PASSWORD`,
-  `OCTO_SUMMARY_READER_PASSWORD`) DO have weak literal defaults and
-  must be changed manually — see "Required environment variables".
+  on any `CHANGE_ME_*` / `CHG_ME*` value (case-insensitive) for either
+  MinIO credential pair; the `preflight` one-shot aborts on any
+  `CHANGE_ME_*` / `CHG_ME*` casing for `OCTO_NOTIFY_INTERNAL_TOKEN` and
+  `OCTO_WUKONGIM_MANAGER_TOKEN`; and `init-extra-dbs.sh` aborts on
+  first MySQL volume init when `MYSQL_ROOT_PASSWORD` is still a
+  `CHANGE_ME_*` / `CHG_ME*` placeholder, when any service-account
+  password contains characters outside `[A-Za-z0-9._-]`, or when the
+  three MySQL service-account passwords (`OCTO_MATTER_DB_PASSWORD`,
+  `OCTO_SUMMARY_DB_PASSWORD`, `OCTO_SUMMARY_READER_PASSWORD`) are
+  still at their literal-string defaults. There is no longer a path
+  for the OOTB stack to come up with placeholder credentials in
+  place.
 - Keep `OCTO_MYSQL_BIND` / `OCTO_REDIS_BIND` /
   `OCTO_MINIO_CONSOLE_BIND` at `127.0.0.1`. Only widen after rotating
   credentials and placing the host behind a firewall.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,242 @@
+# OCTO · Docker Compose deployment
+
+A self-contained one-shot deployment of the full OCTO stack — server,
+admin console, web UI, matter, smart-summary, WuKongIM, MySQL, Redis,
+MinIO, and an nginx reverse proxy — wired together by a single
+`docker-compose.yaml`.
+
+This stack targets:
+
+- single-host evaluation deployments
+- internal demo / staging
+- the canonical "I just want to try OCTO" path
+
+For multi-node / production, use `kustomize/base/` and bring your own
+DB / cache / object store.
+
+---
+
+## Quick start
+
+```bash
+git clone https://github.com/Mininglamp-OSS/octo-deployment.git
+cd octo-deployment
+
+cp docker/.env.example docker/.env
+# Edit docker/.env — at minimum change the placeholders flagged in the file:
+#   MYSQL_ROOT_PASSWORD, MINIO_ROOT_PASSWORD, OCTO_MASTER_KEY,
+#   OCTO_NOTIFY_INTERNAL_TOKEN, OCTO_WUKONGIM_MANAGER_TOKEN
+
+cd docker
+docker compose config            # validate before starting
+docker compose up -d
+docker compose ps                # all services should reach (healthy)
+```
+
+Once healthy, the stack is reachable through nginx on
+`http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}` (default `http://octo.local:28080`).
+Add an `/etc/hosts` entry for `octo.local` if you keep the default domain.
+
+Tear-down (drops the named volumes too — destructive):
+
+```bash
+docker compose down -v
+```
+
+---
+
+## Required environment variables
+
+These MUST be changed before bringing the stack up. Defaults are
+placeholder values that will either fail length checks or trip the
+backing-service guards in `init-extra-dbs.sh`.
+
+| Variable | What it is | How to generate |
+| --- | --- | --- |
+| `MYSQL_ROOT_PASSWORD` | MySQL `root` password (also embedded in `DM_MYSQL_DSN`) | `openssl rand -hex 16` |
+| `MINIO_ROOT_PASSWORD` | MinIO root credential | `openssl rand -hex 16` |
+| `OCTO_MASTER_KEY` | 32-byte server master key | `openssl rand -hex 16` |
+| `OCTO_NOTIFY_INTERNAL_TOKEN` | HMAC secret octo-server ↔ matter / smart-summary share | `openssl rand -hex 32` |
+| `OCTO_WUKONGIM_MANAGER_TOKEN` | WuKongIM admin token, also used by octo-server | `openssl rand -hex 32` |
+| `LLM_API_KEY` | LLM provider key consumed by matter + smart-summary | from your provider |
+
+Everything else has sane defaults documented inline in
+[`docker/.env.example`](.env.example).
+
+### Backing-service host bindings
+
+`OCTO_MYSQL_BIND`, `OCTO_REDIS_BIND`, `OCTO_MINIO_API_BIND`,
+`OCTO_MINIO_CONSOLE_BIND` default to `127.0.0.1`. This means MySQL
+(`23306`), Redis (`26379`), and the MinIO API (`29000`) / console
+(`29001`) ports are **only reachable from the host loopback**. The
+nginx-proxied paths (`/`, `/api/`, `/admin/`, `/matter/`, `/summary/`,
+`/ws`, `/minio/`, `/minio-console/`) remain public.
+
+Override only if you have rotated all credentials and placed the host
+behind a firewall.
+
+---
+
+## First-admin bootstrap
+
+`register.off: true` is the OSS default — public registration is
+disabled, and there is no SMS verification fallback in this stack. So
+the first admin has to be created out-of-band.
+
+Choose **one** of the two paths below.
+
+### Option A · SQL one-liner (manual, recommended for evaluation)
+
+After `docker compose up -d` reaches healthy, exec into the MySQL
+container and seed an admin row directly:
+
+```bash
+docker compose exec mysql mysql -uroot -p"$MYSQL_ROOT_PASSWORD" octo <<'SQL'
+-- Replace the placeholders before running.
+--   - <UID>      : any 11-char string (e.g. shasum -a256 -b username | head -c 11)
+--   - <USERNAME> : the login name
+--   - <PWHASH>   : bcrypt of the password — run:
+--                    docker compose exec octo-server /home/octo-server admin hash-password
+--                  (or any bcrypt tool — cost 10 is fine)
+INSERT INTO `user`
+  (`uid`, `username`, `name`, `password`, `role`, `status`, `created_at`, `updated_at`)
+VALUES
+  ('<UID>', '<USERNAME>', 'OCTO Admin', '<PWHASH>', 1, 1, NOW(), NOW());
+SQL
+```
+
+Then visit `http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}/admin/` and log in.
+
+### Option B · Bootstrap env vars (auto-create on first start)
+
+If your `OCTO_SERVER_IMAGE` is built from a commit that supports the
+bootstrap-admin path, you can have octo-server insert the row itself
+on first start. Add to `docker/.env`:
+
+```bash
+OCTO_BOOTSTRAP_ADMIN_USERNAME=admin
+OCTO_BOOTSTRAP_ADMIN_PASSWORD=<a strong password>
+OCTO_BOOTSTRAP_ADMIN_NAME=OCTO Admin
+```
+
+octo-server creates the row only when the `user` table is empty, so
+this is safe to leave set across restarts.
+
+> If your image does not yet honour these vars, the values are simply
+> ignored and you should fall back to Option A.
+
+---
+
+## Hardening checklist
+
+Before exposing the stack beyond a developer laptop:
+
+- Rotate every `CHANGE_ME_*` value in `.env`. The placeholders in
+  `OCTO_MASTER_KEY` are intentionally one byte short so an unrotated
+  config fails octo-server's length check.
+- Keep `OCTO_*_BIND=127.0.0.1` on backing services. Only widen after
+  rotating credentials and placing the host behind a firewall.
+- Narrow `OCTO_NETWORK_SUBNET` further (already defaults to `/24`) if
+  it overlaps an existing VPN / VPC range.
+- Set a real `OCTO_WUKONGIM_MANAGER_TOKEN`. WuKongIM's `tokenAuthOn`
+  is true in `wk.yaml`; an empty token means admin endpoints are
+  reachable but unusable.
+- Set `OCTO_WEBHOOK_SECRET_KEY` if you accept inbound webhooks.
+- Switch `OCTO_DOMAIN` to a real hostname and front the stack with TLS
+  (uncomment the `443` block in `docker-compose.yaml` and the HTTPS
+  server block in `nginx/conf.d/octo.conf.template`).
+
+---
+
+## Troubleshooting
+
+### `docker compose up` complains about port collisions
+
+Pick different host ports in `.env` — every backing-service port
+(`OCTO_MYSQL_PORT`, `OCTO_REDIS_PORT`, `OCTO_MINIO_API_PORT`, …) and
+every public-facing port (`OCTO_HTTP_PORT`, `OCTO_SERVER_PORT`,
+`OCTO_ADMIN_PORT`, `OCTO_WEB_PORT`, `OCTO_MATTER_PORT`,
+`OCTO_SUMMARY_API_PORT`, `OCTO_WK_*_PORT`) is overridable.
+
+### nginx serves the default Welcome page instead of OCTO
+
+`docker/nginx/empty-default.conf` is mounted on top of the image's
+`default.conf` so the OCTO vhost wins. If you have customised the
+nginx mount, make sure that override is preserved.
+
+### Image upload returns 500 / "PresignedPutter is nil"
+
+The OCTO image upload pipeline depends on the PresignedPutter
+implementation tracked in
+[`Mininglamp-OSS/octo-server#24`](https://github.com/Mininglamp-OSS/octo-server/issues/24).
+Pin `OCTO_SERVER_IMAGE` to a tag built from a commit that includes
+that fix (or `:latest` once it ships).
+
+### `WuKongIM /route` returns the literal string `${OCTO_DOMAIN}`
+
+Compose only interpolates `.env` values once — it does **not**
+recursively expand `${...}` inside a `.env` value. Leave
+`OCTO_WK_WS_ADDR=` empty so the default expression in
+`docker-compose.yaml` builds the address from `OCTO_DOMAIN` /
+`OCTO_HTTP_PORT`. Set a literal value (e.g. `ws://1.2.3.4:28080/ws`)
+only when you want to override the auto-built default.
+
+### MySQL refuses to start with "ERROR 1396 (HY000): Operation CREATE USER failed"
+
+`scripts/init-extra-dbs.sh` runs only on first volume init. If you've
+already booted with the wrong passwords, the simplest fix is:
+
+```bash
+docker compose down -v        # drops mysql-data
+# fix passwords in .env
+docker compose up -d
+```
+
+If you cannot drop the volume, run the SQL by hand against the live
+container — the script's `CREATE USER` / `GRANT` statements are at the
+bottom of `scripts/init-extra-dbs.sh`.
+
+### Health endpoints
+
+After the stack reports healthy, these should all return 200:
+
+| Path | Purpose |
+| --- | --- |
+| `/_nginx_up` | nginx reverse-proxy probe |
+| `/api/v1/health` | octo-server REST |
+| `/matter/health` | octo-matter |
+| `/summary/health` | smart-summary API |
+| `/` | octo-web SPA |
+
+```bash
+for p in /_nginx_up /api/v1/health /matter/health /summary/health /; do
+  printf '%-22s %s\n' "$p" "$(curl -fsS -o /dev/null -w '%{http_code}' "http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}$p")"
+done
+```
+
+---
+
+## Layout
+
+```
+docker/
+├── docker-compose.yaml       # full service orchestration
+├── .env.example              # annotated environment template
+├── README.md                 # this file
+├── configs/
+│   ├── octo-server.yaml      # mounted at /home/configs/tsdd.yaml
+│   └── wk.yaml               # WuKongIM runtime config
+├── nginx/
+│   ├── nginx.conf            # gzip + main http block
+│   ├── empty-default.conf    # silences the stock nginx welcome vhost
+│   └── conf.d/
+│       └── octo.conf.template
+└── scripts/
+    └── init-extra-dbs.sh     # one-shot MySQL bootstrap (matter / summary)
+```
+
+## Out-of-scope
+
+The compose file does NOT cover: clustering / HA, automated TLS
+provisioning, log shipping, or backup. Use the kustomize overlays for
+production-shaped deployments.

--- a/docker/README.md
+++ b/docker/README.md
@@ -25,6 +25,8 @@ cd octo-deployment
 cp docker/.env.example docker/.env
 # Edit docker/.env — at minimum change the placeholders flagged in the file:
 #   MYSQL_ROOT_PASSWORD, MINIO_ROOT_PASSWORD, OCTO_MINIO_APP_PASSWORD,
+#   OCTO_MATTER_DB_PASSWORD, OCTO_SUMMARY_DB_PASSWORD,
+#   OCTO_SUMMARY_READER_PASSWORD,
 #   OCTO_MASTER_KEY, OCTO_NOTIFY_INTERNAL_TOKEN, OCTO_WUKONGIM_MANAGER_TOKEN
 
 cd docker
@@ -48,14 +50,26 @@ docker compose down -v
 ## Required environment variables
 
 These MUST be changed before bringing the stack up. Defaults are
-placeholder values that will either fail length checks or trip the
-backing-service guards in `init-extra-dbs.sh`.
+placeholder values designed to fail fast: `OCTO_MASTER_KEY` is one byte
+short of octo-server's length check, `MINIO_ROOT_PASSWORD` is 7 chars
+(MinIO requires ≥8) so the `minio` container refuses to boot, the
+`minio-init` one-shot aborts on any `CHANGE_ME_*` / `CHG_ME*` value for
+the MinIO root or app credentials, and `init-extra-dbs.sh` aborts when
+any service-account password contains characters outside
+`[A-Za-z0-9._-]` or when `MYSQL_ROOT_PASSWORD` does. The
+service-account defaults below (`matter` / `summary` /
+`summary_reader`) are the one weak spot — they DO let the stack come
+up unrotated, which is why they are first-class entries in this table
+and called out in the Hardening checklist.
 
 | Variable | What it is | How to generate |
 | --- | --- | --- |
-| `MYSQL_ROOT_PASSWORD` | MySQL `root` password (also embedded in `TS_DB_MYSQLADDR` / `DM_MYSQL_DSN`) | `openssl rand -hex 16` |
-| `MINIO_ROOT_PASSWORD` | MinIO root credential — used by `mc admin`, the MinIO console, and the `minio-init` bootstrap. NOT used by octo-server. | `openssl rand -hex 16` |
-| `OCTO_MINIO_APP_PASSWORD` | Application-scoped IAM secret. octo-server signs presigned URLs with this credential pair (NOT the root pair). The `minio-init` service creates the user and attaches the bucket-scoped policy on first boot. | `openssl rand -hex 24` |
+| `MYSQL_ROOT_PASSWORD` | MySQL `root` password (also embedded in `TS_DB_MYSQLADDR` / `DM_MYSQL_DSN` and validated against `[A-Za-z0-9._-]` by `init-extra-dbs.sh` so the Go MySQL DSN parser does not silently misread the user/host boundary) | `openssl rand -hex 16` |
+| `MINIO_ROOT_PASSWORD` | MinIO root credential — used by `mc admin`, the MinIO console, and the `minio-init` bootstrap. NOT used by octo-server. The 7-char placeholder shipped in `.env.example` trips MinIO's own ≥8-char length check; `minio-init` then independently aborts on any `CHANGE_ME_*` / `CHG_ME*` value as defense in depth. | `openssl rand -hex 16` |
+| `OCTO_MINIO_APP_PASSWORD` | Application-scoped IAM secret. octo-server signs presigned URLs with this credential pair (NOT the root pair). The `minio-init` service creates the user, attaches the bucket-scoped policy on first boot, AND aborts with a clear error when this value is empty or still a `CHANGE_ME_*` / `CHG_ME*` placeholder. | `openssl rand -hex 24` |
+| `OCTO_MATTER_DB_PASSWORD` | MySQL service account `matter` (full DML on `octo_matter`). MySQL is loopback-only by default, but a stack that widens `OCTO_MYSQL_BIND` without rotating this hands write access on the matter schema to anyone who reaches `:23306` and guesses the literal default `matter`. | `openssl rand -hex 16` |
+| `OCTO_SUMMARY_DB_PASSWORD` | MySQL service account `summary` (full DML on `octo_summary`). Same widen-bind risk profile as `OCTO_MATTER_DB_PASSWORD`. | `openssl rand -hex 16` |
+| `OCTO_SUMMARY_READER_PASSWORD` | MySQL service account `summary_reader` (`SELECT` on the OCTO IM schema — see the `GRANT` block in `init-extra-dbs.sh`). Without rotation, widening `OCTO_MYSQL_BIND` exposes a read snapshot of every conversation in the IM schema to the network. | `openssl rand -hex 16` |
 | `OCTO_MASTER_KEY` | 32-byte server master key | `openssl rand -hex 16` |
 | `OCTO_NOTIFY_INTERNAL_TOKEN` | HMAC secret octo-server ↔ matter / smart-summary share | `openssl rand -hex 32` |
 | `OCTO_WUKONGIM_MANAGER_TOKEN` | WuKongIM admin token. Bound on WuKongIM via `WK_MANAGERTOKEN` (Viper auto-binds to YAML `managerToken`) and on octo-server via `TS_WUKONGIM_MANAGERTOKEN`. Leaving it empty makes WuKongIM's manager API reachable AND USABLE without auth — set a real value before exposing the stack. | `openssl rand -hex 32` |
@@ -70,14 +84,18 @@ Everything else has sane defaults documented inline in
 default to `127.0.0.1`. This means MySQL (`23306`), Redis (`26379`)
 and the MinIO console (`29001`) are **only reachable from the host
 loopback**. The nginx-proxied paths (`/`, `/api/`, `/v1/`, `/admin/`,
-`/matter/`, `/summary/`, `/ws`, `/minio/`, `/minio-console/`) remain
-public.
+`/matter/`, `/summary/`, `/ws`, `/minio/`) remain public — note that
+`/minio-console/` is **not** in that list (see "Network surface"
+below).
 
 `OCTO_MINIO_API_BIND` is the asymmetric case — see "Network surface"
 below for the rationale.
 
 Override the loopback defaults only if you have rotated all
-credentials and placed the host behind a firewall.
+credentials and placed the host behind a firewall. **Redis runs
+without authentication** in this stack — keep `OCTO_REDIS_BIND` on
+`127.0.0.1` (or a private interface) until you wire `--requirepass`
+into the redis service. See the "Hardening checklist" for the steps.
 
 ---
 
@@ -96,9 +114,28 @@ know which is which before changing any `OCTO_*_BIND` value.
 | smart-summary API | `28087` | `0.0.0.0` | summary service |
 | WuKongIM API / TCP / WS / monitor | `25001` / `25100` / `25200` / `25300` | `0.0.0.0` | IM endpoints |
 | **MinIO API** | **`29000`** | **`0.0.0.0`** | **presigned URLs — see below** |
-| MinIO console | `29001` | `127.0.0.1` | admin only; reach via `/minio-console/` |
+| MinIO console | `29001` | `127.0.0.1` | admin only; reach via SSH tunnel (see below) |
 | MySQL | `23306` | `127.0.0.1` | backing service |
 | Redis | `26379` | `127.0.0.1` | backing service |
+
+The MinIO console is **not** proxied through nginx by default.
+Earlier revisions exposed it under `/minio-console/`, which put the
+MinIO admin login one click away from anyone who reached
+`OCTO_HTTP_PORT` — and a stack booted with the placeholder root
+password would have a known-default credential accepted there.
+Operators reach the console via an SSH tunnel against the loopback
+bind:
+
+```bash
+ssh -L 9001:127.0.0.1:29001 user@host
+# then visit http://localhost:9001 in your browser
+```
+
+To re-enable the public route (NOT recommended; only do this after
+rotating `MINIO_ROOT_PASSWORD` and placing the proxy behind auth),
+uncomment the commented-out `octo_minio_console` upstream and
+`/minio-console/` location block at the top of
+`docker/nginx/conf.d/octo.conf.template`.
 
 ### Why the MinIO API port is public by design
 
@@ -264,12 +301,37 @@ with `superAdmin` and the password you hashed.
 
 Before exposing the stack beyond a developer laptop:
 
-- Rotate every `CHANGE_ME_*` value in `.env`. The placeholders in
-  `OCTO_MASTER_KEY` are intentionally one byte short so an unrotated
-  config fails octo-server's length check.
+- Rotate every `CHANGE_ME_*` / `CHG_ME*` value in `.env`. The
+  placeholder in `OCTO_MASTER_KEY` is intentionally one byte short so
+  an unrotated config fails octo-server's length check;
+  `MINIO_ROOT_PASSWORD` ships at 7 chars so it trips MinIO's own ≥8-
+  char minimum at boot; the `minio-init` one-shot independently aborts
+  on any `CHANGE_ME_*` / `CHG_ME*` value for either MinIO credential
+  pair; and `init-extra-dbs.sh` aborts on first MySQL volume init when
+  `MYSQL_ROOT_PASSWORD` (or any of the service-account passwords)
+  contains characters outside `[A-Za-z0-9._-]`. The MySQL service
+  accounts (`OCTO_MATTER_DB_PASSWORD`, `OCTO_SUMMARY_DB_PASSWORD`,
+  `OCTO_SUMMARY_READER_PASSWORD`) DO have weak literal defaults and
+  must be changed manually — see "Required environment variables".
 - Keep `OCTO_MYSQL_BIND` / `OCTO_REDIS_BIND` /
   `OCTO_MINIO_CONSOLE_BIND` at `127.0.0.1`. Only widen after rotating
   credentials and placing the host behind a firewall.
+- Redis runs **without authentication** in this stack — there is no
+  `--requirepass` on the `redis` service `command:`. Flipping
+  `OCTO_REDIS_BIND` to `0.0.0.0` therefore exposes an unauthenticated
+  Redis to any host that can reach the port. Before widening the
+  bind, EITHER keep Redis on a private interface only, OR add
+  `--requirepass <secret>` to the `redis` service `command:` in
+  `docker-compose.yaml` AND wire the same secret into `TS_DB_REDISPASS`
+  / `DM_REDIS_PASS` on the `octo-server` service so the application
+  side keeps reaching cache. (Adding a CLI-flag-driven Redis password
+  is tracked as a follow-up; see the PR description for the link.)
+- The MinIO console is loopback-only and **not** proxied through
+  nginx by default. Reach it via SSH-forward to `:29001` (see
+  "Network surface"). If you ever uncomment the `/minio-console/`
+  block in `nginx/conf.d/octo.conf.template`, treat
+  `MINIO_ROOT_PASSWORD` rotation as a precondition — the public
+  `OCTO_HTTP_PORT` then becomes a path to `mc admin`.
 - `OCTO_MINIO_API_BIND` stays `0.0.0.0` — see "Network surface · Why
   the MinIO API port is public by design". Restrict the port at the
   firewall layer if you need to limit reach, do not close it.
@@ -291,6 +353,12 @@ Before exposing the stack beyond a developer laptop:
 - Switch `OCTO_DOMAIN` to a real hostname and front the stack with TLS
   (uncomment the `443` block in `docker-compose.yaml` and the HTTPS
   server block in `nginx/conf.d/octo.conf.template`).
+- Pin every `mininglamposs/octo-*` image to a specific tag once the
+  PresignedPutter fix in `Mininglamp-OSS/octo-server#24` ships a
+  release. The compose file currently defaults to `:latest` for
+  `octo-server`, `octo-web`, `octo-admin`, `octo-matter`, and the
+  smart-summary images — fine for a laptop, not fine for a stable
+  deployment. WuKongIM and `mc` are already pinned.
 
 ---
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -65,15 +65,64 @@ Everything else has sane defaults documented inline in
 
 ### Backing-service host bindings
 
-`OCTO_MYSQL_BIND`, `OCTO_REDIS_BIND`, `OCTO_MINIO_API_BIND`,
-`OCTO_MINIO_CONSOLE_BIND` default to `127.0.0.1`. This means MySQL
-(`23306`), Redis (`26379`), and the MinIO API (`29000`) / console
-(`29001`) ports are **only reachable from the host loopback**. The
-nginx-proxied paths (`/`, `/api/`, `/admin/`, `/matter/`, `/summary/`,
-`/ws`, `/minio/`, `/minio-console/`) remain public.
+`OCTO_MYSQL_BIND`, `OCTO_REDIS_BIND`, `OCTO_MINIO_CONSOLE_BIND`
+default to `127.0.0.1`. This means MySQL (`23306`), Redis (`26379`)
+and the MinIO console (`29001`) are **only reachable from the host
+loopback**. The nginx-proxied paths (`/`, `/api/`, `/v1/`, `/admin/`,
+`/matter/`, `/summary/`, `/ws`, `/minio/`, `/minio-console/`) remain
+public.
 
-Override only if you have rotated all credentials and placed the host
-behind a firewall.
+`OCTO_MINIO_API_BIND` is the asymmetric case — see "Network surface"
+below for the rationale.
+
+Override the loopback defaults only if you have rotated all
+credentials and placed the host behind a firewall.
+
+---
+
+## Network surface
+
+The stack exposes two distinct sets of host ports. Operators should
+know which is which before changing any `OCTO_*_BIND` value.
+
+| Service | Port (default) | Default bind | Why |
+| --- | --- | --- | --- |
+| nginx (HTTP) | `28080` | `0.0.0.0` | user-facing entrypoint |
+| octo-server REST | `28081` | `0.0.0.0` | exposed for direct API smoke tests |
+| octo-admin | `28082` | `0.0.0.0` | admin SPA (also reachable via `/admin/`) |
+| octo-web | `28083` | `0.0.0.0` | user SPA (also reachable via `/`) |
+| octo-matter | `28086` | `0.0.0.0` | task service |
+| smart-summary API | `28087` | `0.0.0.0` | summary service |
+| WuKongIM API / TCP / WS / monitor | `25001` / `25100` / `25200` / `25300` | `0.0.0.0` | IM endpoints |
+| **MinIO API** | **`29000`** | **`0.0.0.0`** | **presigned URLs — see below** |
+| MinIO console | `29001` | `127.0.0.1` | admin only; reach via `/minio-console/` |
+| MySQL | `23306` | `127.0.0.1` | backing service |
+| Redis | `26379` | `127.0.0.1` | backing service |
+
+### Why the MinIO API port is public by design
+
+octo-server's `/api/v1/file/*` responses contain **presigned (SigV4)
+URLs that point at the MinIO API directly** — not through nginx. SigV4
+signs the canonical request path; any nginx rewrite (`/minio/...` ->
+`/...`) breaks the signature, so the browser must reach MinIO's `9000`
+port over the same hostname octo-server signed against. That is the
+value of `TS_MINIO_DOWNLOADURL`, which is fixed to host:port form (no
+path prefix) in `docker-compose.yaml`.
+
+The data is protected by:
+
+- the MinIO root credentials (`MINIO_ROOT_*`) — never sent over the
+  wire by the server,
+- the **short TTL** of every presigned URL (minutes, not days),
+- octo-server's authorisation layer in front of `/api/v1/file/*`.
+
+Closing the port closes valid uploads / downloads. If you want a
+firewall-restricted deployment, restrict `29000` to the same client
+range that can reach `28080` — do not block it.
+
+If you absolutely need every public port to live behind nginx, you'd
+need a SigV4-aware proxy (e.g. one that re-signs each request) — that
+is out of scope for this compose stack.
 
 ---
 
@@ -170,8 +219,12 @@ Before exposing the stack beyond a developer laptop:
 - Rotate every `CHANGE_ME_*` value in `.env`. The placeholders in
   `OCTO_MASTER_KEY` are intentionally one byte short so an unrotated
   config fails octo-server's length check.
-- Keep `OCTO_*_BIND=127.0.0.1` on backing services. Only widen after
-  rotating credentials and placing the host behind a firewall.
+- Keep `OCTO_MYSQL_BIND` / `OCTO_REDIS_BIND` /
+  `OCTO_MINIO_CONSOLE_BIND` at `127.0.0.1`. Only widen after rotating
+  credentials and placing the host behind a firewall.
+- `OCTO_MINIO_API_BIND` stays `0.0.0.0` — see "Network surface · Why
+  the MinIO API port is public by design". Restrict the port at the
+  firewall layer if you need to limit reach, do not close it.
 - Narrow `OCTO_NETWORK_SUBNET` further (already defaults to `/24`) if
   it overlaps an existing VPN / VPC range.
 - Set a real `OCTO_WUKONGIM_MANAGER_TOKEN`. WuKongIM's `tokenAuthOn`
@@ -207,6 +260,33 @@ implementation tracked in
 [`Mininglamp-OSS/octo-server#24`](https://github.com/Mininglamp-OSS/octo-server/issues/24).
 Pin `OCTO_SERVER_IMAGE` to a tag built from a commit that includes
 that fix (or `:latest` once it ships).
+
+### Presigned URL access fails with "connection refused" / "name resolution"
+
+Symptom: image / file upload returns 200 from `/api/v1/file/*`, but
+the browser then hangs or 0-bytes when fetching the presigned URL.
+
+The presigned URL points at `${OCTO_DOMAIN}:${OCTO_MINIO_API_PORT}`
+(default `http://octo.local:29000`), bypassing nginx. Check, in
+order:
+
+1. `OCTO_MINIO_API_BIND` is `0.0.0.0` (default). If you narrowed it
+   to `127.0.0.1`, only the host itself can reach the port — LAN /
+   browser clients on other machines will fail.
+2. `OCTO_MINIO_API_PORT` (default `29000`) is reachable from the
+   client's network — `curl -v http://${OCTO_DOMAIN}:29000/minio/health/live`
+   should return `200`.
+3. `${OCTO_DOMAIN}` resolves on the client (the `/etc/hosts` entry
+   for `octo.local` has to exist on every machine that hits the UI,
+   not just the host).
+4. `TS_MINIO_DOWNLOADURL` in the rendered config has **no path
+   component** — `docker compose config | grep TS_MINIO_DOWNLOADURL`
+   should print exactly `http://<host>:<port>`. octo-server PR#50 R4
+   rejects path-prefixed values at startup.
+
+Do **not** "fix" this by routing the URL through nginx (`/minio/...`)
+— SigV4 signatures break under any path rewrite. See "Network surface
+· Why the MinIO API port is public by design" above.
 
 ### `WuKongIM /route` returns the literal string `${OCTO_DOMAIN}`
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -53,12 +53,12 @@ backing-service guards in `init-extra-dbs.sh`.
 
 | Variable | What it is | How to generate |
 | --- | --- | --- |
-| `MYSQL_ROOT_PASSWORD` | MySQL `root` password (also embedded in `DM_MYSQL_DSN`) | `openssl rand -hex 16` |
+| `MYSQL_ROOT_PASSWORD` | MySQL `root` password (also embedded in `TS_DB_MYSQLADDR` / `DM_MYSQL_DSN`) | `openssl rand -hex 16` |
 | `MINIO_ROOT_PASSWORD` | MinIO root credential | `openssl rand -hex 16` |
 | `OCTO_MASTER_KEY` | 32-byte server master key | `openssl rand -hex 16` |
 | `OCTO_NOTIFY_INTERNAL_TOKEN` | HMAC secret octo-server ↔ matter / smart-summary share | `openssl rand -hex 32` |
 | `OCTO_WUKONGIM_MANAGER_TOKEN` | WuKongIM admin token, also used by octo-server | `openssl rand -hex 32` |
-| `LLM_API_KEY` | LLM provider key consumed by matter + smart-summary | from your provider |
+| `LLM_API_KEY` | LLM provider key consumed by matter + smart-summary (required for those features; leave blank for a smoke-test stack) | from your provider |
 
 Everything else has sane defaults documented inline in
 [`docker/.env.example`](.env.example).
@@ -83,47 +83,83 @@ behind a firewall.
 disabled, and there is no SMS verification fallback in this stack. So
 the first admin has to be created out-of-band.
 
-Choose **one** of the two paths below.
+The two paths below are the only ones that work against the current
+octo-server binary. Earlier drafts of this doc referenced
+`OCTO_BOOTSTRAP_ADMIN_*` env vars and an `octo-server admin
+hash-password` CLI subcommand — neither exists in the binary today.
+Use Option A unless you have a strong reason to prefer Option B.
 
-### Option A · SQL one-liner (manual, recommended for evaluation)
+### Option A · `adminPwd` config-driven bootstrap (recommended)
 
-After `docker compose up -d` reaches healthy, exec into the MySQL
-container and seed an admin row directly:
+octo-server has a built-in first-admin hook tied to the `adminPwd`
+config key. On startup, if the user row identified by
+`account.adminUID` (default `"admin"`) does not yet exist AND
+`adminPwd` is non-empty, it inserts a `superAdmin` row with
+`username = "superAdmin"`, `role = "superAdmin"`, and
+`password = bcrypt(adminPwd)`. The hook is a one-shot per database —
+once the row exists, subsequent restarts no-op even if `adminPwd` is
+still set, so leaving the value in place is safe.
+
+To use it:
+
+1. Pick a strong password (treat it as a deploy-time secret —
+   octo-server hashes it before write, but the plaintext sits in your
+   `.env`).
+2. Add to `docker/.env` and uncomment the matching env line in the
+   `octo-server` service in `docker-compose.yaml` (commented out by
+   default to keep the OOTB stack from auto-creating an admin in the
+   wrong environment):
+
+   ```bash
+   # docker/.env
+   OCTO_ADMIN_PWD=<a strong password>
+   ```
+
+   ```yaml
+   # docker/docker-compose.yaml — octo-server service environment:
+   TS_ADMINPWD: ${OCTO_ADMIN_PWD:-}
+   ```
+3. `docker compose up -d` (or `docker compose restart octo-server` if
+   the stack is already up). On first start with an empty `user`
+   table, octo-server seeds the row.
+4. Visit `http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}/admin/` and log in
+   with username `superAdmin` and the password from step 1.
+5. Rotate the password from the admin UI and remove `OCTO_ADMIN_PWD`
+   from `.env`. (The seeded row is the source of truth from this
+   point; the `adminPwd` config key is only consulted when the row is
+   absent.)
+
+### Option B · Manual SQL seed
+
+Use this when you cannot edit `docker-compose.yaml`, or you want a
+non-default username / UID. The schema is in
+`octo-server/modules/user/sql/20191106000003_user_legacy01.sql` (the
+relevant fields are `uid`, `username`, `name`, `password`, `role`,
+`status`).
 
 ```bash
-docker compose exec mysql mysql -uroot -p"$MYSQL_ROOT_PASSWORD" octo <<'SQL'
--- Replace the placeholders before running.
---   - <UID>      : any 11-char string (e.g. shasum -a256 -b username | head -c 11)
---   - <USERNAME> : the login name
---   - <PWHASH>   : bcrypt of the password — run:
---                    docker compose exec octo-server /home/octo-server admin hash-password
---                  (or any bcrypt tool — cost 10 is fine)
-INSERT INTO `user`
-  (`uid`, `username`, `name`, `password`, `role`, `status`, `created_at`, `updated_at`)
+# 1. Generate a bcrypt hash on the host (any cost ≥ 10):
+HTPASSWD_HASH=$(htpasswd -bnBC 10 "" '<your password>' | tr -d ':\n')
+# Or in Python:
+#   python3 -c 'import bcrypt; print(bcrypt.hashpw(b"<pw>", bcrypt.gensalt(10)).decode())'
+
+# 2. Insert the row. role MUST be the string 'superAdmin' (or 'admin')
+#    — the column is VARCHAR(40), not an integer enum.
+docker compose exec mysql mysql -uroot -p"$MYSQL_ROOT_PASSWORD" octo <<SQL
+INSERT INTO \`user\`
+  (uid, username, name, password, role, status, created_at, updated_at)
 VALUES
-  ('<UID>', '<USERNAME>', 'OCTO Admin', '<PWHASH>', 1, 1, NOW(), NOW());
+  ('admin', 'superAdmin', 'OCTO Admin', '${HTPASSWD_HASH}', 'superAdmin', 1, NOW(), NOW());
 SQL
 ```
 
-Then visit `http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}/admin/` and log in.
+Then visit `http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}/admin/` and log in
+with `superAdmin` and the password you hashed.
 
-### Option B · Bootstrap env vars (auto-create on first start)
-
-If your `OCTO_SERVER_IMAGE` is built from a commit that supports the
-bootstrap-admin path, you can have octo-server insert the row itself
-on first start. Add to `docker/.env`:
-
-```bash
-OCTO_BOOTSTRAP_ADMIN_USERNAME=admin
-OCTO_BOOTSTRAP_ADMIN_PASSWORD=<a strong password>
-OCTO_BOOTSTRAP_ADMIN_NAME=OCTO Admin
-```
-
-octo-server creates the row only when the `user` table is empty, so
-this is safe to leave set across restarts.
-
-> If your image does not yet honour these vars, the values are simply
-> ignored and you should fall back to Option A.
+> The placeholder UID `'admin'` matches `account.adminUID`'s default
+> value. If you change `account.adminUID` in `octo-server.yaml`, use
+> the same value here so the Option A re-seed hook stays consistent
+> with your manual row.
 
 ---
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -358,6 +358,18 @@ Before exposing the stack beyond a developer laptop:
   firewall layer if you need to limit reach, do not close it.
 - Narrow `OCTO_NETWORK_SUBNET` further (already defaults to `/24`) if
   it overlaps an existing VPN / VPC range.
+- `OCTO_MASTER_KEY` rotation gotcha: the master key is what
+  octo-server uses to AEAD-encrypt at-rest fields (the encrypted
+  per-user / per-tenant material referenced in the server config).
+  Rotating it after data has been written makes the previously
+  encrypted rows undecryptable — there is no built-in re-encrypt
+  pass. So the rotation flow is: pick a strong key at first deploy
+  (`openssl rand -hex 16`), keep it, and only swap it as part of a
+  full reset (drop the encrypted columns / re-onboard users) or a
+  coordinated migration. This applies only to `OCTO_MASTER_KEY`;
+  `OCTO_NOTIFY_INTERNAL_TOKEN` and `OCTO_WUKONGIM_MANAGER_TOKEN` are
+  HMAC-only and safe to rotate by restarting all dependent services
+  with the new value.
 - Set a real `OCTO_WUKONGIM_MANAGER_TOKEN`. WuKongIM's `tokenAuthOn`
   is `true` in `wk.yaml`, but the token is bound from the env var
   `WK_MANAGERTOKEN` (Viper auto-binds upper-case `WK_<KEY>` to the

--- a/docker/configs/minio-octo-app-policy.json
+++ b/docker/configs/minio-octo-app-policy.json
@@ -1,0 +1,49 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "OctoAppBucketReadWrite",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads"
+      ],
+      "Resource": [
+        "arn:aws:s3:::file",
+        "arn:aws:s3:::chat",
+        "arn:aws:s3:::moment",
+        "arn:aws:s3:::sticker",
+        "arn:aws:s3:::report",
+        "arn:aws:s3:::chatbg",
+        "arn:aws:s3:::common",
+        "arn:aws:s3:::download",
+        "arn:aws:s3:::group",
+        "arn:aws:s3:::avatar"
+      ]
+    },
+    {
+      "Sid": "OctoAppObjectReadWrite",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts"
+      ],
+      "Resource": [
+        "arn:aws:s3:::file/*",
+        "arn:aws:s3:::chat/*",
+        "arn:aws:s3:::moment/*",
+        "arn:aws:s3:::sticker/*",
+        "arn:aws:s3:::report/*",
+        "arn:aws:s3:::chatbg/*",
+        "arn:aws:s3:::common/*",
+        "arn:aws:s3:::download/*",
+        "arn:aws:s3:::group/*",
+        "arn:aws:s3:::avatar/*"
+      ]
+    }
+  ]
+}

--- a/docker/configs/octo-server.yaml
+++ b/docker/configs/octo-server.yaml
@@ -6,11 +6,10 @@
 # docker-compose.yaml. Do not change those strings unless you also rename
 # the corresponding compose services.
 #
-# Credentials with CHANGE_ME_* placeholders are overridden at runtime from
-# the environment via the names listed in kustomize/base/octo-server-secret
-# (DM_MYSQL_DSN, DM_REDIS_ADDR, WUKONGIM_MANAGER_TOKEN, …) plus Viper's
-# AutomaticEnv mapping for the YAML keys (TS_MINIO_*). OSS users only need
-# to edit .env — not this file.
+# Credentials with CHANGE_ME_* placeholders are overridden at runtime via
+# Viper's AutomaticEnv (`SetEnvPrefix("TS")`, `.` -> `_`). The compose file
+# passes the matching `TS_*` env names — see the `octo-server` service
+# block in `docker-compose.yaml` for the full list.
 # -----------------------------------------------------------------------------
 
 # Runtime mode: debug | release
@@ -24,17 +23,26 @@ external:
 # Test-only SMS verification code. Ignored in release mode.
 smsCode: ""
 
+# First-admin bootstrap.
+# When non-empty AND no row exists for `account.adminUID` (default "admin"),
+# octo-server creates a superAdmin row on startup with username "superAdmin"
+# and password = bcrypt(adminPwd). Idempotent across restarts. Override via
+# .env -> TS_ADMINPWD on the octo-server service. Leave blank to skip the
+# bootstrap and seed the first admin manually (see docker/README.md).
+adminPwd: ""
+
 db:
-  # mysqlAddr / redisAddr are overridden by DM_MYSQL_DSN / DM_REDIS_ADDR
-  # set in docker-compose.yaml (which sources them from .env). Leave the
-  # placeholders below — they exist only so the YAML structure parses.
+  # mysqlAddr / redisAddr are overridden at runtime by TS_DB_MYSQLADDR /
+  # TS_DB_REDISADDR set in docker-compose.yaml (which sources them from
+  # .env). Leave the placeholders below — they exist only so the YAML
+  # structure parses.
   mysqlAddr: "root:CHANGE_ME_MYSQL_PASSWORD@tcp(mysql:3306)/octo?charset=utf8mb4&parseTime=true&loc=Local"
   redisAddr: "redis:6379"
   redisPass: ""
 
 wukongIM:
   apiURL: "http://wukongim:5001"
-  # managerToken is overridden via WUKONGIM_MANAGER_TOKEN env from .env;
+  # managerToken is overridden via TS_WUKONGIM_MANAGERTOKEN env from .env;
   # leaving this empty means tokenAuthOn-protected admin calls will fail.
   managerToken: ""
 
@@ -44,7 +52,15 @@ wukongIM:
 # fix, /api/v1/file/upload will 500 even with this stack healthy.
 fileService: "minio"
 minio:
+  # In-cluster API endpoint used by the server itself for uploads / GETs
+  # against MinIO. Stays as the Docker DNS name since that traffic never
+  # leaves octo-net.
   url: "http://minio:9000"
+  # Client-facing endpoint baked into the URLs returned by /api/v1/file/*.
+  # Empty here so the compose env (TS_MINIO_DOWNLOADURL) is the single
+  # source of truth — see the octo-server service block in
+  # docker-compose.yaml for the chosen value and the rationale.
+  downloadURL: ""
   accessKeyID: "octoadmin"
   secretAccessKey: "CHANGE_ME_MINIO_PASSWORD"
 
@@ -57,3 +73,4 @@ register:
   off: true
   onlyChina: false
   emailOn: false
+

--- a/docker/configs/octo-server.yaml
+++ b/docker/configs/octo-server.yaml
@@ -44,9 +44,10 @@ db:
   # mysqlAddr / redisAddr are overridden at runtime by TS_DB_MYSQLADDR /
   # TS_DB_REDISADDR set in docker-compose.yaml (which sources them from
   # .env). Leave the placeholders below — they exist only so the YAML
-  # structure parses.
-  mysqlAddr: "root:CHANGE_ME_MYSQL_PASSWORD@tcp(mysql:3306)/octo?charset=utf8mb4&parseTime=true&loc=Local"
-  redisAddr: "redis:6379"
+  # structure parses, and contain no credentials so a config dump from
+  # this file alone never carries a real password.
+  mysqlAddr: ""
+  redisAddr: ""
   redisPass: ""
 
 wukongIM:
@@ -70,8 +71,15 @@ minio:
   # source of truth — see the octo-server service block in
   # docker-compose.yaml for the chosen value and the rationale.
   downloadURL: ""
-  accessKeyID: "octoadmin"
-  secretAccessKey: "CHANGE_ME_MINIO_PASSWORD"
+  # accessKeyID / secretAccessKey are overridden at runtime by
+  # TS_MINIO_ACCESSKEYID / TS_MINIO_SECRETACCESSKEY (sourced from
+  # OCTO_MINIO_APP_USER / OCTO_MINIO_APP_PASSWORD in .env). Keeping the
+  # YAML values blank — same pattern as `external.*` above — means a
+  # leaked tsdd.yaml never contains a credential string and no
+  # known-default credential can sneak through if an operator forgets
+  # to set TS_MINIO_*.
+  accessKeyID: ""
+  secretAccessKey: ""
 
 logger:
   level: 2

--- a/docker/configs/octo-server.yaml
+++ b/docker/configs/octo-server.yaml
@@ -15,10 +15,19 @@
 # Runtime mode: debug | release
 mode: "release"
 
+# external.* is intentionally left empty here. The mounted YAML loses
+# precedence to env vars at runtime; the compose `octo-server` service
+# block sets:
+#   TS_EXTERNAL_BASEURL = http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}
+#   TS_EXTERNAL_IP      = ${OCTO_EXTERNAL_IP}
+# Those values are the single source of truth — change them in `.env`,
+# not here. Hard-coding them in this file shadows the env vars and
+# silently strands operators on `octo.local:28080` no matter what they
+# put in `.env`.
 external:
-  ip: "127.0.0.1"
-  baseURL: "http://octo.local:28080"
-  # webLoginURL: "http://octo.local:28080/"
+  ip: ""
+  baseURL: ""
+  # webLoginURL: ""
 
 # Test-only SMS verification code. Ignored in release mode.
 smsCode: ""

--- a/docker/configs/octo-server.yaml
+++ b/docker/configs/octo-server.yaml
@@ -1,0 +1,59 @@
+# -----------------------------------------------------------------------------
+# OCTO Server runtime config — minimal single-host deployment.
+# -----------------------------------------------------------------------------
+# Values shared with MySQL / Redis / MinIO / WuKongIM match the service
+# names (not ports) on the `octo-net` bridge network declared in
+# docker-compose.yaml. Do not change those strings unless you also rename
+# the corresponding compose services.
+#
+# Credentials with CHANGE_ME_* placeholders are overridden at runtime from
+# the environment via the names listed in kustomize/base/octo-server-secret
+# (DM_MYSQL_DSN, DM_REDIS_ADDR, WUKONGIM_MANAGER_TOKEN, …) plus Viper's
+# AutomaticEnv mapping for the YAML keys (TS_MINIO_*). OSS users only need
+# to edit .env — not this file.
+# -----------------------------------------------------------------------------
+
+# Runtime mode: debug | release
+mode: "release"
+
+external:
+  ip: "127.0.0.1"
+  baseURL: "http://octo.local:28080"
+  # webLoginURL: "http://octo.local:28080/"
+
+# Test-only SMS verification code. Ignored in release mode.
+smsCode: ""
+
+db:
+  # mysqlAddr / redisAddr are overridden by DM_MYSQL_DSN / DM_REDIS_ADDR
+  # set in docker-compose.yaml (which sources them from .env). Leave the
+  # placeholders below — they exist only so the YAML structure parses.
+  mysqlAddr: "root:CHANGE_ME_MYSQL_PASSWORD@tcp(mysql:3306)/octo?charset=utf8mb4&parseTime=true&loc=Local"
+  redisAddr: "redis:6379"
+  redisPass: ""
+
+wukongIM:
+  apiURL: "http://wukongim:5001"
+  # managerToken is overridden via WUKONGIM_MANAGER_TOKEN env from .env;
+  # leaving this empty means tokenAuthOn-protected admin calls will fail.
+  managerToken: ""
+
+# Image upload requires the PresignedPutter implementation merged in
+# Mininglamp-OSS/octo-server#24 (or any octo-server image built from a
+# commit that includes it). If your OCTO_SERVER_IMAGE pin predates that
+# fix, /api/v1/file/upload will 500 even with this stack healthy.
+fileService: "minio"
+minio:
+  url: "http://minio:9000"
+  accessKeyID: "octoadmin"
+  secretAccessKey: "CHANGE_ME_MINIO_PASSWORD"
+
+logger:
+  level: 2
+  dir: "./logs"
+  lineNum: false
+
+register:
+  off: true
+  onlyChina: false
+  emailOn: false

--- a/docker/configs/wk.yaml
+++ b/docker/configs/wk.yaml
@@ -1,0 +1,27 @@
+# -----------------------------------------------------------------------------
+# WuKongIM configuration for the OCTO stack.
+# Mounted at /root/wukongim/wk.yaml inside the octo-wukongim container.
+# -----------------------------------------------------------------------------
+
+# debug | release | bench
+mode: "debug"
+
+tokenAuthOn: true
+
+# External addresses advertised to clients on GET /route.
+# Override via .env → OCTO_EXTERNAL_IP / OCTO_WK_WS_ADDR / OCTO_WK_WSS_ADDR.
+external:
+  ip: "127.0.0.1"
+  tcpAddr: ""
+  wsAddr: ""
+  wssAddr: ""
+
+monitor:
+  on: true
+  addr: "0.0.0.0:5300"
+
+webhook:
+  grpcAddr: "octo-server:6979"
+
+conversation:
+  on: true

--- a/docker/configs/wk.yaml
+++ b/docker/configs/wk.yaml
@@ -21,6 +21,12 @@ monitor:
   addr: "0.0.0.0:5300"
 
 webhook:
+  # `octo-server:6979` is octo-server's internal gRPC listener. WuKongIM
+  # dials this address whenever it needs to deliver a message-event
+  # webhook back to OCTO, so the hostname must resolve inside the
+  # octo-net Docker bridge — which `octo-server` (the docker service
+  # name) does. This is an internal-only port; it is NOT published to
+  # the host.
   grpcAddr: "octo-server:6979"
 
 conversation:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -163,14 +163,14 @@ services:
         done
 
         echo "[minio-init] ensuring application user exists"
-        if mc admin user info local "$$OCTO_MINIO_APP_USER" >/dev/null 2>&1; then
-          # Re-set the secret so password rotations in .env take effect on
-          # `docker compose up -d`. This is the only `mc` call that is not
-          # idempotent on its own.
-          mc admin user add local "$$OCTO_MINIO_APP_USER" "$$OCTO_MINIO_APP_PASSWORD" >/dev/null
-        else
-          mc admin user add local "$$OCTO_MINIO_APP_USER" "$$OCTO_MINIO_APP_PASSWORD"
-        fi
+        # `mc admin user add` is upsert-semantics on current MinIO releases:
+        # it creates the user on first call, and overwrites the secret on
+        # subsequent calls. That makes rotation a matter of bumping
+        # OCTO_MINIO_APP_PASSWORD in .env and re-running `up -d`. We swallow
+        # stdout (just a status string, never the secret) to keep logs
+        # clean and avoid any chance of confusing operators with re-prints
+        # on every boot.
+        mc admin user add local "$$OCTO_MINIO_APP_USER" "$$OCTO_MINIO_APP_PASSWORD" >/dev/null
 
         echo "[minio-init] (re)installing octo-app policy"
         mc admin policy create local octo-app /etc/minio/octo-app-policy.json 2>/dev/null \

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -712,6 +712,14 @@ services:
       # Canonical worker trigger / callback paths (kustomize alignment).
       WORKER_TRIGGER_URL:      http://summary-worker:8082/internal/worker-trigger
       WORKER_API_CALLBACK_URL: http://summary-api:8081/internal/task-event
+      # HMAC secret on /internal/worker-trigger and /internal/task-event
+      # (router.go:91-92). Without it, callbacks between summary-api,
+      # summary-worker, and octo-server either fall back to insecure
+      # mode or silently no-op (worst case: a triggered summary task
+      # never gets dispatched to the worker). Same shape as
+      # octo-server / matter — no `:-` default; preflight refuses
+      # placeholder tokens before any service starts.
+      NOTIFY_INTERNAL_TOKEN: ${OCTO_NOTIFY_INTERNAL_TOKEN}
     # Direct port. Loopback by default; nginx /summary/ is the public
     # path and carries octo_api rate-limit. Override OCTO_SUMMARY_API_BIND
     # for cross-host operator access.
@@ -764,6 +772,11 @@ services:
       WORKER_INTERNAL_PORT:    "8082"
       WORKER_TRIGGER_URL:      http://summary-worker:8082/internal/worker-trigger
       WORKER_API_CALLBACK_URL: http://summary-api:8081/internal/task-event
+      # Same HMAC secret summary-api / matter / octo-server use on
+      # /internal/* callbacks. Required — no `:-` default — so the
+      # worker fails closed when .env is missing the token instead of
+      # silently posting unsigned task-events back to summary-api.
+      NOTIFY_INTERNAL_TOKEN: ${OCTO_NOTIFY_INTERNAL_TOKEN}
     networks:
       - octo-net
     # The worker exposes /internal/healthz on 8082 (no public /health).

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -39,6 +39,70 @@ volumes:
   nginx-logs:
 
 services:
+  # ---------------------------------------------------------------------------
+  # Preflight (one-shot)
+  # ---------------------------------------------------------------------------
+  # Refuses to let the stack come up with shared-secret tokens still on
+  # their `.env.example` `CHANGE_ME_*` / `CHG_ME*` placeholders.
+  # `init-extra-dbs.sh` already handles the MySQL service-account
+  # passwords (it runs inside MySQL's docker-entrypoint-initdb.d on the
+  # first volume init), and `minio-init` handles the MinIO root + app
+  # passwords. The two values left without a fail-fast were the
+  # cross-service auth tokens:
+  #
+  #   - OCTO_NOTIFY_INTERNAL_TOKEN — HMAC secret octo-server / matter /
+  #     summary-api use on /internal/* callbacks. Without rotation, a
+  #     stack widening any of the app-service binds (or a peer on the
+  #     same LAN reaching octo-net) can forge `task-event` /
+  #     `worker-trigger` calls with the well-known `CHANGE_ME_*`
+  #     literal.
+  #   - OCTO_WUKONGIM_MANAGER_TOKEN — admin token for WuKongIM's
+  #     manager API. wk.yaml ships with `tokenAuthOn: true`, but an
+  #     empty / placeholder value short-circuits the comparison and
+  #     accepts any string.
+  #
+  # The matching MinIO / MySQL / OCTO_MASTER_KEY checks live elsewhere
+  # (see minio-init for MINIO_ROOT_PASSWORD / OCTO_MINIO_APP_PASSWORD,
+  # init-extra-dbs.sh for MYSQL_ROOT_PASSWORD + the three DB account
+  # passwords, octo-server's own startup for the 32-byte length on
+  # OCTO_MASTER_KEY). This preflight stays narrowly scoped to the
+  # tokens that have no other guard.
+  preflight:
+    image: ${OCTO_PREFLIGHT_IMAGE:-busybox:1.36}
+    container_name: octo-preflight
+    restart: "no"
+    environment:
+      OCTO_NOTIFY_INTERNAL_TOKEN: ${OCTO_NOTIFY_INTERNAL_TOKEN:-}
+      OCTO_WUKONGIM_MANAGER_TOKEN: ${OCTO_WUKONGIM_MANAGER_TOKEN:-}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -eu
+        # Lower-case the value before pattern matching so any casing
+        # of the placeholder (`CHANGE_ME_*`, `Change_Me_*`, `chg_me*`)
+        # trips the same branch — busybox sh has no `nocasematch`.
+        check() {
+          name=$$1
+          raw=$$(eval "printf %s \"\$$$$name\"")
+          if [ -z "$$raw" ]; then
+            echo "[preflight] FATAL: $$name is empty — set it in .env (openssl rand -hex 32)" >&2
+            exit 1
+          fi
+          lc=$$(printf %s "$$raw" | tr 'A-Z' 'a-z')
+          case "$$lc" in
+            change_me_*|chg_me*)
+              echo "[preflight] FATAL: $$name is still a CHANGE_ME / CHG_ME placeholder." >&2
+              echo "[preflight]        Rotate it in .env (openssl rand -hex 32) before bringing the stack up." >&2
+              exit 1
+              ;;
+          esac
+        }
+        check OCTO_NOTIFY_INTERNAL_TOKEN
+        check OCTO_WUKONGIM_MANAGER_TOKEN
+        echo "[preflight] tokens look rotated"
+    networks:
+      - octo-net
+
   mysql:
     image: mysql:8.0
     container_name: octo-mysql
@@ -63,8 +127,15 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
       - ./scripts/init-extra-dbs.sh:/docker-entrypoint-initdb.d/01-extra-dbs.sh:ro
+    # MYSQL_PWD avoids leaking the root password into `/proc/<pid>/cmdline`
+    # the way `-p"$MYSQL_ROOT_PASSWORD"` would (any container co-tenant
+    # could `cat /proc/<pid>/cmdline` and read it). The mysql client
+    # reads MYSQL_PWD from the env automatically. mysqladmin emits a
+    # one-line warning to stderr about MYSQL_PWD being insecure on
+    # multi-user hosts; that warning does not affect the exit code or
+    # the healthcheck verdict.
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      test: ["CMD-SHELL", "MYSQL_PWD=\"$$MYSQL_ROOT_PASSWORD\" mysqladmin ping -h localhost -u root --silent"]
       interval: 10s
       timeout: 5s
       retries: 12
@@ -188,19 +259,26 @@ services:
         # octo-server signs presigned URLs with; root is what `mc admin`
         # / the MinIO console accept. Either at a placeholder is a
         # blocking condition.
-        case "$${MINIO_ROOT_PASSWORD:-}" in
-          ""|CHANGE_ME_*|CHG_ME*|change_me_*|chg_me*)
+        #
+        # Lower-case before matching so any casing of the placeholder
+        # (`CHANGE_ME_*`, `Change_Me_*`, `chg_me*`) trips the same
+        # branch — busybox sh in the `mc` image has no `nocasematch`,
+        # so we normalise with `tr` instead of growing the case list.
+        root_lc=$$(printf %s "$${MINIO_ROOT_PASSWORD:-}" | tr 'A-Z' 'a-z')
+        case "$$root_lc" in
+          ""|change_me_*|chg_me*)
             echo "[minio-init] FATAL: MINIO_ROOT_PASSWORD is empty or still a CHANGE_ME / CHG_ME placeholder." >&2
             echo "[minio-init]        Rotate it in .env (openssl rand -hex 16) before bringing the stack up." >&2
             exit 1
             ;;
         esac
-        case "$${OCTO_MINIO_APP_PASSWORD:-}" in
+        app_lc=$$(printf %s "$${OCTO_MINIO_APP_PASSWORD:-}" | tr 'A-Z' 'a-z')
+        case "$$app_lc" in
           "")
             echo "[minio-init] FATAL: OCTO_MINIO_APP_PASSWORD is empty — set it in .env" >&2
             exit 1
             ;;
-          CHANGE_ME_*|CHG_ME*|change_me_*|chg_me*)
+          change_me_*|chg_me*)
             echo "[minio-init] FATAL: OCTO_MINIO_APP_PASSWORD is still a CHANGE_ME / CHG_ME placeholder." >&2
             echo "[minio-init]        Rotate it in .env (openssl rand -hex 24) before bringing the stack up." >&2
             exit 1
@@ -277,7 +355,12 @@ services:
       - "${OCTO_WK_API_PORT:-25001}:5001"
       - "${OCTO_WK_TCP_PORT:-25100}:5100"
       - "${OCTO_WK_WS_PORT:-25200}:5200"
-      - "${OCTO_WK_MONITOR_PORT:-25300}:5300"
+      # Monitor port is an internal observability surface (varz / metrics
+      # / `/route` admin), not a chat transport — bind to loopback by
+      # default. Override via OCTO_WK_MONITOR_BIND for operators who want
+      # to reach it from a jumphost. The user-facing surfaces above
+      # (API/TCP/WS) stay on 0.0.0.0 because clients connect to them.
+      - "${OCTO_WK_MONITOR_BIND:-127.0.0.1}:${OCTO_WK_MONITOR_PORT:-25300}:5300"
     volumes:
       - wukongim-data:/root/wukongim
       - ./configs/wk.yaml:/root/wukongim/wk.yaml:ro
@@ -380,25 +463,47 @@ services:
       # --- are the single source of truth.
       TS_EXTERNAL_BASEURL: "http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}"
       TS_EXTERNAL_IP: "${OCTO_EXTERNAL_IP:-127.0.0.1}"
-      NOTIFY_INTERNAL_TOKEN: ${OCTO_NOTIFY_INTERNAL_TOKEN:-}
+      # No `:-` default — an empty value here would silently drop
+      # /internal/* callback HMAC verification on the octo-server side
+      # and leave matter / summary-api trusting unsigned requests. The
+      # `preflight` service refuses placeholder tokens; compose itself
+      # warns when this var is missing from .env. Two-name sync with
+      # matter (line below) keeps the contract symmetric.
+      NOTIFY_INTERNAL_TOKEN: ${OCTO_NOTIFY_INTERNAL_TOKEN}
       # First-admin bootstrap. Uncomment to have octo-server seed a
       # superAdmin row (username "superAdmin", password bcrypt(<value>))
       # on first start when the user table is empty. See "First-admin
       # bootstrap · Option A" in docker/README.md before enabling.
       # TS_ADMINPWD: ${OCTO_ADMIN_PWD:-}
     depends_on:
+      preflight:
+        condition: service_completed_successfully
       mysql:
         condition: service_healthy
       redis:
         condition: service_healthy
+      # `service_started` (not `service_healthy`) is intentional: the
+      # octo-server -> wukongim contract is webhook-style (gRPC at
+      # octo-server:6979, WuKongIM dials *us*), so wukongim only needs
+      # to be running, not yet healthy. Using `service_healthy` here
+      # would create a deadlock — wukongim's healthcheck has flapped
+      # in past releases and a stuck WK kept octo-server from booting
+      # even though the missing piece was wukongim itself.
       wukongim:
         condition: service_started
       minio:
         condition: service_healthy
       minio-init:
         condition: service_completed_successfully
+    # Direct REST port, intended for operator smoke tests / debugging.
+    # Loopback by default so the OOTB stack does not expose octo-server
+    # past the rate-limited nginx vhost (`/api/`, `/v1/` carry the
+    # octo_api / octo_auth limit_req zones from nginx.conf:31-32; a
+    # client hitting :28081 directly bypasses both). Flip
+    # OCTO_SERVER_BIND to 0.0.0.0 for an operator who needs the port
+    # reachable from a different host.
     ports:
-      - "${OCTO_SERVER_PORT:-28081}:8090"
+      - "${OCTO_SERVER_BIND:-127.0.0.1}:${OCTO_SERVER_PORT:-28081}:8090"
     volumes:
       - ./configs/octo-server.yaml:/home/configs/tsdd.yaml:ro
       - server-logs:/home/logs
@@ -498,6 +603,8 @@ services:
     container_name: octo-matter
     restart: unless-stopped
     depends_on:
+      preflight:
+        condition: service_completed_successfully
       mysql:
         condition: service_healthy
       octo-server:
@@ -514,8 +621,13 @@ services:
       LLM_API_KEY: ${LLM_API_KEY:-}
       LLM_MODEL: ${LLM_MODEL:-claude-sonnet-4-6}
       LLM_TIMEOUT: "30"
+    # Direct port, intended for operator smoke tests. Loopback by
+    # default — production traffic reaches matter via nginx /matter/
+    # which carries the octo_api rate-limit zone. Override
+    # OCTO_MATTER_BIND when an operator needs the port from another
+    # host.
     ports:
-      - "${OCTO_MATTER_PORT:-28086}:8080"
+      - "${OCTO_MATTER_BIND:-127.0.0.1}:${OCTO_MATTER_PORT:-28086}:8080"
     networks:
       - octo-net
     healthcheck:
@@ -533,6 +645,8 @@ services:
     container_name: octo-summary-api
     restart: unless-stopped
     depends_on:
+      preflight:
+        condition: service_completed_successfully
       mysql:
         condition: service_healthy
     environment:
@@ -553,8 +667,11 @@ services:
       # Canonical worker trigger / callback paths (kustomize alignment).
       WORKER_TRIGGER_URL:      http://summary-worker:8082/internal/worker-trigger
       WORKER_API_CALLBACK_URL: http://summary-api:8081/internal/task-event
+    # Direct port. Loopback by default; nginx /summary/ is the public
+    # path and carries octo_api rate-limit. Override OCTO_SUMMARY_API_BIND
+    # for cross-host operator access.
     ports:
-      - "${OCTO_SUMMARY_API_PORT:-28087}:8080"
+      - "${OCTO_SUMMARY_API_BIND:-127.0.0.1}:${OCTO_SUMMARY_API_PORT:-28087}:8080"
     networks:
       - octo-net
     healthcheck:
@@ -562,7 +679,14 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 10s
+      # Bumped to 30s to match octo-server's `start_period`. The
+      # summary-api boot path warms a MySQL connection pool against
+      # the loopback-bound mysql service AND validates required env
+      # (OCTO_API_URL etc.) before serving /health, which on a cold
+      # `docker compose up` overlaps with mysql still finishing its
+      # init script. 10s left the OOTB stack reporting transient
+      # `(unhealthy)` on cold boot.
+      start_period: 30s
 
   summary-worker:
     image: ${OCTO_SUMMARY_WORKER_IMAGE:-mininglamposs/octo-smart-summary-worker:latest}
@@ -606,4 +730,7 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 10s
+      # 30s matches octo-server / summary-api so the cold-boot grace
+      # window does not wedge the worker into `(unhealthy)` while the
+      # mysql init script is still finishing.
+      start_period: 30s

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -122,8 +122,86 @@ services:
     networks:
       - octo-net
 
+  # ---------------------------------------------------------------------------
+  # MinIO bootstrap (one-shot)
+  # ---------------------------------------------------------------------------
+  # Provisions a dedicated IAM user (`octo-app` by default) scoped to the
+  # bucket whitelist octo-server uses (see modules/file/helpers.go). The
+  # `octo-server` service then mounts THESE credentials as
+  # TS_MINIO_ACCESSKEYID / TS_MINIO_SECRETACCESSKEY instead of the MinIO
+  # root pair, so a leak of the app credentials does not hand over
+  # `mc admin` / console / IAM control.
+  #
+  # Idempotent: every `mc` call is wrapped in `|| true` (or guarded by
+  # `--insecure` semantics on update commands) so re-running the service
+  # after the first boot is a no-op rather than an error. The compose
+  # `service_completed_successfully` gate on octo-server therefore keeps
+  # working across restarts of the stack.
+  minio-init:
+    image: ${OCTO_MINIO_MC_IMAGE:-minio/mc:RELEASE.2025-04-16T18-13-26Z}
+    container_name: octo-minio-init
+    restart: "no"
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-octoadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+      OCTO_MINIO_APP_USER: ${OCTO_MINIO_APP_USER:-octo-app}
+      OCTO_MINIO_APP_PASSWORD: ${OCTO_MINIO_APP_PASSWORD}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -eu
+        if [ -z "$${OCTO_MINIO_APP_PASSWORD:-}" ]; then
+          echo "[minio-init] FATAL: OCTO_MINIO_APP_PASSWORD is empty — set it in .env" >&2
+          exit 1
+        fi
+        echo "[minio-init] waiting for MinIO root alias…"
+        until mc alias set local "http://minio:9000" "$$MINIO_ROOT_USER" "$$MINIO_ROOT_PASSWORD" >/dev/null 2>&1; do
+          sleep 1
+        done
+
+        echo "[minio-init] ensuring application user exists"
+        if mc admin user info local "$$OCTO_MINIO_APP_USER" >/dev/null 2>&1; then
+          # Re-set the secret so password rotations in .env take effect on
+          # `docker compose up -d`. This is the only `mc` call that is not
+          # idempotent on its own.
+          mc admin user add local "$$OCTO_MINIO_APP_USER" "$$OCTO_MINIO_APP_PASSWORD" >/dev/null
+        else
+          mc admin user add local "$$OCTO_MINIO_APP_USER" "$$OCTO_MINIO_APP_PASSWORD"
+        fi
+
+        echo "[minio-init] (re)installing octo-app policy"
+        mc admin policy create local octo-app /etc/minio/octo-app-policy.json 2>/dev/null \
+          || mc admin policy update local octo-app /etc/minio/octo-app-policy.json
+
+        echo "[minio-init] attaching octo-app policy to $$OCTO_MINIO_APP_USER"
+        mc admin policy attach local octo-app --user "$$OCTO_MINIO_APP_USER" 2>/dev/null || true
+
+        # Pre-create the bucket whitelist octo-server uses so the first
+        # /api/v1/file/upload call does NOT depend on the app user having
+        # CreateBucket privileges (the policy below intentionally omits
+        # bucket admin actions). Each `mb` is `--ignore-existing` so the
+        # service stays idempotent.
+        for b in file chat moment sticker report chatbg common download group avatar; do
+          mc mb --ignore-existing "local/$$b" >/dev/null
+        done
+
+        echo "[minio-init] done"
+    volumes:
+      - ./configs/minio-octo-app-policy.json:/etc/minio/octo-app-policy.json:ro
+    networks:
+      - octo-net
+
   wukongim:
-    image: wukongim/wukongim:latest
+    # Pinned to a specific WuKongIM release. `:latest` is a moving target —
+    # different channels disagree on whether `tokenAuthOn: true` is honoured
+    # or rejected at startup, and the env-var contract for `managerToken`
+    # has not been stable across pre-2.x builds. Bump deliberately after
+    # validating the new tag against `wk.yaml` (tokenAuthOn) and the
+    # WK_MANAGERTOKEN binding below. Override via .env -> OCTO_WK_IMAGE.
+    image: ${OCTO_WK_IMAGE:-wukongim/wukongim:v2.2.4-20260313}
     container_name: octo-wukongim
     restart: unless-stopped
     environment:
@@ -136,10 +214,16 @@ services:
       # OCTO_WK_WS_ADDR to a literal in .env when they want to override.
       WK_EXTERNAL_WSADDR:  ${OCTO_WK_WS_ADDR:-ws://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}/ws}
       WK_EXTERNAL_WSSADDR: ${OCTO_WK_WSS_ADDR:-}
-      # Shared admin token: must match what octo-server uses as
-      # WUKONGIM_MANAGER_TOKEN. Both come from the same .env value so they
-      # cannot drift.
-      WK_TOKEN: ${OCTO_WUKONGIM_MANAGER_TOKEN:-}
+      # Shared admin token. WuKongIM binds env vars to YAML keys via Viper's
+      # default key replacer (`.` -> `_`, upper-cased, prefix `WK_`), so the
+      # YAML key `managerToken` is set from the env var `WK_MANAGERTOKEN`.
+      # There is NO top-level `token` / `WK_TOKEN` key — that name is
+      # silently ignored, which is exactly what the previous revision of
+      # this stack did, and which left `wk.yaml`'s `tokenAuthOn: true`
+      # paired with an empty `managerToken` (= admin endpoints reachable
+      # without auth). The single .env value below feeds both this binding
+      # and octo-server's TS_WUKONGIM_MANAGERTOKEN so they cannot drift.
+      WK_MANAGERTOKEN: ${OCTO_WUKONGIM_MANAGER_TOKEN:-}
     ports:
       - "${OCTO_WK_API_PORT:-25001}:5001"
       - "${OCTO_WK_TCP_PORT:-25100}:5100"
@@ -203,8 +287,21 @@ services:
       # MinIO credentials surfaced as Viper-style env overrides for the
       # tsdd.yaml `minio:` block. Compose-only — kustomize installs use
       # tencentCOS / s3 instead and ship credentials via octo-server-secret.
-      TS_MINIO_ACCESSKEYID:     "${MINIO_ROOT_USER:-octoadmin}"
-      TS_MINIO_SECRETACCESSKEY: "${MINIO_ROOT_PASSWORD}"
+      #
+      # These are deliberately NOT the MinIO root credentials. The root
+      # credentials are also what `mc admin` and the MinIO console use,
+      # so reusing them here would mean a single env-dump / log spillage
+      # / Docker-socket exposure hands an attacker full IAM control of
+      # the bucket store, not just app-level read/write. The `minio-init`
+      # service (below) provisions a dedicated `octo-app` user scoped to
+      # the buckets octo-server actually touches (`file`, `chat`,
+      # `moment`, `sticker`, `report`, `chatbg`, `common`, `download`,
+      # `group`, `avatar` — the whitelist in
+      # octo-server/modules/file/helpers.go). Rotation now means
+      # restarting `minio-init` + `octo-server` only; the root password
+      # stays put.
+      TS_MINIO_ACCESSKEYID:     "${OCTO_MINIO_APP_USER:-octo-app}"
+      TS_MINIO_SECRETACCESSKEY: "${OCTO_MINIO_APP_PASSWORD}"
       # --- MinIO client-facing download URL.
       # --- An empty `minio.downloadURL` falls back to `minio.url`
       # --- (= http://minio:9000), which only resolves inside the
@@ -249,6 +346,8 @@ services:
         condition: service_started
       minio:
         condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
     ports:
       - "${OCTO_SERVER_PORT:-28081}:8090"
     volumes:
@@ -427,17 +526,28 @@ services:
       OCTO_API_URL:   http://octo-server:8090
       DMWORK_API_URL: http://octo-server:8090
       LLM_API_URL:  ${LLM_API_URL:-https://api.example.com/v1}
-      LLM_API_KEY:  ${LLM_API_KEY:-}
+      # summary-worker (cmd/summary-worker/main.go) calls
+      # config.ValidateRequired on LLM_API_KEY and exits the process when
+      # it's empty — unlike summary-api / matter, which only fail at first
+      # LLM call. To keep `docker compose up -d` reaching `(healthy)` for
+      # the OOTB smoke-test path, fall back to a clearly-fake placeholder
+      # when .env leaves LLM_API_KEY blank. The worker boots, advertises
+      # /internal/healthz, and ONLY explodes when an actual summarization
+      # task hits the LLM client. Set LLM_API_KEY in .env before exercising
+      # smart-summary features. See README "Validation" for the probe.
+      LLM_API_KEY:  ${LLM_API_KEY:-changeme-set-real-llm-api-key-to-enable-summary}
       LLM_MODEL:    ${LLM_MODEL:-claude-sonnet-4-6}
       WORKER_INTERNAL_PORT:    "8082"
       WORKER_TRIGGER_URL:      http://summary-worker:8082/internal/worker-trigger
       WORKER_API_CALLBACK_URL: http://summary-api:8081/internal/task-event
     networks:
       - octo-net
-    # TCP healthcheck because the worker only exposes /internal/* on 8082
-    # and has no public /health route; matches kustomize livenessProbe.
+    # The worker exposes /internal/healthz on 8082 (no public /health).
+    # Probe that explicitly — the previous `nc -z` fallback masked
+    # process-exits because compose still sees the port as listening
+    # while a panicking goroutine winds the process down.
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O - http://localhost:8082/internal/healthz >/dev/null 2>&1 || nc -z localhost 8082 || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O - http://localhost:8082/internal/healthz >/dev/null 2>&1 || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -102,10 +102,14 @@ services:
       # the composition lives here instead of in .env.
       MINIO_SERVER_URL: ${MINIO_SERVER_URL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}/minio}
       MINIO_BROWSER_REDIRECT_URL: ${MINIO_BROWSER_REDIRECT_URL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}/minio-console/}
-    # Backing service API on loopback by default. Console likewise — operators
-    # access it via the nginx /minio-console/ route, not the raw 9001 port.
+    # MinIO API is public by default: octo-server hands browser clients
+    # presigned (SigV4) URLs that point at this port directly, and SigV4
+    # signatures cannot survive an nginx path-prefix rewrite. Access keys
+    # protect the data — the port being reachable does not.
+    # The MinIO console is loopback-only — admins reach it through the
+    # nginx /minio-console/ route or via SSH-forwarded :9001.
     ports:
-      - "${OCTO_MINIO_API_BIND:-127.0.0.1}:${OCTO_MINIO_API_PORT:-29000}:9000"
+      - "${OCTO_MINIO_API_BIND:-0.0.0.0}:${OCTO_MINIO_API_PORT:-29000}:9000"
       - "${OCTO_MINIO_CONSOLE_BIND:-127.0.0.1}:${OCTO_MINIO_CONSOLE_PORT:-29001}:9001"
     volumes:
       - minio-data:/data
@@ -208,15 +212,14 @@ services:
       # --- cannot reach that hostname, so /api/v1/file/* responses
       # --- become unusable. We override with a host-reachable URL.
       # ---
-      # --- The host:port form below bypasses nginx — chosen because it
-      # --- works against ANY octo-server image, including ones that do
-      # --- not yet include the path-prefix preservation tracked in
-      # --- octo-server PR#50 (YUJ-728). When that ships, this can be
-      # --- flipped to the path-prefixed nginx form:
-      # ---     http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}/minio
-      # --- For host:port to be reachable from non-loopback clients the
-      # --- operator must widen OCTO_MINIO_API_BIND from 127.0.0.1 to
-      # --- 0.0.0.0 in .env (single-host loopback users need no change).
+      # --- Host:port form (no path prefix) is intentional. SigV4
+      # --- presigned URLs sign the canonical path, so any nginx
+      # --- /minio rewrite breaks the signature. octo-server PR#50 R4
+      # --- (YUJ-728) drops path-prefix support and validates that
+      # --- DownloadURL is host:port only — anything else is rejected
+      # --- at startup. The MinIO API port is bound to 0.0.0.0 by
+      # --- default (see the `minio` service block) so this URL is
+      # --- reachable from the same hosts that hit the nginx vhost.
       TS_MINIO_DOWNLOADURL: "http://${OCTO_DOMAIN:-octo.local}:${OCTO_MINIO_API_PORT:-29000}"
       NOTIFY_INTERNAL_TOKEN: ${OCTO_NOTIFY_INTERNAL_TOKEN:-}
       # First-admin bootstrap. Uncomment to have octo-server seed a

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -221,6 +221,19 @@ services:
       # --- default (see the `minio` service block) so this URL is
       # --- reachable from the same hosts that hit the nginx vhost.
       TS_MINIO_DOWNLOADURL: "http://${OCTO_DOMAIN:-octo.local}:${OCTO_MINIO_API_PORT:-29000}"
+      # --- octo-server's own external URL (the value it returns to
+      # --- clients in places that need an absolute URL — e.g. login
+      # --- redirects, OIDC callback hints, public asset links). The
+      # --- baseURL must include the user-visible host AND the nginx
+      # --- HTTP port, because the SPA / admin / mobile clients all
+      # --- hit nginx on OCTO_HTTP_PORT, not octo-server on 8090.
+      # --- TS_EXTERNAL_IP is what octo-server advertises when a peer
+      # --- needs the host's IP literal (rare; defaults to loopback so
+      # --- it is never a leak vector). The mounted octo-server.yaml
+      # --- carries empty `external.*` placeholders so these env vars
+      # --- are the single source of truth.
+      TS_EXTERNAL_BASEURL: "http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}"
+      TS_EXTERNAL_IP: "${OCTO_EXTERNAL_IP:-127.0.0.1}"
       NOTIFY_INTERNAL_TOKEN: ${OCTO_NOTIFY_INTERNAL_TOKEN:-}
       # First-admin bootstrap. Uncomment to have octo-server seed a
       # superAdmin row (username "superAdmin", password bcrypt(<value>))

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -158,24 +158,72 @@ services:
     container_name: octo-server
     restart: unless-stopped
     command: ["api"]
+    # -------------------------------------------------------------------
+    # Why this env block carries TWO names for the same value
+    # -------------------------------------------------------------------
+    # The current octo-server binary configures Viper with
+    # `SetEnvPrefix("TS")` + `SetEnvKeyReplacer(".", "_")` + `AutomaticEnv()`,
+    # so it reads YAML keys like `db.mysqlAddr` from `TS_DB_MYSQLADDR`,
+    # `db.redisAddr` from `TS_DB_REDISADDR`, `wukongIM.managerToken`
+    # from `TS_WUKONGIM_MANAGERTOKEN`, and the `minio.*` block from
+    # the matching `TS_MINIO_*` names. The kustomize overlays use a
+    # different convention (`DM_MYSQL_DSN`, `DM_REDIS_ADDR`,
+    # `WUKONGIM_MANAGER_TOKEN`) that is NOT honoured by the current
+    # binary. We pass both name sets so that:
+    #   - the running binary actually picks the values up (TS_*),
+    #   - any sidecar / external tooling that follows the kustomize
+    #     names keeps working (DM_*).
+    # The aliases can be dropped once octo-server adds explicit BindEnv
+    # mappings for the kustomize names (or unifies on a single prefix).
+    # -------------------------------------------------------------------
     environment:
       TZ: ${TZ:-UTC}
       OCTO_MASTER_KEY: ${OCTO_MASTER_KEY}
       DMWORK_MASTER_KEY: ${OCTO_MASTER_KEY}
-      # Canonical env names align with kustomize/base/octo-server-secret.
-      DM_MYSQL_DSN: "root:${MYSQL_ROOT_PASSWORD}@tcp(mysql:3306)/${MYSQL_DATABASE:-octo}?charset=utf8mb4&parseTime=true&loc=Local"
-      DM_REDIS_ADDR: "redis:6379"
-      # WuKongIM admin token — must match wk.yaml's tokenAuthOn / WK_TOKEN.
-      WUKONGIM_MANAGER_TOKEN: ${OCTO_WUKONGIM_MANAGER_TOKEN:-}
+      # --- DB / cache: TS_* are read by the binary, DM_* mirror the
+      # --- kustomize/base/octo-server-secret naming for tooling parity.
+      TS_DB_MYSQLADDR:  "root:${MYSQL_ROOT_PASSWORD}@tcp(mysql:3306)/${MYSQL_DATABASE:-octo}?charset=utf8mb4&parseTime=true&loc=Local"
+      TS_DB_REDISADDR:  "redis:6379"
+      DM_MYSQL_DSN:     "root:${MYSQL_ROOT_PASSWORD}@tcp(mysql:3306)/${MYSQL_DATABASE:-octo}?charset=utf8mb4&parseTime=true&loc=Local"
+      DM_REDIS_ADDR:    "redis:6379"
+      # --- WuKongIM admin token: TS_WUKONGIM_MANAGERTOKEN is what the
+      # --- binary reads (overrides wukongIM.managerToken in tsdd.yaml);
+      # --- WUKONGIM_MANAGER_TOKEN is the kustomize alias. Both come
+      # --- from the same .env value so they cannot drift, and must
+      # --- match wk.yaml's tokenAuthOn / WK_TOKEN.
+      TS_WUKONGIM_MANAGERTOKEN: ${OCTO_WUKONGIM_MANAGER_TOKEN:-}
+      WUKONGIM_MANAGER_TOKEN:   ${OCTO_WUKONGIM_MANAGER_TOKEN:-}
       # Optional inbound webhook HMAC. Compose-only addition (not in
       # kustomize) — explained in .env.example.
       TS_WEBHOOK_SECRET_KEY: ${OCTO_WEBHOOK_SECRET_KEY:-}
       # MinIO credentials surfaced as Viper-style env overrides for the
       # tsdd.yaml `minio:` block. Compose-only — kustomize installs use
       # tencentCOS / s3 instead and ship credentials via octo-server-secret.
-      TS_MINIO_ACCESSKEYID: "${MINIO_ROOT_USER:-octoadmin}"
+      TS_MINIO_ACCESSKEYID:     "${MINIO_ROOT_USER:-octoadmin}"
       TS_MINIO_SECRETACCESSKEY: "${MINIO_ROOT_PASSWORD}"
+      # --- MinIO client-facing download URL.
+      # --- An empty `minio.downloadURL` falls back to `minio.url`
+      # --- (= http://minio:9000), which only resolves inside the
+      # --- octo-net Docker bridge. Browser clients on the host or LAN
+      # --- cannot reach that hostname, so /api/v1/file/* responses
+      # --- become unusable. We override with a host-reachable URL.
+      # ---
+      # --- The host:port form below bypasses nginx — chosen because it
+      # --- works against ANY octo-server image, including ones that do
+      # --- not yet include the path-prefix preservation tracked in
+      # --- octo-server PR#50 (YUJ-728). When that ships, this can be
+      # --- flipped to the path-prefixed nginx form:
+      # ---     http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}/minio
+      # --- For host:port to be reachable from non-loopback clients the
+      # --- operator must widen OCTO_MINIO_API_BIND from 127.0.0.1 to
+      # --- 0.0.0.0 in .env (single-host loopback users need no change).
+      TS_MINIO_DOWNLOADURL: "http://${OCTO_DOMAIN:-octo.local}:${OCTO_MINIO_API_PORT:-29000}"
       NOTIFY_INTERNAL_TOKEN: ${OCTO_NOTIFY_INTERNAL_TOKEN:-}
+      # First-admin bootstrap. Uncomment to have octo-server seed a
+      # superAdmin row (username "superAdmin", password bcrypt(<value>))
+      # on first start when the user table is empty. See "First-admin
+      # bootstrap · Option A" in docker/README.md before enabling.
+      # TS_ADMINPWD: ${OCTO_ADMIN_PWD:-}
     depends_on:
       mysql:
         condition: service_healthy
@@ -320,7 +368,12 @@ services:
     environment:
       MYSQL_DSN:    "summary:${OCTO_SUMMARY_DB_PASSWORD:-summary}@tcp(mysql:3306)/octo_summary?charset=utf8mb4&parseTime=true"
       IM_MYSQL_DSN: "summary_reader:${OCTO_SUMMARY_READER_PASSWORD:-summary_reader}@tcp(mysql:3306)/${MYSQL_DATABASE:-octo}?charset=utf8mb4&parseTime=true"
-      # Canonical env names from kustomize/base/octo-smart-summary-config.
+      # The current octo-smart-summary binary requires OCTO_API_URL on
+      # startup (cmd/summary-api/main.go marks it required); without it
+      # the container exits with "required environment variables not
+      # set: OCTO_API_URL". DMWORK_API_URL is the kustomize alias and
+      # is kept so any tooling that still reads it keeps working.
+      OCTO_API_URL:   http://octo-server:8090
       DMWORK_API_URL: http://octo-server:8090
       LLM_API_URL:  ${LLM_API_URL:-https://api.example.com/v1}
       LLM_API_KEY:  ${LLM_API_KEY:-}
@@ -353,6 +406,9 @@ services:
     environment:
       MYSQL_DSN:    "summary:${OCTO_SUMMARY_DB_PASSWORD:-summary}@tcp(mysql:3306)/octo_summary?charset=utf8mb4&parseTime=true"
       IM_MYSQL_DSN: "summary_reader:${OCTO_SUMMARY_READER_PASSWORD:-summary_reader}@tcp(mysql:3306)/${MYSQL_DATABASE:-octo}?charset=utf8mb4&parseTime=true"
+      # Worker shares the same OCTO_API_URL contract as summary-api;
+      # DMWORK_API_URL kept as a kustomize-naming alias.
+      OCTO_API_URL:   http://octo-server:8090
       DMWORK_API_URL: http://octo-server:8090
       LLM_API_URL:  ${LLM_API_URL:-https://api.example.com/v1}
       LLM_API_KEY:  ${LLM_API_KEY:-}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -162,22 +162,51 @@ services:
       - octo-net
 
   minio:
-    image: minio/minio:latest
+    # Pinned to a specific MinIO release rather than `:latest`. Two
+    # contracts in this stack break silently when the upstream image
+    # rolls forward:
+    #   1. `minio-init` runs `mc admin user add` / `mc admin policy
+    #      create` / `mc admin policy attach`. The CLI semantics across
+    #      these commands have flipped before — the `mc admin user add`
+    #      upsert behaviour we rely on (see the comment block in the
+    #      `minio-init` service) is a contract that has changed across
+    #      MinIO releases, so the `mc` image is pinned to a known-good
+    #      release and the server image must come from the same release
+    #      family to keep them in sync.
+    #   2. `MINIO_ROOT_PASSWORD` ≥8-char minimum-length check is the
+    #      first placeholder fail-fast layer (see .env.example: the
+    #      7-char `CHG_ME!` placeholder trips MinIO's own length check
+    #      at boot before `minio-init` even runs). If a future MinIO
+    #      release softens or removes that check, the `CHG_ME!` trap
+    #      stops working and an unrotated stack would reach `(healthy)`.
+    # Bump deliberately after validating the new server tag against the
+    # `mc` tag below (and re-running the placeholder fail-fast smoke
+    # test). Override via .env -> OCTO_MINIO_IMAGE, mirroring the
+    # OCTO_WK_IMAGE / OCTO_MINIO_MC_IMAGE pattern.
+    image: ${OCTO_MINIO_IMAGE:-minio/minio:RELEASE.2025-04-22T22-12-26Z}
     container_name: octo-minio
     restart: unless-stopped
     command: ["server", "/data", "--console-address", ":9001"]
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-octoadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
-      # Compose interpolates these once into the YAML below; we cannot rely
-      # on nested `${VAR}` inside .env values being expanded at runtime, so
-      # the composition lives here instead of in .env.
+      # MINIO_SERVER_URL is what MinIO uses to construct absolute URLs
+      # in multipart redirects, error responses with retry hints, and
+      # federated bucket discovery. It must point at the SAME endpoint
+      # octo-server tells browser clients to hit when handing out
+      # presigned URLs (TS_MINIO_DOWNLOADURL below) — otherwise MinIO-
+      # emitted absolute URLs route through nginx `/minio/` while
+      # presigned URLs hit `:29000` directly, and a SigV4 signature
+      # signed for one path will not validate on the other.
       #
-      # MINIO_SERVER_URL is the public S3 endpoint clients are told about
-      # in error responses / multipart redirects. The /minio path prefix
-      # works because nginx exposes /minio/ as a passthrough proxy to
-      # `minio:9000`.
-      MINIO_SERVER_URL: ${MINIO_SERVER_URL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}/minio}
+      # Host:port-only form is therefore the canonical default. The
+      # nginx /minio/ passthrough at nginx/conf.d/octo.conf.template:116
+      # stays exposed for in-cluster diagnostics (curl from a sidecar
+      # against the host's nginx is convenient), but it is NOT the URL
+      # MinIO advertises to clients. To override (e.g. when fronting
+      # with TLS at a different hostname), set MINIO_SERVER_URL to a
+      # literal value in .env.
+      MINIO_SERVER_URL: ${MINIO_SERVER_URL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_MINIO_API_PORT:-29000}}
       # MINIO_BROWSER_REDIRECT_URL is the canonical URL MinIO redirects
       # the console to after auth. The previous default pointed at the
       # nginx /minio-console/ route, but that route is no longer exposed
@@ -351,6 +380,22 @@ services:
       # without auth). The single .env value below feeds both this binding
       # and octo-server's TS_WUKONGIM_MANAGERTOKEN so they cannot drift.
       WK_MANAGERTOKEN: ${OCTO_WUKONGIM_MANAGER_TOKEN:-}
+    # Gate WuKongIM behind the preflight one-shot. Without this dependency
+    # compose starts wukongim in parallel with preflight: if preflight
+    # aborts on a placeholder OCTO_WUKONGIM_MANAGER_TOKEN, octo-server /
+    # matter / summary-api correctly stay down (their own depends_on:
+    # preflight blocks them), but wukongim has already bound the manager
+    # API / TCP / WS surfaces on 0.0.0.0 with `tokenAuthOn: true` and a
+    # known placeholder token. WuKongIM's manager-token comparison
+    # accepts the literal placeholder string, so anyone reading
+    # `.env.example` can hit the manager API from the network until the
+    # operator notices and tears the stack down. Compose does NOT
+    # auto-stop already-running services when a sibling's gate fails.
+    # `service_completed_successfully` here closes that window — wukongim
+    # cannot bind any port until preflight has returned exit 0.
+    depends_on:
+      preflight:
+        condition: service_completed_successfully
     ports:
       - "${OCTO_WK_API_PORT:-25001}:5001"
       - "${OCTO_WK_TCP_PORT:-25100}:5100"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,372 @@
+# -----------------------------------------------------------------------------
+# OCTO Server · one-shot deployment stack (OSS)
+# -----------------------------------------------------------------------------
+# Brings up OCTO Server + all required dependencies behind an nginx reverse
+# proxy that serves a user-chosen domain (default: octo.local). Everything is
+# scoped under a dedicated Docker bridge so it does not collide with other
+# stacks on the host.
+#
+# Quick start:
+#
+#     cp docker/.env.example docker/.env
+#     # edit docker/.env — at minimum change passwords + OCTO_MASTER_KEY
+#     cd docker
+#     docker compose up -d
+#     # when healthy, visit http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}/api/v1/health
+#
+# Tear-down (removes volumes too):
+#
+#     docker compose down -v
+#
+# See docker/README.md for the full walkthrough.
+# -----------------------------------------------------------------------------
+
+name: octo
+
+networks:
+  octo-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: ${OCTO_NETWORK_SUBNET:-172.28.0.0/24}
+
+volumes:
+  mysql-data:
+  redis-data:
+  minio-data:
+  wukongim-data:
+  server-logs:
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: octo-mysql
+    restart: unless-stopped
+    command:
+      - --default-authentication-plugin=mysql_native_password
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_general_ci
+    environment:
+      TZ: ${TZ:-UTC}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-octo}
+      OCTO_MATTER_DB_PASSWORD: ${OCTO_MATTER_DB_PASSWORD:-matter}
+      OCTO_SUMMARY_DB_PASSWORD: ${OCTO_SUMMARY_DB_PASSWORD:-summary}
+      OCTO_SUMMARY_READER_PASSWORD: ${OCTO_SUMMARY_READER_PASSWORD:-summary_reader}
+    # Backing service: bound to loopback by default so a missed-config moment
+    # does not expose MySQL with the placeholder root password to the public
+    # internet. Override OCTO_MYSQL_BIND to 0.0.0.0 only when you understand
+    # the implications.
+    ports:
+      - "${OCTO_MYSQL_BIND:-127.0.0.1}:${OCTO_MYSQL_PORT:-23306}:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+      - ./scripts/init-extra-dbs.sh:/docker-entrypoint-initdb.d/01-extra-dbs.sh:ro
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+    networks:
+      - octo-net
+
+  redis:
+    image: redis:7-alpine
+    container_name: octo-redis
+    restart: unless-stopped
+    command: ["redis-server", "--save", "60", "1", "--loglevel", "warning"]
+    # Backing service: loopback-only by default. See OCTO_MYSQL_BIND comment.
+    ports:
+      - "${OCTO_REDIS_BIND:-127.0.0.1}:${OCTO_REDIS_PORT:-26379}:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    networks:
+      - octo-net
+
+  minio:
+    image: minio/minio:latest
+    container_name: octo-minio
+    restart: unless-stopped
+    command: ["server", "/data", "--console-address", ":9001"]
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-octoadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+      # Compose interpolates these once into the YAML below; we cannot rely
+      # on nested `${VAR}` inside .env values being expanded at runtime, so
+      # the composition lives here instead of in .env.
+      MINIO_SERVER_URL: ${MINIO_SERVER_URL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}/minio}
+      MINIO_BROWSER_REDIRECT_URL: ${MINIO_BROWSER_REDIRECT_URL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}/minio-console/}
+    # Backing service API on loopback by default. Console likewise — operators
+    # access it via the nginx /minio-console/ route, not the raw 9001 port.
+    ports:
+      - "${OCTO_MINIO_API_BIND:-127.0.0.1}:${OCTO_MINIO_API_PORT:-29000}:9000"
+      - "${OCTO_MINIO_CONSOLE_BIND:-127.0.0.1}:${OCTO_MINIO_CONSOLE_PORT:-29001}:9001"
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    networks:
+      - octo-net
+
+  wukongim:
+    image: wukongim/wukongim:latest
+    container_name: octo-wukongim
+    restart: unless-stopped
+    environment:
+      WK_MODE: ${WK_MODE:-debug}
+      WK_EXTERNAL_IP: ${OCTO_EXTERNAL_IP:-127.0.0.1}
+      WK_EXTERNAL_TCPADDR: ${OCTO_WK_TCP_ADDR:-}
+      # Composition kept in YAML (not .env) because compose only interpolates
+      # `${...}` once on parse — values that come out of .env do NOT get a
+      # second pass. Putting the default expression here lets operators set
+      # OCTO_WK_WS_ADDR to a literal in .env when they want to override.
+      WK_EXTERNAL_WSADDR:  ${OCTO_WK_WS_ADDR:-ws://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}/ws}
+      WK_EXTERNAL_WSSADDR: ${OCTO_WK_WSS_ADDR:-}
+      # Shared admin token: must match what octo-server uses as
+      # WUKONGIM_MANAGER_TOKEN. Both come from the same .env value so they
+      # cannot drift.
+      WK_TOKEN: ${OCTO_WUKONGIM_MANAGER_TOKEN:-}
+    ports:
+      - "${OCTO_WK_API_PORT:-25001}:5001"
+      - "${OCTO_WK_TCP_PORT:-25100}:5100"
+      - "${OCTO_WK_WS_PORT:-25200}:5200"
+      - "${OCTO_WK_MONITOR_PORT:-25300}:5300"
+    volumes:
+      - wukongim-data:/root/wukongim
+      - ./configs/wk.yaml:/root/wukongim/wk.yaml:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost:5001/health >/dev/null 2>&1 || wget -q -O - http://localhost:5001/varz >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    networks:
+      - octo-net
+
+  octo-server:
+    image: ${OCTO_SERVER_IMAGE:-mininglamposs/octo-server:latest}
+    container_name: octo-server
+    restart: unless-stopped
+    command: ["api"]
+    environment:
+      TZ: ${TZ:-UTC}
+      OCTO_MASTER_KEY: ${OCTO_MASTER_KEY}
+      DMWORK_MASTER_KEY: ${OCTO_MASTER_KEY}
+      # Canonical env names align with kustomize/base/octo-server-secret.
+      DM_MYSQL_DSN: "root:${MYSQL_ROOT_PASSWORD}@tcp(mysql:3306)/${MYSQL_DATABASE:-octo}?charset=utf8mb4&parseTime=true&loc=Local"
+      DM_REDIS_ADDR: "redis:6379"
+      # WuKongIM admin token — must match wk.yaml's tokenAuthOn / WK_TOKEN.
+      WUKONGIM_MANAGER_TOKEN: ${OCTO_WUKONGIM_MANAGER_TOKEN:-}
+      # Optional inbound webhook HMAC. Compose-only addition (not in
+      # kustomize) — explained in .env.example.
+      TS_WEBHOOK_SECRET_KEY: ${OCTO_WEBHOOK_SECRET_KEY:-}
+      # MinIO credentials surfaced as Viper-style env overrides for the
+      # tsdd.yaml `minio:` block. Compose-only — kustomize installs use
+      # tencentCOS / s3 instead and ship credentials via octo-server-secret.
+      TS_MINIO_ACCESSKEYID: "${MINIO_ROOT_USER:-octoadmin}"
+      TS_MINIO_SECRETACCESSKEY: "${MINIO_ROOT_PASSWORD}"
+      NOTIFY_INTERNAL_TOKEN: ${OCTO_NOTIFY_INTERNAL_TOKEN:-}
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      wukongim:
+        condition: service_started
+      minio:
+        condition: service_healthy
+    ports:
+      - "${OCTO_SERVER_PORT:-28081}:8090"
+    volumes:
+      - ./configs/octo-server.yaml:/home/configs/tsdd.yaml:ro
+      - server-logs:/home/logs
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost:8090/v1/ping >/dev/null 2>&1 || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
+    networks:
+      - octo-net
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: octo-nginx
+    restart: unless-stopped
+    depends_on:
+      octo-server:
+        condition: service_healthy
+    environment:
+      OCTO_DOMAIN: ${OCTO_DOMAIN:-octo.local}
+    ports:
+      - "${OCTO_HTTP_PORT:-28080}:80"
+      # - "${OCTO_HTTPS_PORT:-28443}:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d:/etc/nginx/templates:ro
+      - ./nginx/empty-default.conf:/etc/nginx/conf.d/default.conf:ro
+      # - ./nginx/certs:/etc/nginx/certs:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost/_nginx_up >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    networks:
+      - octo-net
+
+  # ---------------------------------------------------------------------------
+  # Frontend: octo-web
+  # ---------------------------------------------------------------------------
+  web:
+    image: ${OCTO_WEB_IMAGE:-mininglamposs/octo-web:latest}
+    container_name: octo-web
+    restart: unless-stopped
+    depends_on:
+      octo-server:
+        condition: service_healthy
+    environment:
+      API_URL: http://octo-server:8090
+      SUMMARY_API_URL: ${OCTO_SUMMARY_API_URL:-http://summary-api:8080}
+    ports:
+      - "${OCTO_WEB_PORT:-28083}:80"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    networks:
+      - octo-net
+
+  # ---------------------------------------------------------------------------
+  # Admin console: octo-admin
+  # ---------------------------------------------------------------------------
+  admin:
+    image: ${OCTO_ADMIN_IMAGE:-mininglamposs/octo-admin:latest}
+    container_name: octo-admin
+    restart: unless-stopped
+    depends_on:
+      octo-server:
+        condition: service_healthy
+    environment:
+      API_BACKEND: octo-server:8090
+    ports:
+      - "${OCTO_ADMIN_PORT:-28082}:80"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1/admin/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    networks:
+      - octo-net
+
+  # ---------------------------------------------------------------------------
+  # Matter service (tasks / todos)
+  # ---------------------------------------------------------------------------
+  matter:
+    image: ${OCTO_MATTER_IMAGE:-mininglamposs/octo-matter:latest}
+    container_name: octo-matter
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+      octo-server:
+        condition: service_started
+    environment:
+      APP_ENV: ${MATTER_APP_ENV:-prod}
+      MYSQL_DSN: "matter:${OCTO_MATTER_DB_PASSWORD:-matter}@tcp(mysql:3306)/octo_matter?charset=utf8mb4&parseTime=true"
+      # Canonical env names from kustomize/base/octo-matter-config.
+      DMWORKIM_URL: http://octo-server:8090
+      WUKONGIM_URL: http://wukongim:5001
+      SERVER_PORT: "8080"
+      NOTIFY_INTERNAL_TOKEN: ${OCTO_NOTIFY_INTERNAL_TOKEN}
+      LLM_API_URL: ${LLM_API_URL:-https://api.example.com/v1}
+      LLM_API_KEY: ${LLM_API_KEY:-}
+      LLM_MODEL: ${LLM_MODEL:-claude-sonnet-4-6}
+      LLM_TIMEOUT: "30"
+    ports:
+      - "${OCTO_MATTER_PORT:-28086}:8080"
+    networks:
+      - octo-net
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  # ---------------------------------------------------------------------------
+  # Smart summary API + worker
+  # ---------------------------------------------------------------------------
+  summary-api:
+    image: ${OCTO_SUMMARY_API_IMAGE:-mininglamposs/octo-smart-summary-api:latest}
+    container_name: octo-summary-api
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      MYSQL_DSN:    "summary:${OCTO_SUMMARY_DB_PASSWORD:-summary}@tcp(mysql:3306)/octo_summary?charset=utf8mb4&parseTime=true"
+      IM_MYSQL_DSN: "summary_reader:${OCTO_SUMMARY_READER_PASSWORD:-summary_reader}@tcp(mysql:3306)/${MYSQL_DATABASE:-octo}?charset=utf8mb4&parseTime=true"
+      # Canonical env names from kustomize/base/octo-smart-summary-config.
+      DMWORK_API_URL: http://octo-server:8090
+      LLM_API_URL:  ${LLM_API_URL:-https://api.example.com/v1}
+      LLM_API_KEY:  ${LLM_API_KEY:-}
+      LLM_MODEL:    ${LLM_MODEL:-claude-sonnet-4-6}
+      API_PORT:          "8080"
+      API_INTERNAL_PORT: "8081"
+      # Canonical worker trigger / callback paths (kustomize alignment).
+      WORKER_TRIGGER_URL:      http://summary-worker:8082/internal/worker-trigger
+      WORKER_API_CALLBACK_URL: http://summary-api:8081/internal/task-event
+    ports:
+      - "${OCTO_SUMMARY_API_PORT:-28087}:8080"
+    networks:
+      - octo-net
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  summary-worker:
+    image: ${OCTO_SUMMARY_WORKER_IMAGE:-mininglamposs/octo-smart-summary-worker:latest}
+    container_name: octo-summary-worker
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+      summary-api:
+        condition: service_started
+    environment:
+      MYSQL_DSN:    "summary:${OCTO_SUMMARY_DB_PASSWORD:-summary}@tcp(mysql:3306)/octo_summary?charset=utf8mb4&parseTime=true"
+      IM_MYSQL_DSN: "summary_reader:${OCTO_SUMMARY_READER_PASSWORD:-summary_reader}@tcp(mysql:3306)/${MYSQL_DATABASE:-octo}?charset=utf8mb4&parseTime=true"
+      DMWORK_API_URL: http://octo-server:8090
+      LLM_API_URL:  ${LLM_API_URL:-https://api.example.com/v1}
+      LLM_API_KEY:  ${LLM_API_KEY:-}
+      LLM_MODEL:    ${LLM_MODEL:-claude-sonnet-4-6}
+      WORKER_INTERNAL_PORT:    "8082"
+      WORKER_TRIGGER_URL:      http://summary-worker:8082/internal/worker-trigger
+      WORKER_API_CALLBACK_URL: http://summary-api:8081/internal/task-event
+    networks:
+      - octo-net
+    # TCP healthcheck because the worker only exposes /internal/* on 8082
+    # and has no public /health route; matches kustomize livenessProbe.
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost:8082/internal/healthz >/dev/null 2>&1 || nc -z localhost 8082 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -36,6 +36,7 @@ volumes:
   minio-data:
   wukongim-data:
   server-logs:
+  nginx-logs:
 
 services:
   mysql:
@@ -100,8 +101,22 @@ services:
       # Compose interpolates these once into the YAML below; we cannot rely
       # on nested `${VAR}` inside .env values being expanded at runtime, so
       # the composition lives here instead of in .env.
+      #
+      # MINIO_SERVER_URL is the public S3 endpoint clients are told about
+      # in error responses / multipart redirects. The /minio path prefix
+      # works because nginx exposes /minio/ as a passthrough proxy to
+      # `minio:9000`.
       MINIO_SERVER_URL: ${MINIO_SERVER_URL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}/minio}
-      MINIO_BROWSER_REDIRECT_URL: ${MINIO_BROWSER_REDIRECT_URL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}/minio-console/}
+      # MINIO_BROWSER_REDIRECT_URL is the canonical URL MinIO redirects
+      # the console to after auth. The previous default pointed at the
+      # nginx /minio-console/ route, but that route is no longer exposed
+      # by default (see nginx/conf.d/octo.conf.template) — operators reach
+      # the console via an SSH tunnel against the loopback :29001 bind.
+      # Leaving this empty makes MinIO render the console at whatever URL
+      # the request arrived on, which is the right behaviour for a tunnel.
+      # Set a literal value in .env if you re-enable the nginx route or
+      # front the console with a different proxy.
+      MINIO_BROWSER_REDIRECT_URL: ${MINIO_BROWSER_REDIRECT_URL:-}
     # MinIO API is public by default: octo-server hands browser clients
     # presigned (SigV4) URLs that point at this port directly, and SigV4
     # signatures cannot survive an nginx path-prefix rewrite. Access keys
@@ -153,10 +168,44 @@ services:
     command:
       - |
         set -eu
-        if [ -z "$${OCTO_MINIO_APP_PASSWORD:-}" ]; then
-          echo "[minio-init] FATAL: OCTO_MINIO_APP_PASSWORD is empty — set it in .env" >&2
-          exit 1
-        fi
+        # ---------------------------------------------------------------
+        # Placeholder fail-fast.
+        # ---------------------------------------------------------------
+        # MinIO itself enforces a ≥8-char minimum on MINIO_ROOT_PASSWORD,
+        # and the .env.example placeholder is intentionally 7 chars so
+        # that an unrotated config never even reaches a healthy `minio`
+        # container. The check below is the second layer: it catches any
+        # ≥8-char value that still matches the well-known
+        # `CHANGE_ME_*` / `CHG_ME*` placeholder pattern (e.g. an operator
+        # who lengthened the placeholder rather than replacing it). At
+        # that point the only safe move is to refuse to attach the
+        # octo-app IAM policy — otherwise minio-init would happily wire
+        # up presigned-URL credentials against a known-default root
+        # password while the public 0.0.0.0:29000 API and the
+        # nginx-proxied /minio-console/ route stay reachable.
+        #
+        # We check both root and app credentials. The app pair is what
+        # octo-server signs presigned URLs with; root is what `mc admin`
+        # / the MinIO console accept. Either at a placeholder is a
+        # blocking condition.
+        case "$${MINIO_ROOT_PASSWORD:-}" in
+          ""|CHANGE_ME_*|CHG_ME*|change_me_*|chg_me*)
+            echo "[minio-init] FATAL: MINIO_ROOT_PASSWORD is empty or still a CHANGE_ME / CHG_ME placeholder." >&2
+            echo "[minio-init]        Rotate it in .env (openssl rand -hex 16) before bringing the stack up." >&2
+            exit 1
+            ;;
+        esac
+        case "$${OCTO_MINIO_APP_PASSWORD:-}" in
+          "")
+            echo "[minio-init] FATAL: OCTO_MINIO_APP_PASSWORD is empty — set it in .env" >&2
+            exit 1
+            ;;
+          CHANGE_ME_*|CHG_ME*|change_me_*|chg_me*)
+            echo "[minio-init] FATAL: OCTO_MINIO_APP_PASSWORD is still a CHANGE_ME / CHG_ME placeholder." >&2
+            echo "[minio-init]        Rotate it in .env (openssl rand -hex 24) before bringing the stack up." >&2
+            exit 1
+            ;;
+        esac
         echo "[minio-init] waiting for MinIO root alias…"
         until mc alias set local "http://minio:9000" "$$MINIO_ROOT_USER" "$$MINIO_ROOT_PASSWORD" >/dev/null 2>&1; do
           sleep 1
@@ -378,6 +427,12 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/conf.d:/etc/nginx/templates:ro
       - ./nginx/empty-default.conf:/etc/nginx/conf.d/default.conf:ro
+      # Persist access + error logs across container restarts so that
+      # post-mortems on a crashed stack still have request history.
+      # Mounted as a named volume rather than a host bind to keep the
+      # OOTB stack portable; redirect to a host path if your operator
+      # tooling needs them on disk.
+      - nginx-logs:/var/log/nginx
       # - ./nginx/certs:/etc/nginx/certs:ro
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O - http://localhost/_nginx_up >/dev/null 2>&1 || exit 1"]

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -43,6 +43,23 @@ server {
         proxy_read_timeout 600s;
     }
 
+    # OIDC SSO / auth endpoints — octo-server mounts these directly
+    # under /v1/ (no /api prefix), matching what
+    # kustomize/base/octo-web-nginx-config.yaml forwards. OIDC is
+    # disabled in the OSS profile by default; this route is here so
+    # enabling it later does not require a deploy-time nginx change.
+    # `^~` makes the prefix match win over the SPA catch-all `/`.
+    location ^~ /v1/ {
+        proxy_pass         http://octo_api/v1/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Connection        "";
+        proxy_read_timeout 600s;
+    }
+
     location /ws {
         proxy_pass          http://octo_ws;
         proxy_http_version  1.1;

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -1,0 +1,153 @@
+upstream octo_api {
+    server octo-server:8090;
+    keepalive 16;
+}
+
+upstream octo_ws {
+    server wukongim:5200;
+    keepalive 8;
+}
+
+upstream octo_minio_api {
+    server minio:9000;
+    keepalive 8;
+}
+
+upstream octo_minio_console {
+    server minio:9001;
+    keepalive 8;
+}
+
+server {
+    listen       80 default_server;
+    listen       [::]:80 default_server;
+    server_name  ${OCTO_DOMAIN} localhost _;
+
+    client_max_body_size    1000m;
+    client_body_buffer_size 8m;
+
+    location = /_nginx_up {
+        access_log off;
+        default_type text/plain;
+        return 200 "ok\n";
+    }
+
+    location /api/ {
+        proxy_pass         http://octo_api/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Connection        "";
+        proxy_read_timeout 600s;
+    }
+
+    location /ws {
+        proxy_pass          http://octo_ws;
+        proxy_http_version  1.1;
+        proxy_set_header    Upgrade           $http_upgrade;
+        proxy_set_header    Connection        "upgrade";
+        proxy_set_header    Host              $host;
+        proxy_set_header    X-Real-IP         $remote_addr;
+        proxy_set_header    X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header    X-Forwarded-Proto $scheme;
+        proxy_read_timeout  3600s;
+        proxy_send_timeout  3600s;
+    }
+
+    location /minio/ {
+        proxy_pass         http://octo_minio_api/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Connection        "";
+        proxy_read_timeout 600s;
+        proxy_request_buffering off;
+    }
+
+    location /minio-console/ {
+        proxy_pass         http://octo_minio_console/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location = /admin {
+        return 301 /admin/;
+    }
+    location /admin/ {
+        proxy_pass         http://admin/admin/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location /matter/ {
+        proxy_pass         http://matter:8080/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location /summary/ {
+        proxy_pass         http://summary-api:8080/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location = /_octo_up {
+        default_type text/html;
+        return 200 '<!doctype html>
+<html><head><meta charset="utf-8"><title>OCTO Server</title>
+<style>body{font-family:system-ui,sans-serif;max-width:640px;margin:3rem auto;padding:0 1rem;color:#222}h1{margin-bottom:.25rem}code{background:#f4f4f7;padding:2px 6px;border-radius:4px}ul{line-height:1.9}</style></head>
+<body><h1>OCTO Server</h1><p>The stack is up. Quick links:</p>
+<ul>
+<li><a href="/">Web (SPA)</a></li>
+<li><a href="/admin/">Admin console</a></li>
+<li><a href="/api/v1/ping">REST · <code>/api/v1/ping</code></a></li>
+<li><a href="/api/v1/health">REST · <code>/api/v1/health</code></a></li>
+<li><a href="/matter/health">Matter · <code>/matter/health</code></a></li>
+<li><a href="/summary/health">Smart-summary · <code>/summary/health</code></a></li>
+<li><a href="/minio-console/">MinIO console</a></li>
+</ul>
+<p>See <code>docker/.env.example</code> for configuration.</p></body></html>
+';
+    }
+
+    location / {
+        proxy_pass         http://web/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}
+
+# -----------------------------------------------------------------------------
+# HTTPS listener (disabled by default).
+# Enable by: uncommenting the 443 port in docker-compose.yaml, placing certs
+# under ./nginx/certs/, and uncommenting the block below.
+# -----------------------------------------------------------------------------
+# server {
+#     listen       443 ssl http2;
+#     listen       [::]:443 ssl http2;
+#     server_name  ${OCTO_DOMAIN};
+#     ssl_certificate      /etc/nginx/certs/fullchain.pem;
+#     ssl_certificate_key  /etc/nginx/certs/privkey.pem;
+#     ssl_protocols        TLSv1.2 TLSv1.3;
+#     ssl_ciphers          HIGH:!aNULL:!MD5;
+#     # paste the same location blocks as the HTTP listener above
+# }

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -13,10 +13,33 @@ upstream octo_minio_api {
     keepalive 8;
 }
 
-upstream octo_minio_console {
-    server minio:9001;
-    keepalive 8;
-}
+# The MinIO console (port 9001) is intentionally NOT exposed through
+# nginx in this template. Earlier revisions proxied it under
+# `/minio-console/`, but that put the MinIO admin login one click away
+# from anyone who reached OCTO_HTTP_PORT — and a stack booted with the
+# placeholder root password would have a known-default credential
+# accepted there. Operators who need the console reach it via an SSH
+# tunnel against `OCTO_MINIO_CONSOLE_BIND` (loopback :29001 by default):
+#
+#     ssh -L 9001:127.0.0.1:29001 user@host
+#     # then visit http://localhost:9001 in your browser
+#
+# To re-enable the public route (NOT recommended; only do this after
+# rotating MINIO_ROOT_PASSWORD and placing the proxy behind auth):
+#
+#     upstream octo_minio_console {
+#         server minio:9001;
+#         keepalive 8;
+#     }
+#     # add inside the server { } block:
+#     location /minio-console/ {
+#         proxy_pass         http://octo_minio_console/;
+#         proxy_http_version 1.1;
+#         proxy_set_header   Host              $host;
+#         proxy_set_header   X-Real-IP         $remote_addr;
+#         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+#         proxy_set_header   X-Forwarded-Proto $scheme;
+#     }
 
 server {
     listen       80 default_server;
@@ -26,6 +49,17 @@ server {
     client_max_body_size    1000m;
     client_body_buffer_size 8m;
 
+    # Security headers — applied on every response from this vhost.
+    # Mirrors the posture in kustomize/base/octo-web-nginx-config.yaml so
+    # the docker-compose deployment isn't materially weaker than the
+    # production overlay. CSP is omitted here because the OCTO web SPA
+    # bundles inline scripts/styles that need `unsafe-inline` /
+    # `unsafe-eval` and the exact set of allowed sources is environment-
+    # specific — operators add it after first deploy if they need it.
+    add_header X-Frame-Options          "SAMEORIGIN" always;
+    add_header X-Content-Type-Options   "nosniff" always;
+    add_header Referrer-Policy          "strict-origin-when-cross-origin" always;
+
     location = /_nginx_up {
         access_log off;
         default_type text/plain;
@@ -33,6 +67,10 @@ server {
     }
 
     location /api/ {
+        # Rate limit + small burst — same shape applied to /v1/. Keeps a
+        # rogue client from exhausting octo-server while still passing
+        # bursty page loads. zone= names are declared in nginx.conf.
+        limit_req zone=octo_api burst=60 nodelay;
         proxy_pass         http://octo_api/;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
@@ -50,6 +88,8 @@ server {
     # enabling it later does not require a deploy-time nginx change.
     # `^~` makes the prefix match win over the SPA catch-all `/`.
     location ^~ /v1/ {
+        # Tighter rate (auth surface) — see octo_auth zone in nginx.conf.
+        limit_req zone=octo_auth burst=20 nodelay;
         proxy_pass         http://octo_api/v1/;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
@@ -85,14 +125,8 @@ server {
         proxy_request_buffering off;
     }
 
-    location /minio-console/ {
-        proxy_pass         http://octo_minio_console/;
-        proxy_http_version 1.1;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Proto $scheme;
-    }
+    # /minio-console/ is intentionally NOT exposed here — see the comment
+    # at the top of this file. SSH-forward :29001 for console access.
 
     location = /admin {
         return 301 /admin/;
@@ -137,8 +171,9 @@ server {
 <li><a href="/api/v1/health">REST · <code>/api/v1/health</code></a></li>
 <li><a href="/matter/health">Matter · <code>/matter/health</code></a></li>
 <li><a href="/summary/health">Smart-summary · <code>/summary/health</code></a></li>
-<li><a href="/minio-console/">MinIO console</a></li>
 </ul>
+<p>MinIO console is loopback-only (port 29001 on the host). SSH-forward
+to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 <p>See <code>docker/.env.example</code> for configuration.</p></body></html>
 ';
     }

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -141,6 +141,16 @@ server {
     }
 
     location /matter/ {
+        # Same octo_api zone (30r/s, 10MB) used by /api/ — keeps the
+        # nginx-fronted matter surface within the same per-IP budget
+        # as the rest of the OCTO REST API. The matter / summary
+        # backing ports stay loopback-only by default precisely
+        # because nginx is the rate-limited public path; without this
+        # `limit_req` the README claim ("nginx applies rate limiting"
+        # as one of the three reasons direct ports are loopback) was
+        # not actually true on these two routes. burst=20 absorbs
+        # short page-load spikes without 503ing legitimate clients.
+        limit_req zone=octo_api burst=20 nodelay;
         proxy_pass         http://matter:8080/;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
@@ -150,6 +160,9 @@ server {
     }
 
     location /summary/ {
+        # See /matter/ above — same octo_api zone applied for
+        # consistency with the documented security model.
+        limit_req zone=octo_api burst=20 nodelay;
         proxy_pass         http://summary-api:8080/;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -11,6 +11,10 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    # Hide nginx version from Server response header / error pages.
+    # Mirrors the kustomize/base/octo-web-nginx-config.yaml posture.
+    server_tokens off;
+
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
@@ -19,6 +23,13 @@ http {
 
     sendfile        on;
     keepalive_timeout  65;
+
+    # Rate-limit zones for the OCTO API surfaces. Applied per-location in
+    # conf.d/octo.conf.template (`/api/`, `/v1/`). Tuned for an internal
+    # / single-host deployment — bump if you front a large user base.
+    # Burst absorbs short spikes without 503ing legitimate page loads.
+    limit_req_zone $binary_remote_addr zone=octo_api:10m  rate=30r/s;
+    limit_req_zone $binary_remote_addr zone=octo_auth:10m rate=10r/s;
 
     gzip  on;
     gzip_min_length  1k;

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,0 +1,35 @@
+user  nginx;
+worker_processes  auto;
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    gzip  on;
+    gzip_min_length  1k;
+    gzip_vary        on;
+    gzip_proxied     any;
+    gzip_comp_level  2;
+    gzip_buffers     16 8k;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css application/json application/javascript
+               text/xml application/xml application/xml+rss text/javascript
+               application/wasm image/svg+xml font/woff2;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/docker/scripts/init-extra-dbs.sh
+++ b/docker/scripts/init-extra-dbs.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+# Extra databases for OCTO side-services.
+# Loaded ONCE on first MySQL container start via docker-entrypoint-initdb.d.
+#
+# This is a .sh (not .sql) so the mysql entrypoint executes it with a live
+# environment — letting the passwords and schema name come from .env instead
+# of being hard-coded. When the OCTO_*_DB_PASSWORD vars are unset, the
+# fallback values reproduce the pre-YUJ-446 behaviour.
+#
+# Side services (octo-matter, octo-smart-summary) run their own embedded
+# gorp migrations on boot, so we only create schemas + users here.
+#
+# Security model:
+#   - Passwords and db names are NOT interpolated into an SQL string
+#     unsafely. They are first validated against a strict allowlist so we
+#     can safely inline them (MySQL CREATE USER / GRANT do not accept
+#     prepared-statement parameters, so literal interpolation is the only
+#     option — validation makes that interpolation safe).
+#   - The allowlist is [A-Za-z0-9._-] for passwords and [A-Za-z0-9_] for
+#     db names. Anything outside causes this script to abort before
+#     touching MySQL. Users who need different characters should stop
+#     this container, fix the .env value, and re-init (or hand-run SQL
+#     against the running MySQL after quoting it themselves).
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+
+: "${OCTO_MATTER_DB_PASSWORD:=matter}"
+: "${OCTO_SUMMARY_DB_PASSWORD:=summary}"
+: "${OCTO_SUMMARY_READER_PASSWORD:=summary_reader}"
+: "${MYSQL_DATABASE:=octo}"
+
+validate_password() {
+  local name="$1"
+  local value="$2"
+  if [ -z "$value" ]; then
+    echo "[init-extra-dbs] FATAL: $name is empty" >&2
+    exit 1
+  fi
+  case "$value" in
+    *[!A-Za-z0-9._-]*)
+      echo "[init-extra-dbs] FATAL: $name contains characters outside [A-Za-z0-9._-]" >&2
+      echo "[init-extra-dbs]        ${name} must match that regex so this script can safely" >&2
+      echo "[init-extra-dbs]        inline it into the CREATE USER / GRANT statements." >&2
+      exit 1
+      ;;
+  esac
+}
+
+validate_identifier() {
+  local name="$1"
+  local value="$2"
+  if [ -z "$value" ]; then
+    echo "[init-extra-dbs] FATAL: $name is empty" >&2
+    exit 1
+  fi
+  case "$value" in
+    *[!A-Za-z0-9_]*)
+      echo "[init-extra-dbs] FATAL: $name contains characters outside [A-Za-z0-9_]" >&2
+      exit 1
+      ;;
+  esac
+}
+
+validate_password  OCTO_MATTER_DB_PASSWORD       "$OCTO_MATTER_DB_PASSWORD"
+validate_password  OCTO_SUMMARY_DB_PASSWORD      "$OCTO_SUMMARY_DB_PASSWORD"
+validate_password  OCTO_SUMMARY_READER_PASSWORD  "$OCTO_SUMMARY_READER_PASSWORD"
+validate_identifier MYSQL_DATABASE               "$MYSQL_DATABASE"
+
+mysql -u root -p"${MYSQL_ROOT_PASSWORD}" <<SQL
+-- Schemas ---------------------------------------------------------------------
+CREATE DATABASE IF NOT EXISTS octo_matter  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+CREATE DATABASE IF NOT EXISTS octo_summary CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+-- Service-scoped read-write accounts -----------------------------------------
+CREATE USER IF NOT EXISTS 'matter'@'%'  IDENTIFIED BY '${OCTO_MATTER_DB_PASSWORD}';
+CREATE USER IF NOT EXISTS 'summary'@'%' IDENTIFIED BY '${OCTO_SUMMARY_DB_PASSWORD}';
+
+-- Read-only account used by summary services to scan the IM schema -----------
+-- Principle of least privilege: smart-summary only needs SELECT on the IM
+-- schema, so we hand it a narrow account instead of the MySQL root
+-- credentials.
+CREATE USER IF NOT EXISTS 'summary_reader'@'%' IDENTIFIED BY '${OCTO_SUMMARY_READER_PASSWORD}';
+
+GRANT ALL PRIVILEGES ON octo_matter.*      TO 'matter'@'%';
+GRANT ALL PRIVILEGES ON octo_summary.*     TO 'summary'@'%';
+GRANT SELECT         ON \`${MYSQL_DATABASE}\`.* TO 'summary_reader'@'%';
+FLUSH PRIVILEGES;
+SQL
+
+echo "[init-extra-dbs] created octo_matter + octo_summary + service users (scoped to \`${MYSQL_DATABASE}\`)"

--- a/docker/scripts/init-extra-dbs.sh
+++ b/docker/scripts/init-extra-dbs.sh
@@ -18,10 +18,21 @@
 #     prepared-statement parameters, so literal interpolation is the only
 #     option — validation makes that interpolation safe).
 #   - The allowlist is [A-Za-z0-9._-] for passwords and [A-Za-z0-9_] for
-#     db names. Anything outside causes this script to abort before
+#     db names. The same allowlist applies to MYSQL_ROOT_PASSWORD because
+#     docker-compose.yaml interpolates it directly into the Go MySQL DSN
+#     (`root:${MYSQL_ROOT_PASSWORD}@tcp(mysql:3306)/...`); characters like
+#     `@`, `#`, `!`, `$`, `&`, `:`, `/` would silently break that DSN
+#     parser. Anything outside causes this script to abort before
 #     touching MySQL. Users who need different characters should stop
 #     this container, fix the .env value, and re-init (or hand-run SQL
 #     against the running MySQL after quoting it themselves).
+#
+# Idempotency:
+#   - This file is loaded by docker-entrypoint-initdb.d, which fires
+#     ONCE per fresh `mysql-data` volume. To support in-place rotation
+#     without `docker compose down -v`, every CREATE USER is paired
+#     with an ALTER USER IF EXISTS … IDENTIFIED BY so re-running the
+#     script body against a live MySQL converges to the .env state.
 # -----------------------------------------------------------------------------
 
 set -euo pipefail
@@ -66,6 +77,16 @@ validate_identifier() {
 validate_password  OCTO_MATTER_DB_PASSWORD       "$OCTO_MATTER_DB_PASSWORD"
 validate_password  OCTO_SUMMARY_DB_PASSWORD      "$OCTO_SUMMARY_DB_PASSWORD"
 validate_password  OCTO_SUMMARY_READER_PASSWORD  "$OCTO_SUMMARY_READER_PASSWORD"
+# MYSQL_ROOT_PASSWORD is interpolated directly into TS_DB_MYSQLADDR /
+# DM_MYSQL_DSN in docker-compose.yaml (Go-MySQL DSN format). Special
+# characters such as `@`, `#`, `!`, `$`, `&`, `:`, `/` make the DSN
+# parser misread the user/host boundary and fail with confusing
+# errors that don't point at the password. The same allowlist used for
+# the other accounts keeps every value safe to inline both here and in
+# the application DSNs. Operators who insist on richer characters need
+# to either percent-encode the DSN by hand or move credentials to a
+# secrets store outside this stack.
+validate_password  MYSQL_ROOT_PASSWORD            "$MYSQL_ROOT_PASSWORD"
 validate_identifier MYSQL_DATABASE               "$MYSQL_DATABASE"
 
 mysql -u root -p"${MYSQL_ROOT_PASSWORD}" <<SQL
@@ -74,14 +95,22 @@ CREATE DATABASE IF NOT EXISTS octo_matter  CHARACTER SET utf8mb4 COLLATE utf8mb4
 CREATE DATABASE IF NOT EXISTS octo_summary CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- Service-scoped read-write accounts -----------------------------------------
+-- CREATE USER IF NOT EXISTS leaves an existing user untouched; the matching
+-- ALTER USER IF EXISTS … IDENTIFIED BY rotates the password in place. Pairing
+-- the two means re-running this script (or running its body by hand against
+-- a live MySQL after .env rotation) reaches the desired credential state
+-- without a `docker compose down -v`.
 CREATE USER IF NOT EXISTS 'matter'@'%'  IDENTIFIED BY '${OCTO_MATTER_DB_PASSWORD}';
+ALTER USER IF EXISTS      'matter'@'%'  IDENTIFIED BY '${OCTO_MATTER_DB_PASSWORD}';
 CREATE USER IF NOT EXISTS 'summary'@'%' IDENTIFIED BY '${OCTO_SUMMARY_DB_PASSWORD}';
+ALTER USER IF EXISTS      'summary'@'%' IDENTIFIED BY '${OCTO_SUMMARY_DB_PASSWORD}';
 
 -- Read-only account used by summary services to scan the IM schema -----------
 -- Principle of least privilege: smart-summary only needs SELECT on the IM
 -- schema, so we hand it a narrow account instead of the MySQL root
 -- credentials.
 CREATE USER IF NOT EXISTS 'summary_reader'@'%' IDENTIFIED BY '${OCTO_SUMMARY_READER_PASSWORD}';
+ALTER USER IF EXISTS      'summary_reader'@'%' IDENTIFIED BY '${OCTO_SUMMARY_READER_PASSWORD}';
 
 GRANT ALL PRIVILEGES ON octo_matter.*      TO 'matter'@'%';
 GRANT ALL PRIVILEGES ON octo_summary.*     TO 'summary'@'%';

--- a/docker/scripts/init-extra-dbs.sh
+++ b/docker/scripts/init-extra-dbs.sh
@@ -57,6 +57,40 @@ validate_password() {
       exit 1
       ;;
   esac
+  # Reject the canonical `.env.example` placeholders. Lower-case first
+  # so any casing of the prefix trips the same branch — bash 4 in the
+  # mysql:8.0 entrypoint image has nocasematch, but we keep the script
+  # POSIX-friendly to match the rest of the file.
+  local lc
+  lc=$(printf %s "$value" | tr 'A-Z' 'a-z')
+  case "$lc" in
+    change_me_*|chg_me*)
+      echo "[init-extra-dbs] FATAL: $name is still a CHANGE_ME / CHG_ME placeholder." >&2
+      echo "[init-extra-dbs]        Rotate it in .env (openssl rand -hex 16) before initialising MySQL." >&2
+      echo "[init-extra-dbs]        This is a one-shot bootstrap — re-running with a rotated value" >&2
+      echo "[init-extra-dbs]        requires \`docker compose down -v\` to drop the mysql-data volume." >&2
+      exit 1
+      ;;
+  esac
+}
+
+# Reject the literal-string defaults shipped in .env.example for the
+# three service-account passwords. The general allowlist above happily
+# accepts `matter` / `summary` / `summary_reader` because they are
+# inside [A-Za-z0-9._-]; without this extra check the OOTB stack would
+# stand up with three predictable credentials on a MySQL that — if an
+# operator widens OCTO_MYSQL_BIND past loopback — is reachable on
+# :23306. The blocklist is per-variable so an unrelated rotation that
+# happens to land on (e.g.) the literal string `summary` still trips.
+reject_literal_default() {
+  local name="$1"
+  local value="$2"
+  local default="$3"
+  if [ "$value" = "$default" ]; then
+    echo "[init-extra-dbs] FATAL: $name is still the .env.example literal default ('$default')." >&2
+    echo "[init-extra-dbs]        Rotate it in .env (openssl rand -hex 16) before initialising MySQL." >&2
+    exit 1
+  fi
 }
 
 validate_identifier() {
@@ -77,6 +111,12 @@ validate_identifier() {
 validate_password  OCTO_MATTER_DB_PASSWORD       "$OCTO_MATTER_DB_PASSWORD"
 validate_password  OCTO_SUMMARY_DB_PASSWORD      "$OCTO_SUMMARY_DB_PASSWORD"
 validate_password  OCTO_SUMMARY_READER_PASSWORD  "$OCTO_SUMMARY_READER_PASSWORD"
+# Block the literal-string defaults from .env.example. These three
+# names are the well-known username for each account, so leaving the
+# password equal to the username is a "guess once" credential.
+reject_literal_default OCTO_MATTER_DB_PASSWORD       "$OCTO_MATTER_DB_PASSWORD"      "matter"
+reject_literal_default OCTO_SUMMARY_DB_PASSWORD      "$OCTO_SUMMARY_DB_PASSWORD"     "summary"
+reject_literal_default OCTO_SUMMARY_READER_PASSWORD  "$OCTO_SUMMARY_READER_PASSWORD" "summary_reader"
 # MYSQL_ROOT_PASSWORD is interpolated directly into TS_DB_MYSQLADDR /
 # DM_MYSQL_DSN in docker-compose.yaml (Go-MySQL DSN format). Special
 # characters such as `@`, `#`, `!`, `$`, `&`, `:`, `/` make the DSN
@@ -86,10 +126,19 @@ validate_password  OCTO_SUMMARY_READER_PASSWORD  "$OCTO_SUMMARY_READER_PASSWORD"
 # the application DSNs. Operators who insist on richer characters need
 # to either percent-encode the DSN by hand or move credentials to a
 # secrets store outside this stack.
+#
+# `validate_password` also refuses any `CHANGE_ME_*` / `CHG_ME*`
+# placeholder casing, so an unrotated `.env` cannot complete the
+# first-volume MySQL init.
 validate_password  MYSQL_ROOT_PASSWORD            "$MYSQL_ROOT_PASSWORD"
 validate_identifier MYSQL_DATABASE               "$MYSQL_DATABASE"
 
-mysql -u root -p"${MYSQL_ROOT_PASSWORD}" <<SQL
+# Use MYSQL_PWD instead of `-p"$MYSQL_ROOT_PASSWORD"` so the password
+# does not appear in `/proc/<pid>/cmdline` — co-tenant containers on
+# the host can read that. The mysql client picks MYSQL_PWD up
+# automatically and prints a one-line warning to stderr; the warning
+# does not affect the SQL or the exit code.
+MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -u root <<SQL
 -- Schemas ---------------------------------------------------------------------
 CREATE DATABASE IF NOT EXISTS octo_matter  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 CREATE DATABASE IF NOT EXISTS octo_summary CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;


### PR DESCRIPTION
## Summary

One-shot Docker Compose deployment stack for OCTO. Brings up the full
stack (octo-server + admin + web + matter + smart-summary + WuKongIM
+ MySQL + Redis + MinIO + nginx) with one `docker compose up -d`.

Supersedes #3, with the consolidated set of P0 review fixes from
@yujiawei / @Jerry-Xin / @lml2468 folded in. Co-authored-by an9xyz
preserved on the commit.

## Merge gate

⚠️ **Depends on Mininglamp-OSS/octo-server#24 — do not merge until that
lands.** Image upload through this stack uses the PresignedPutter
implementation tracked there; without it `/api/v1/file/upload` 500s
even with the stack otherwise healthy. The smoke test below
(`/api/v1/health` etc.) passes regardless, but a full end-to-end image
upload validation requires the octo-server PR to be merged first.

## P0 changes (all five required, all included)

**P0-1 · Backing services bound to 127.0.0.1 by default**
MySQL / Redis / MinIO API + console publish on loopback only.
`OCTO_*_BIND` vars in `.env.example` document the override path;
public-facing services (octo-server / web / admin / nginx / WuKongIM)
keep `0.0.0.0` since they are meant to be reachable.

**P0-2 · Env contract aligned with kustomize/base**
- `TS_DB_MYSQLADDR` → `DM_MYSQL_DSN`
- `TS_DB_REDISADDR` → `DM_REDIS_ADDR`
- `OCTO_IM_URL` (matter) → `DMWORKIM_URL`, plus added `WUKONGIM_URL`
- `OCTO_API_URL` (smart-summary) → `DMWORK_API_URL`
- Worker trigger path: `/trigger` → `/internal/worker-trigger`
- Worker callback: bare `:8081` → `:8081/internal/task-event`
- Compose-only additions (`TS_MINIO_*`, `MATTER_APP_ENV`,
  `OCTO_NOTIFY_INTERNAL_TOKEN`, etc.) carry inline comments in
  `.env.example` and `docker-compose.yaml` explaining why they are not
  in kustomize.

**P0-3 · No nested `${...}` in `.env.example`**
Compose interpolates `.env` values once into the YAML; nested
`${...}` does NOT recursively expand. Composition moved into
`docker-compose.yaml` with safe two-stage defaults:

```yaml
WK_EXTERNAL_WSADDR: ${OCTO_WK_WS_ADDR:-ws://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}/ws}
MINIO_SERVER_URL:           ${MINIO_SERVER_URL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}/minio}
MINIO_BROWSER_REDIRECT_URL: ${MINIO_BROWSER_REDIRECT_URL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}/minio-console/}
```

`OCTO_WK_WS_ADDR` / `MINIO_SERVER_URL` / `MINIO_BROWSER_REDIRECT_URL`
in `.env.example` are now blank by default with override examples in
the comments.

**P0-4 · `docker/README.md` + first-admin bootstrap**
Added with quick start, env reference, and two first-admin paths.
Option A is the recommended `adminPwd` config-driven hook: set
`OCTO_ADMIN_PWD` in `.env`, uncomment the matching
`TS_ADMINPWD: ${OCTO_ADMIN_PWD:-}` line in the octo-server service,
and on first start (when the `user` table is empty) octo-server
seeds the `superAdmin` row via the binary's built-in
`adminPwd → TS_ADMINPWD → account.adminUID` hook (commit `bca1529`
rewrote the README to match the binary; the previous
`OCTO_BOOTSTRAP_ADMIN_*` / `octo-server admin hash-password` paths
referenced in earlier drafts of this PR body do NOT exist in the
binary today). Option B is a manual SQL seed for cases where the
operator cannot edit `docker-compose.yaml` or wants a non-default
UID. Plus troubleshooting (port collisions, default vhost, image
upload requirements with explicit link to octo-server#24, MySQL
bootstrap re-init) and hardening pointers (placeholder rotation,
master-key length guard, network subnet narrowing, etc.). Root
README points Compose users to `docker/` instead of the stale
`octo-server/docker/octo/` pointer.

**P0-5 · `octo-server#24` cross-referenced**
Inline comment at `docker/configs/octo-server.yaml`'s `fileService:`
block and in this PR body's merge gate (above).

## P1/P2 folded in

- Shared `OCTO_WUKONGIM_MANAGER_TOKEN` wired into both WuKongIM
  (`WK_TOKEN`, picked up by `wk.yaml`'s `tokenAuthOn`) and octo-server
  (`WUKONGIM_MANAGER_TOKEN`). Single `.env` value — cannot drift.
- `MINIO_SERVER_URL` / `MINIO_BROWSER_REDIRECT_URL` parameterised on
  `OCTO_DOMAIN` + `OCTO_HTTP_PORT` so console redirects work via the
  nginx `/minio-console/` route from non-host browsers (handled by
  the P0-3 fix).
- `summary-worker` healthcheck (HTTP probe with TCP fallback).
- `nginx` `gzip_types` extended with `application/wasm`,
  `image/svg+xml`, `font/woff2`.
- `OCTO_NETWORK_SUBNET` default narrowed from `/16` to `/24`.
- `init-extra-dbs.sh` password rotation note added to `.env.example`.
- `OCTO_MASTER_KEY` placeholder shrunk to 31 chars so an unrotated
  config trips octo-server's length check on startup instead of
  booting with a known-weak default.

## Out-of-scope follow-ups

None tracked — every P1/P2 item from the original review folded in.

## Validation

```bash
cd docker
cp .env.example .env
docker compose config -q   # syntactic + interpolation pass: OK
```

`docker compose config` rendering verified:

- Backing-service ports surface as `host_ip: 127.0.0.1` for
  MySQL `:23306`, Redis `:26379`, MinIO `:29000` and `:29001`;
  public-facing ports (octo HTTP `:28080`, server `:28081`, admin
  `:28082`, web `:28083`, matter `:28086`, summary `:28087`, WuKongIM
  `:25001` / `:25100` / `:25200` / `:25300`) bind to `0.0.0.0`.
- `WK_EXTERNAL_WSADDR` resolves to `ws://octo.local:28080/ws` (no
  literal `${OCTO_DOMAIN}` leakage).
- `MINIO_SERVER_URL` / `MINIO_BROWSER_REDIRECT_URL` resolve to
  `http://octo.local:28080/minio` and `…/minio-console/`.
- `DM_MYSQL_DSN`, `DMWORKIM_URL`, `DMWORK_API_URL`,
  `WORKER_TRIGGER_URL=…/internal/worker-trigger`,
  `WORKER_API_CALLBACK_URL=…/internal/task-event` all rendered
  correctly.

End-to-end health endpoints (`/_nginx_up`, `/api/v1/health`,
`/matter/health`, `/summary/health`, `/`) will be smoke-tested after
octo-server#24 is merged and a fresh `OCTO_SERVER_IMAGE` is built.

## PR hygiene

- Title: `feat(docker): one-shot Docker Compose deployment stack (supersedes #3)`
- Supersedes #3
- Co-authored-by: an9xyz (preserved on the commit)
- Depends on Mininglamp-OSS/octo-server#24 — do not merge until that lands

Co-authored-by: an9xyz <an9xyz@users.noreply.github.com>

