### PR TITLE
feat(docker): OOTB setup script + deployment hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ kustomize/overlays/**
 # until an operator wires HTTPS, but the path is gitignored anyway so
 # `cp` / `mv` accidents do not commit a real cert.
 docker/nginx/certs/
+
+# TLS certificates in docker/certs/ — see docker/certs/README.md
+docker/certs/*.pem
+docker/certs/*.key
+docker/certs/*.crt

--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,9 @@ kustomize/overlays/**
 !kustomize/overlays/prod/**
 
 # nginx TLS material — keep certificates / keys out of the repo. The
-# `docker/nginx/certs/` mount is commented out in docker-compose.yaml
-# until an operator wires HTTPS, but the path is gitignored anyway so
-# `cp` / `mv` accidents do not commit a real cert.
-docker/nginx/certs/
+# active TLS mount path is `docker/certs/` (see below); the older
+# `docker/nginx/certs/` layout is no longer referenced by any compose
+# file, so only the canonical path is ignored.
 
 # TLS certificates in docker/certs/ — see docker/certs/README.md
 docker/certs/*.pem

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -285,13 +285,19 @@ LLM_API_URL=https://api.example.com/v1
 LLM_API_KEY=
 LLM_MODEL=claude-sonnet-4-6
 
-# --- First-admin bootstrap (optional) -------------------------------------
-# When set AND the docker-compose.yaml octo-server service has the
-# matching `TS_ADMINPWD: ${OCTO_ADMIN_PWD:-}` line uncommented,
-# octo-server will seed a superAdmin row on first start (username
-# "superAdmin", password = bcrypt of this value). See
-# docker/README.md → "First-admin bootstrap" before enabling.
-# OCTO_ADMIN_PWD=
+# --- Admin bootstrap -------------------------------------------------------
+# Initial superAdmin password. setup.sh generates a random value.
+# Leave empty to skip auto-bootstrap (create admin manually via API).
+OCTO_ADMIN_PWD=CHANGE_ME_ADMIN_PASSWORD
+
+# --- TLS -------------------------------------------------------------------
+# Set to true when fronting the stack with TLS certificates in docker/certs/.
+# setup.sh --https sets this automatically.
+OCTO_TLS_ENABLED=false
+
+# --- Optional services -----------------------------------------------------
+# Set to false to skip summary-api and summary-worker (no LLM needed).
+OCTO_ENABLE_SUMMARY=true
 
 # --- Image overrides -------------------------------------------------------
 # OCTO_SERVER_IMAGE=mininglamposs/octo-server:latest

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -287,8 +287,10 @@ LLM_MODEL=claude-sonnet-4-6
 
 # --- Admin bootstrap -------------------------------------------------------
 # Initial superAdmin password. setup.sh generates a random value.
-# Leave empty to skip auto-bootstrap (create admin manually via API).
-OCTO_ADMIN_PWD=CHANGE_ME_ADMIN_PASSWORD
+# Leave empty/commented to skip auto-bootstrap (create admin manually
+# via API). Do NOT set a well-known default — TS_ADMINPWD is live in
+# docker-compose.yaml and any value here seeds a superAdmin on first start.
+# OCTO_ADMIN_PWD=
 
 # --- TLS -------------------------------------------------------------------
 # Set to true when fronting the stack with TLS certificates in docker/certs/.
@@ -296,8 +298,9 @@ OCTO_ADMIN_PWD=CHANGE_ME_ADMIN_PASSWORD
 OCTO_TLS_ENABLED=false
 
 # --- Optional services -----------------------------------------------------
-# Set to false to skip summary-api and summary-worker (no LLM needed).
-OCTO_ENABLE_SUMMARY=true
+# Summary services are controlled by COMPOSE_PROFILES below, not this var.
+# This variable is only used by setup.sh as an input flag.
+# OCTO_ENABLE_SUMMARY=true
 
 # To enable summary services, set COMPOSE_PROFILES=summary.
 # setup.sh --summary sets this automatically.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -291,6 +291,11 @@ LLM_MODEL=claude-sonnet-4-6
 # via API). Do NOT set a well-known default — TS_ADMINPWD is live in
 # docker-compose.yaml and any value here seeds a superAdmin on first start.
 # OCTO_ADMIN_PWD=
+# Setting any value here on a fresh stack auto-seeds superAdmin with
+# bcrypt(<value>). Leave commented OR set a strong random value —
+# NEVER a placeholder like "changeme", "admin", or "password". Once the
+# stack has started, the MySQL volume keeps the original hash; changing
+# this value afterwards does NOT rotate the admin password.
 
 # --- TLS -------------------------------------------------------------------
 # Set to true when fronting the stack with TLS certificates in docker/certs/.
@@ -298,12 +303,8 @@ LLM_MODEL=claude-sonnet-4-6
 OCTO_TLS_ENABLED=false
 
 # --- Optional services -----------------------------------------------------
-# Summary services are controlled by COMPOSE_PROFILES below, not this var.
-# This variable is only used by setup.sh as an input flag.
-# OCTO_ENABLE_SUMMARY=true
-
-# To enable summary services, set COMPOSE_PROFILES=summary.
-# setup.sh --summary sets this automatically.
+# Summary services are gated by Docker Compose profiles. To enable them,
+# uncomment COMPOSE_PROFILES below (setup.sh --summary does this for you).
 # COMPOSE_PROFILES=summary
 
 # --- Image overrides -------------------------------------------------------

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -188,7 +188,7 @@ OCTO_MINIO_APP_PASSWORD=CHANGE_ME_MINIO_APP_PASSWORD
 
 # --- WuKongIM -------------------------------------------------------------
 # debug | release | bench
-WK_MODE=debug
+WK_MODE=release
 
 # WuKongIM advertised endpoints. LEAVE BLANK for the OOTB default
 # (compose builds ws://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}/ws). Set a literal
@@ -298,6 +298,10 @@ OCTO_TLS_ENABLED=false
 # --- Optional services -----------------------------------------------------
 # Set to false to skip summary-api and summary-worker (no LLM needed).
 OCTO_ENABLE_SUMMARY=true
+
+# To enable summary services, set COMPOSE_PROFILES=summary.
+# setup.sh --summary sets this automatically.
+# COMPOSE_PROFILES=summary
 
 # --- Image overrides -------------------------------------------------------
 # OCTO_SERVER_IMAGE=mininglamposs/octo-server:latest

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,22 +18,32 @@ DB / cache / object store.
 
 ## Quick start
 
+Recommended (interactive setup):
+
 ```bash
 git clone https://github.com/Mininglamp-OSS/octo-deployment.git
 cd octo-deployment
-
-cp docker/.env.example docker/.env
-# Edit docker/.env — at minimum change the placeholders flagged in the file:
-#   MYSQL_ROOT_PASSWORD, MINIO_ROOT_PASSWORD, OCTO_MINIO_APP_PASSWORD,
-#   OCTO_MATTER_DB_PASSWORD, OCTO_SUMMARY_DB_PASSWORD,
-#   OCTO_SUMMARY_READER_PASSWORD,
-#   OCTO_MASTER_KEY, OCTO_NOTIFY_INTERNAL_TOKEN, OCTO_WUKONGIM_MANAGER_TOKEN
-
-cd docker
-docker compose config            # validate before starting
-docker compose up -d
-docker compose ps                # all services should reach (healthy)
+./setup.sh                          # interactive prompts
+cd docker && docker compose up -d
 ```
+
+Or non-interactive:
+
+```bash
+./setup.sh --non-interactive --domain octo.example.com --ip 1.2.3.4
+cd docker && docker compose up -d
+```
+
+To enable the optional LLM summary services, add `--summary`:
+
+```bash
+./setup.sh --summary --domain octo.example.com --ip 1.2.3.4
+cd docker && docker compose up -d
+```
+
+`setup.sh` writes `docker/.env` with rotated random secrets and a
+generated `OCTO_ADMIN_PWD`. It is the only path that gets a fresh
+checkout to a `(healthy)` stack without manual editing.
 
 Once healthy, the stack is reachable through nginx on
 `http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}` (default `http://octo.local:28080`).
@@ -44,6 +54,29 @@ Tear-down (drops the named volumes too — destructive):
 ```bash
 docker compose down -v
 ```
+
+### Manual setup (advanced)
+
+Skip `setup.sh` only if you need to drive the env-file generation from
+your own tooling (Ansible, Vault, etc.):
+
+```bash
+cp docker/.env.example docker/.env
+# Edit docker/.env — rotate ALL placeholders flagged in the file:
+#   MYSQL_ROOT_PASSWORD, MINIO_ROOT_PASSWORD, OCTO_MINIO_APP_PASSWORD,
+#   OCTO_MATTER_DB_PASSWORD, OCTO_SUMMARY_DB_PASSWORD,
+#   OCTO_SUMMARY_READER_PASSWORD,
+#   OCTO_MASTER_KEY, OCTO_NOTIFY_INTERNAL_TOKEN, OCTO_WUKONGIM_MANAGER_TOKEN
+# Set OCTO_DOMAIN / OCTO_EXTERNAL_IP, and OCTO_ADMIN_PWD if you want
+# auto-bootstrap of the first superAdmin (see "First-admin bootstrap").
+
+cd docker
+docker compose config            # validate before starting
+docker compose up -d
+docker compose ps                # all services should reach (healthy)
+```
+
+See "Required environment variables" below for the full contract.
 
 ---
 
@@ -255,10 +288,11 @@ To use it:
 1. Pick a strong password (treat it as a deploy-time secret —
    octo-server hashes it before write, but the plaintext sits in your
    `.env`).
-2. Add to `docker/.env` and uncomment the matching env line in the
-   `octo-server` service in `docker-compose.yaml` (commented out by
-   default to keep the OOTB stack from auto-creating an admin in the
-   wrong environment):
+2. Add to `docker/.env`. `TS_ADMINPWD` is wired into the
+   `octo-server` service in `docker-compose.yaml` by default — when
+   `OCTO_ADMIN_PWD` is non-empty, octo-server seeds the row on first
+   start. Leave `OCTO_ADMIN_PWD` empty (or commented) to skip
+   auto-bootstrap and create the admin manually via Option B:
 
    ```bash
    # docker/.env
@@ -266,9 +300,12 @@ To use it:
    ```
 
    ```yaml
-   # docker/docker-compose.yaml — octo-server service environment:
+   # docker/docker-compose.yaml — octo-server service environment (already present):
    TS_ADMINPWD: ${OCTO_ADMIN_PWD:-}
    ```
+
+   `setup.sh` generates a random `OCTO_ADMIN_PWD` automatically and
+   prints it once at the end of the run.
 3. `docker compose up -d` (or `docker compose restart octo-server` if
    the stack is already up). On first start with an empty `user`
    table, octo-server seeds the row.
@@ -472,21 +509,32 @@ bottom of `scripts/init-extra-dbs.sh`.
 
 ### Health endpoints
 
-After the stack reports healthy, these should all return 200:
+After the stack reports healthy, these should all return 200 for the
+default (no-summary) deployment:
 
 | Path | Purpose |
 | --- | --- |
 | `/_nginx_up` | nginx reverse-proxy probe |
 | `/api/v1/health` | octo-server REST |
 | `/matter/health` | octo-matter |
-| `/summary/health` | smart-summary API |
 | `/` | octo-web SPA |
 
 ```bash
-for p in /_nginx_up /api/v1/health /matter/health /summary/health /; do
+for p in /_nginx_up /api/v1/health /matter/health /; do
   printf '%-22s %s\n' "$p" "$(curl -fsS -o /dev/null -w '%{http_code}' "http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}$p")"
 done
 ```
+
+If the summary profile is enabled (`./setup.sh --summary`, or
+`COMPOSE_PROFILES=summary` in `.env`), also probe `/summary/health`:
+
+```bash
+curl -fsS "http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}/summary/health"
+```
+
+Without the summary profile the `summary-api` container is not
+started, so `/summary/health` will 502 through nginx — that is
+expected, not a failure.
 
 The `summary-worker` container has no public route — it serves
 `/internal/healthz` on port `8082` inside the `octo-net` network only.

--- a/docker/certs/README.md
+++ b/docker/certs/README.md
@@ -30,19 +30,24 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
 
 After placing certificates here:
 
-1. Comment out the existing HTTP `server { listen 80 default_server; … }`
-   block in `docker/nginx/conf.d/octo.conf.template`. Both the HTTP and
-   HTTPS blocks ship as `default_server` on their respective ports;
-   leaving the HTTP block active while uncommenting the HTTPS block
-   causes nginx to refuse to start with "a duplicate default server".
-   If you want to keep HTTP responding (e.g. as a permanent redirect to
-   HTTPS), replace the HTTP `server` block body with a 301 redirect
-   rather than removing the `listen 80` line entirely.
+1. Uncomment the HTTPS server block in
+   `docker/nginx/conf.d/octo.conf.template`. HTTP on port 80 and HTTPS
+   on port 443 can coexist (HTTP will not auto-redirect to HTTPS); the
+   shipped HTTP and HTTPS blocks each declare `listen … default_server`
+   on a different port, so they do not collide.
+
+   The conflict you should avoid is enabling a *second* port 80 server
+   block (for example, a dedicated `HTTP → HTTPS` redirect block) while
+   the original HTTP server block is still active — both would claim
+   `listen 80 default_server` and nginx would refuse to start with
+   "a duplicate default server". If you want a permanent HTTP→HTTPS
+   redirect, either replace the body of the existing HTTP block with a
+   `301` to `https://$host$request_uri`, or comment out the original
+   HTTP block before adding a separate redirect block.
 2. Uncomment the `443` port mapping in `docker/docker-compose.yaml`
 3. Uncomment the certs volume mount in `docker/docker-compose.yaml`
-4. Uncomment the HTTPS server block in `docker/nginx/conf.d/octo.conf.template`
-5. Set `OCTO_TLS_ENABLED=true` in `docker/.env`
-6. Restart: `docker compose up -d`
+4. Set `OCTO_TLS_ENABLED=true` in `docker/.env`
+5. Restart: `docker compose up -d`
 
 > **Note:** The `.gitignore` excludes `*.pem` files from version control.
 > Never commit private keys to the repository.

--- a/docker/certs/README.md
+++ b/docker/certs/README.md
@@ -30,11 +30,19 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
 
 After placing certificates here:
 
-1. Uncomment the `443` port mapping in `docker/docker-compose.yaml`
-2. Uncomment the certs volume mount in `docker/docker-compose.yaml`
-3. Uncomment the HTTPS server block in `docker/nginx/conf.d/octo.conf.template`
-4. Set `OCTO_TLS_ENABLED=true` in `docker/.env`
-5. Restart: `docker compose up -d`
+1. Comment out the existing HTTP `server { listen 80 default_server; … }`
+   block in `docker/nginx/conf.d/octo.conf.template`. Both the HTTP and
+   HTTPS blocks ship as `default_server` on their respective ports;
+   leaving the HTTP block active while uncommenting the HTTPS block
+   causes nginx to refuse to start with "a duplicate default server".
+   If you want to keep HTTP responding (e.g. as a permanent redirect to
+   HTTPS), replace the HTTP `server` block body with a 301 redirect
+   rather than removing the `listen 80` line entirely.
+2. Uncomment the `443` port mapping in `docker/docker-compose.yaml`
+3. Uncomment the certs volume mount in `docker/docker-compose.yaml`
+4. Uncomment the HTTPS server block in `docker/nginx/conf.d/octo.conf.template`
+5. Set `OCTO_TLS_ENABLED=true` in `docker/.env`
+6. Restart: `docker compose up -d`
 
 > **Note:** The `.gitignore` excludes `*.pem` files from version control.
 > Never commit private keys to the repository.

--- a/docker/certs/README.md
+++ b/docker/certs/README.md
@@ -1,0 +1,40 @@
+# TLS Certificates
+
+Place your TLS certificates in this directory for HTTPS support:
+
+- **`fullchain.pem`** — Full certificate chain (server cert + intermediates)
+- **`privkey.pem`** — Private key (RSA or ECDSA)
+
+## Quick start with Let's Encrypt (certbot)
+
+```bash
+# Obtain certificates
+sudo certbot certonly --standalone -d your-domain.com
+
+# Copy into this directory
+sudo cp /etc/letsencrypt/live/your-domain.com/fullchain.pem docker/certs/
+sudo cp /etc/letsencrypt/live/your-domain.com/privkey.pem docker/certs/
+sudo chown $(id -u):$(id -g) docker/certs/*.pem
+```
+
+## Quick start with self-signed (development only)
+
+```bash
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout docker/certs/privkey.pem \
+  -out docker/certs/fullchain.pem \
+  -subj "/CN=octo.local"
+```
+
+## Enabling HTTPS
+
+After placing certificates here:
+
+1. Uncomment the `443` port mapping in `docker/docker-compose.yaml`
+2. Uncomment the certs volume mount in `docker/docker-compose.yaml`
+3. Uncomment the HTTPS server block in `docker/nginx/conf.d/octo.conf.template`
+4. Set `OCTO_TLS_ENABLED=true` in `docker/.env`
+5. Restart: `docker compose up -d`
+
+> **Note:** The `.gitignore` excludes `*.pem` files from version control.
+> Never commit private keys to the repository.

--- a/docker/configs/wk.yaml
+++ b/docker/configs/wk.yaml
@@ -4,7 +4,7 @@
 # -----------------------------------------------------------------------------
 
 # debug | release | bench
-mode: "debug"
+mode: "release"
 
 tokenAuthOn: true
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -689,6 +689,7 @@ services:
     image: ${OCTO_SUMMARY_API_IMAGE:-mininglamposs/octo-smart-summary-api:latest}
     container_name: octo-summary-api
     restart: unless-stopped
+    profiles: ["summary"]
     depends_on:
       preflight:
         condition: service_completed_successfully
@@ -745,6 +746,7 @@ services:
     image: ${OCTO_SUMMARY_WORKER_IMAGE:-mininglamposs/octo-smart-summary-worker:latest}
     container_name: octo-summary-worker
     restart: unless-stopped
+    profiles: ["summary"]
     depends_on:
       mysql:
         condition: service_healthy

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -515,11 +515,13 @@ services:
       # warns when this var is missing from .env. Two-name sync with
       # matter (line below) keeps the contract symmetric.
       NOTIFY_INTERNAL_TOKEN: ${OCTO_NOTIFY_INTERNAL_TOKEN}
-      # First-admin bootstrap. Uncomment to have octo-server seed a
-      # superAdmin row (username "superAdmin", password bcrypt(<value>))
-      # on first start when the user table is empty. See "First-admin
-      # bootstrap · Option A" in docker/README.md before enabling.
-      # TS_ADMINPWD: ${OCTO_ADMIN_PWD:-}
+      # First-admin bootstrap. octo-server seeds a superAdmin row
+      # (username "superAdmin", password bcrypt(<value>)) on first start
+      # when the user table is empty. setup.sh generates a random value
+      # for OCTO_ADMIN_PWD and prints it for the operator to save.
+      # Leave OCTO_ADMIN_PWD empty in .env to skip auto-bootstrap
+      # (create admin manually via API).
+      TS_ADMINPWD: ${OCTO_ADMIN_PWD:-}
     depends_on:
       preflight:
         condition: service_completed_successfully
@@ -583,7 +585,7 @@ services:
       # OOTB stack portable; redirect to a host path if your operator
       # tooling needs them on disk.
       - nginx-logs:/var/log/nginx
-      # - ./nginx/certs:/etc/nginx/certs:ro
+      # - ./certs:/etc/nginx/certs:ro
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O - http://localhost/_nginx_up >/dev/null 2>&1 || exit 1"]
       interval: 10s

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -204,15 +204,134 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 # -----------------------------------------------------------------------------
 # HTTPS listener (disabled by default).
 # Enable by: uncommenting the 443 port in docker-compose.yaml, placing certs
-# under ./nginx/certs/, and uncommenting the block below.
+# under docker/certs/, uncommenting the certs volume mount, and uncommenting
+# the block below. See docker/certs/README.md for cert placement details.
 # -----------------------------------------------------------------------------
+# --- Uncomment the block below to enable HTTPS (requires certs in docker/certs/) ---
 # server {
-#     listen       443 ssl http2;
-#     listen       [::]:443 ssl http2;
-#     server_name  ${OCTO_DOMAIN};
-#     ssl_certificate      /etc/nginx/certs/fullchain.pem;
-#     ssl_certificate_key  /etc/nginx/certs/privkey.pem;
-#     ssl_protocols        TLSv1.2 TLSv1.3;
-#     ssl_ciphers          HIGH:!aNULL:!MD5;
-#     # paste the same location blocks as the HTTP listener above
+#     listen       443 ssl http2 default_server;
+#     listen       [::]:443 ssl http2 default_server;
+#     server_name  ${OCTO_DOMAIN} _;
+#
+#     ssl_certificate     /etc/nginx/certs/fullchain.pem;
+#     ssl_certificate_key /etc/nginx/certs/privkey.pem;
+#     ssl_protocols       TLSv1.2 TLSv1.3;
+#     ssl_ciphers         HIGH:!aNULL:!MD5;
+#
+#     client_max_body_size    1000m;
+#     client_body_buffer_size 8m;
+#
+#     add_header X-Frame-Options          "SAMEORIGIN" always;
+#     add_header X-Content-Type-Options   "nosniff" always;
+#     add_header Referrer-Policy          "strict-origin-when-cross-origin" always;
+#     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+#
+#     location = /_nginx_up {
+#         access_log off;
+#         default_type text/plain;
+#         return 200 "ok\n";
+#     }
+#
+#     location /api/ {
+#         limit_req zone=octo_api burst=60 nodelay;
+#         proxy_pass         http://octo_api/;
+#         proxy_http_version 1.1;
+#         proxy_set_header   Host              $host;
+#         proxy_set_header   X-Real-IP         $remote_addr;
+#         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+#         proxy_set_header   X-Forwarded-Proto $scheme;
+#         proxy_set_header   Connection        "";
+#         proxy_read_timeout 600s;
+#     }
+#
+#     location ^~ /v1/ {
+#         limit_req zone=octo_auth burst=20 nodelay;
+#         proxy_pass         http://octo_api/v1/;
+#         proxy_http_version 1.1;
+#         proxy_set_header   Host              $host;
+#         proxy_set_header   X-Real-IP         $remote_addr;
+#         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+#         proxy_set_header   X-Forwarded-Proto $scheme;
+#         proxy_set_header   Connection        "";
+#         proxy_read_timeout 600s;
+#     }
+#
+#     location /ws {
+#         proxy_pass          http://octo_ws;
+#         proxy_http_version  1.1;
+#         proxy_set_header    Upgrade           $http_upgrade;
+#         proxy_set_header    Connection        "upgrade";
+#         proxy_set_header    Host              $host;
+#         proxy_set_header    X-Real-IP         $remote_addr;
+#         proxy_set_header    X-Forwarded-For   $proxy_add_x_forwarded_for;
+#         proxy_set_header    X-Forwarded-Proto $scheme;
+#         proxy_read_timeout  3600s;
+#         proxy_send_timeout  3600s;
+#     }
+#
+#     location /minio/ {
+#         proxy_pass         http://octo_minio_api/;
+#         proxy_http_version 1.1;
+#         proxy_set_header   Host              $host;
+#         proxy_set_header   X-Real-IP         $remote_addr;
+#         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+#         proxy_set_header   X-Forwarded-Proto $scheme;
+#         proxy_set_header   Connection        "";
+#         proxy_read_timeout 600s;
+#         proxy_request_buffering off;
+#     }
+#
+#     location = /admin {
+#         return 301 /admin/;
+#     }
+#     location /admin/ {
+#         proxy_pass         http://admin/admin/;
+#         proxy_http_version 1.1;
+#         proxy_set_header   Host              $host;
+#         proxy_set_header   X-Real-IP         $remote_addr;
+#         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+#         proxy_set_header   X-Forwarded-Proto $scheme;
+#     }
+#
+#     location /matter/ {
+#         limit_req zone=octo_api burst=20 nodelay;
+#         proxy_pass         http://matter:8080/;
+#         proxy_http_version 1.1;
+#         proxy_set_header   Host              $host;
+#         proxy_set_header   X-Real-IP         $remote_addr;
+#         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+#         proxy_set_header   X-Forwarded-Proto $scheme;
+#     }
+#
+#     location /summary/ {
+#         limit_req zone=octo_api burst=20 nodelay;
+#         proxy_pass         http://summary-api:8080/;
+#         proxy_http_version 1.1;
+#         proxy_set_header   Host              $host;
+#         proxy_set_header   X-Real-IP         $remote_addr;
+#         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+#         proxy_set_header   X-Forwarded-Proto $scheme;
+#     }
+#
+#     location = /_octo_up {
+#         default_type text/html;
+#         return 200 '<!doctype html><html><body><h1>OCTO Server (HTTPS)</h1></body></html>';
+#     }
+#
+#     location / {
+#         proxy_pass         http://web/;
+#         proxy_http_version 1.1;
+#         proxy_set_header   Host              $host;
+#         proxy_set_header   X-Real-IP         $remote_addr;
+#         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+#         proxy_set_header   X-Forwarded-Proto $scheme;
+#     }
+# }
+#
+# # HTTP → HTTPS redirect (replaces the HTTP server block above)
+# server {
+#     listen       80 default_server;
+#     listen       [::]:80 default_server;
+#     server_name  ${OCTO_DOMAIN} _;
+#     return 301 https://$host$request_uri;
 # }

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -167,13 +167,20 @@ server {
         # default. A static `proxy_pass http://summary-api:8080` would make
         # nginx resolve the hostname at startup — when the container is absent
         # that resolution fails and nginx refuses to start (emerg: host not
-        # found). Using a variable (`$summary_upstream`) defers resolution to
-        # request time via the Docker embedded DNS resolver. When summary-api
-        # is down the client gets a 502 instead of a hard crash.
+        # found). Using a variable defers resolution to request time via the
+        # Docker embedded DNS resolver; when summary-api is down the client
+        # gets a 502 instead of a hard crash.
+        #
+        # IMPORTANT: when `proxy_pass` contains a variable, nginx does NOT
+        # perform the location-prefix replacement that strips `/summary/`
+        # from the URI. We must rewrite the URI explicitly with `rewrite`
+        # and use a `proxy_pass` target that has NO URI component, so the
+        # rewritten request URI (`/health`, `/foo`, …) is forwarded as-is.
         limit_req zone=octo_api burst=20 nodelay;
         resolver 127.0.0.11 valid=10s ipv6=off;
-        set $summary_upstream http://summary-api:8080;
-        proxy_pass         $summary_upstream/;
+        set $summary_backend summary-api;
+        rewrite ^/summary/(.*) /$1 break;
+        proxy_pass         http://$summary_backend:8080;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
@@ -316,8 +323,9 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #     location /summary/ {
 #         limit_req zone=octo_api burst=20 nodelay;
 #         resolver 127.0.0.11 valid=10s ipv6=off;
-#         set $summary_upstream http://summary-api:8080;
-#         proxy_pass         $summary_upstream/;
+#         set $summary_backend summary-api;
+#         rewrite ^/summary/(.*) /$1 break;
+#         proxy_pass         http://$summary_backend:8080;
 #         proxy_http_version 1.1;
 #         proxy_set_header   Host              $host;
 #         proxy_set_header   X-Real-IP         $remote_addr;

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -162,8 +162,18 @@ server {
     location /summary/ {
         # See /matter/ above — same octo_api zone applied for
         # consistency with the documented security model.
+        #
+        # summary-api lives in `profiles: [summary]` and is NOT started by
+        # default. A static `proxy_pass http://summary-api:8080` would make
+        # nginx resolve the hostname at startup — when the container is absent
+        # that resolution fails and nginx refuses to start (emerg: host not
+        # found). Using a variable (`$summary_upstream`) defers resolution to
+        # request time via the Docker embedded DNS resolver. When summary-api
+        # is down the client gets a 502 instead of a hard crash.
         limit_req zone=octo_api burst=20 nodelay;
-        proxy_pass         http://summary-api:8080/;
+        resolver 127.0.0.11 valid=10s ipv6=off;
+        set $summary_upstream http://summary-api:8080;
+        proxy_pass         $summary_upstream/;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
@@ -305,7 +315,9 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #
 #     location /summary/ {
 #         limit_req zone=octo_api burst=20 nodelay;
-#         proxy_pass         http://summary-api:8080/;
+#         resolver 127.0.0.11 valid=10s ipv6=off;
+#         set $summary_upstream http://summary-api:8080;
+#         proxy_pass         $summary_upstream/;
 #         proxy_http_version 1.1;
 #         proxy_set_header   Host              $host;
 #         proxy_set_header   X-Real-IP         $remote_addr;

--- a/setup.sh
+++ b/setup.sh
@@ -38,6 +38,22 @@ warn()  { printf '%s[setup]%s %s\n' "${YELLOW}" "${RESET}" "$*"; }
 err()   { printf '%s[setup]%s %s\n' "${RED}" "${RESET}" "$*" >&2; }
 fatal() { err "$@"; exit 1; }
 
+# Portable in-place sed (GNU + BSD/macOS compatible).
+# GNU sed accepts `sed -i "..."`; BSD/macOS sed requires `-i ''` (an
+# explicit, possibly empty, backup-extension argument). Without this
+# shim, `sed -i "s|foo|bar|" file` on macOS errors out with
+# "extra characters at the end of p command" because BSD sed treats
+# the next argument as the backup suffix.
+sed_inplace() {
+  if sed --version >/dev/null 2>&1; then
+    # GNU sed
+    sed -i "$@"
+  else
+    # BSD/macOS sed needs an explicit (empty) backup extension
+    sed -i '' "$@"
+  fi
+}
+
 # ── Parse CLI arguments ─────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -77,6 +93,14 @@ fi
 
 if ! command -v openssl &>/dev/null; then
   fatal "openssl is not installed. Install it before running setup."
+fi
+
+# curl is used only for external-IP auto-detection. Missing curl is not
+# fatal — detect_ip falls back to 127.0.0.1 — but warn so the operator
+# knows why EXTERNAL_IP came out as loopback.
+if ! command -v curl &>/dev/null; then
+  warn "curl is not installed; external IP auto-detection will fall back to 127.0.0.1."
+  warn "Pass --ip <address> explicitly, or install curl, for a public IP."
 fi
 
 if [[ ! -f "${ENV_EXAMPLE}" ]]; then
@@ -179,49 +203,49 @@ info "Generating docker/.env from template…"
 cp "${ENV_EXAMPLE}" "${ENV_OUT}"
 
 # Replace domain and IP
-sed -i "s|^OCTO_DOMAIN=.*|OCTO_DOMAIN=${DOMAIN}|" "${ENV_OUT}"
-sed -i "s|^OCTO_EXTERNAL_IP=.*|OCTO_EXTERNAL_IP=${EXTERNAL_IP}|" "${ENV_OUT}"
+sed_inplace "s|^OCTO_DOMAIN=.*|OCTO_DOMAIN=${DOMAIN}|" "${ENV_OUT}"
+sed_inplace "s|^OCTO_EXTERNAL_IP=.*|OCTO_EXTERNAL_IP=${EXTERNAL_IP}|" "${ENV_OUT}"
 
 # Replace all CHANGE_ME / placeholder passwords
-sed -i "s|^MYSQL_ROOT_PASSWORD=.*|MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}|" "${ENV_OUT}"
-sed -i "s|^MINIO_ROOT_PASSWORD=.*|MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}|" "${ENV_OUT}"
-sed -i "s|^OCTO_MINIO_APP_PASSWORD=.*|OCTO_MINIO_APP_PASSWORD=${OCTO_MINIO_APP_PASSWORD}|" "${ENV_OUT}"
-sed -i "s|^OCTO_MATTER_DB_PASSWORD=.*|OCTO_MATTER_DB_PASSWORD=${OCTO_MATTER_DB_PASSWORD}|" "${ENV_OUT}"
-sed -i "s|^OCTO_SUMMARY_DB_PASSWORD=.*|OCTO_SUMMARY_DB_PASSWORD=${OCTO_SUMMARY_DB_PASSWORD}|" "${ENV_OUT}"
-sed -i "s|^OCTO_SUMMARY_READER_PASSWORD=.*|OCTO_SUMMARY_READER_PASSWORD=${OCTO_SUMMARY_READER_PASSWORD}|" "${ENV_OUT}"
-sed -i "s|^OCTO_MASTER_KEY=.*|OCTO_MASTER_KEY=${OCTO_MASTER_KEY}|" "${ENV_OUT}"
-sed -i "s|^OCTO_NOTIFY_INTERNAL_TOKEN=.*|OCTO_NOTIFY_INTERNAL_TOKEN=${OCTO_NOTIFY_INTERNAL_TOKEN}|" "${ENV_OUT}"
-sed -i "s|^OCTO_WUKONGIM_MANAGER_TOKEN=.*|OCTO_WUKONGIM_MANAGER_TOKEN=${OCTO_WUKONGIM_MANAGER_TOKEN}|" "${ENV_OUT}"
+sed_inplace "s|^MYSQL_ROOT_PASSWORD=.*|MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}|" "${ENV_OUT}"
+sed_inplace "s|^MINIO_ROOT_PASSWORD=.*|MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}|" "${ENV_OUT}"
+sed_inplace "s|^OCTO_MINIO_APP_PASSWORD=.*|OCTO_MINIO_APP_PASSWORD=${OCTO_MINIO_APP_PASSWORD}|" "${ENV_OUT}"
+sed_inplace "s|^OCTO_MATTER_DB_PASSWORD=.*|OCTO_MATTER_DB_PASSWORD=${OCTO_MATTER_DB_PASSWORD}|" "${ENV_OUT}"
+sed_inplace "s|^OCTO_SUMMARY_DB_PASSWORD=.*|OCTO_SUMMARY_DB_PASSWORD=${OCTO_SUMMARY_DB_PASSWORD}|" "${ENV_OUT}"
+sed_inplace "s|^OCTO_SUMMARY_READER_PASSWORD=.*|OCTO_SUMMARY_READER_PASSWORD=${OCTO_SUMMARY_READER_PASSWORD}|" "${ENV_OUT}"
+sed_inplace "s|^OCTO_MASTER_KEY=.*|OCTO_MASTER_KEY=${OCTO_MASTER_KEY}|" "${ENV_OUT}"
+sed_inplace "s|^OCTO_NOTIFY_INTERNAL_TOKEN=.*|OCTO_NOTIFY_INTERNAL_TOKEN=${OCTO_NOTIFY_INTERNAL_TOKEN}|" "${ENV_OUT}"
+sed_inplace "s|^OCTO_WUKONGIM_MANAGER_TOKEN=.*|OCTO_WUKONGIM_MANAGER_TOKEN=${OCTO_WUKONGIM_MANAGER_TOKEN}|" "${ENV_OUT}"
 
 # Set WK_MODE to release
-sed -i "s|^WK_MODE=.*|WK_MODE=release|" "${ENV_OUT}"
+sed_inplace "s|^WK_MODE=.*|WK_MODE=release|" "${ENV_OUT}"
 
 # Replace admin password
-sed -i "s|^OCTO_ADMIN_PWD=.*|OCTO_ADMIN_PWD=${OCTO_ADMIN_PWD}|" "${ENV_OUT}"
+sed_inplace "s|^OCTO_ADMIN_PWD=.*|OCTO_ADMIN_PWD=${OCTO_ADMIN_PWD}|" "${ENV_OUT}"
 # If the line was commented, uncomment it
-sed -i "s|^# *OCTO_ADMIN_PWD=.*|OCTO_ADMIN_PWD=${OCTO_ADMIN_PWD}|" "${ENV_OUT}"
+sed_inplace "s|^# *OCTO_ADMIN_PWD=.*|OCTO_ADMIN_PWD=${OCTO_ADMIN_PWD}|" "${ENV_OUT}"
 
 # TLS setting
 if [[ "${ENABLE_HTTPS}" == "true" ]]; then
-  sed -i "s|^OCTO_TLS_ENABLED=.*|OCTO_TLS_ENABLED=true|" "${ENV_OUT}"
+  sed_inplace "s|^OCTO_TLS_ENABLED=.*|OCTO_TLS_ENABLED=true|" "${ENV_OUT}"
 else
-  sed -i "s|^OCTO_TLS_ENABLED=.*|OCTO_TLS_ENABLED=false|" "${ENV_OUT}"
+  sed_inplace "s|^OCTO_TLS_ENABLED=.*|OCTO_TLS_ENABLED=false|" "${ENV_OUT}"
 fi
 
 # Summary setting
 if [[ "${ENABLE_SUMMARY}" == "true" ]]; then
-  sed -i "s|^OCTO_ENABLE_SUMMARY=.*|OCTO_ENABLE_SUMMARY=true|" "${ENV_OUT}"
+  sed_inplace "s|^OCTO_ENABLE_SUMMARY=.*|OCTO_ENABLE_SUMMARY=true|" "${ENV_OUT}"
   # Activate the summary Docker Compose profile so that
   # `docker compose up -d` (without --profile) starts summary services.
   if grep -q '^COMPOSE_PROFILES=' "${ENV_OUT}"; then
-    sed -i "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=summary|" "${ENV_OUT}"
+    sed_inplace "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=summary|" "${ENV_OUT}"
   elif grep -q '^# *COMPOSE_PROFILES=' "${ENV_OUT}"; then
-    sed -i "s|^# *COMPOSE_PROFILES=.*|COMPOSE_PROFILES=summary|" "${ENV_OUT}"
+    sed_inplace "s|^# *COMPOSE_PROFILES=.*|COMPOSE_PROFILES=summary|" "${ENV_OUT}"
   else
     printf '\n# Activate summary services (summary-api + summary-worker)\nCOMPOSE_PROFILES=summary\n' >> "${ENV_OUT}"
   fi
 else
-  sed -i "s|^OCTO_ENABLE_SUMMARY=.*|OCTO_ENABLE_SUMMARY=false|" "${ENV_OUT}"
+  sed_inplace "s|^OCTO_ENABLE_SUMMARY=.*|OCTO_ENABLE_SUMMARY=false|" "${ENV_OUT}"
 fi
 
 # ── Print summary ───────────────────────────────────────────────────────────

--- a/setup.sh
+++ b/setup.sh
@@ -201,6 +201,12 @@ OCTO_ADMIN_PWD="$(openssl rand -base64 18)"
 info "Generating docker/.env from template…"
 
 cp "${ENV_EXAMPLE}" "${ENV_OUT}"
+# The .env file holds DB passwords, admin password, MinIO root credentials
+# and notify/manager tokens. `cp` honors the inherited umask (typically
+# 022 → 0644 = world-readable), which would let any local user on the
+# host read every secret in the stack. Lock the file down to the owner
+# only before we write the generated values into it.
+chmod 600 "${ENV_OUT}"
 
 # Replace domain and IP
 sed_inplace "s|^OCTO_DOMAIN=.*|OCTO_DOMAIN=${DOMAIN}|" "${ENV_OUT}"
@@ -233,8 +239,12 @@ else
 fi
 
 # Summary setting
+# OCTO_ENABLE_SUMMARY itself is just an informational comment in
+# .env.example (Compose profiles are the real on/off switch), so we
+# only flip COMPOSE_PROFILES below — no sed against OCTO_ENABLE_SUMMARY
+# is needed (and any such sed would be a no-op against the commented
+# template line).
 if [[ "${ENABLE_SUMMARY}" == "true" ]]; then
-  sed_inplace "s|^OCTO_ENABLE_SUMMARY=.*|OCTO_ENABLE_SUMMARY=true|" "${ENV_OUT}"
   # Activate the summary Docker Compose profile so that
   # `docker compose up -d` (without --profile) starts summary services.
   if grep -q '^COMPOSE_PROFILES=' "${ENV_OUT}"; then
@@ -244,8 +254,6 @@ if [[ "${ENABLE_SUMMARY}" == "true" ]]; then
   else
     printf '\n# Activate summary services (summary-api + summary-worker)\nCOMPOSE_PROFILES=summary\n' >> "${ENV_OUT}"
   fi
-else
-  sed_inplace "s|^OCTO_ENABLE_SUMMARY=.*|OCTO_ENABLE_SUMMARY=false|" "${ENV_OUT}"
 fi
 
 # ── Print summary ───────────────────────────────────────────────────────────

--- a/setup.sh
+++ b/setup.sh
@@ -22,6 +22,17 @@ ENABLE_SUMMARY=false
 NON_INTERACTIVE=false
 FORCE_OVERWRITE=false
 
+# Track which configuration values were supplied explicitly via CLI flags
+# so the interactive prompts (when invoked without --non-interactive)
+# don't silently overwrite them. See README.md examples like:
+#   ./setup.sh --summary --domain octo.example.com --ip 1.2.3.4
+# When any of these "decision" flags are set we auto-switch to
+# non-interactive mode — the operator has already made the choice.
+DOMAIN_SET_VIA_CLI=false
+IP_SET_VIA_CLI=false
+HTTPS_SET_VIA_CLI=false
+SUMMARY_SET_VIA_CLI=false
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_EXAMPLE="${SCRIPT_DIR}/docker/.env.example"
 ENV_OUT="${SCRIPT_DIR}/docker/.env"
@@ -59,17 +70,54 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --non-interactive) NON_INTERACTIVE=true; shift ;;
     --force)   FORCE_OVERWRITE=true; shift ;;
-    --domain)   DOMAIN="${2:?--domain requires a value}";   shift 2 ;;
-    --ip)       EXTERNAL_IP="${2:?--ip requires a value}";  shift 2 ;;
-    --https)    ENABLE_HTTPS=true;   shift ;;
-    --summary)  ENABLE_SUMMARY=true; shift ;;
+    --domain)   DOMAIN="${2:?--domain requires a value}";   DOMAIN_SET_VIA_CLI=true;  shift 2 ;;
+    --ip)       EXTERNAL_IP="${2:?--ip requires a value}";  IP_SET_VIA_CLI=true;      shift 2 ;;
+    --https)    ENABLE_HTTPS=true;   HTTPS_SET_VIA_CLI=true;   shift ;;
+    --summary)  ENABLE_SUMMARY=true; SUMMARY_SET_VIA_CLI=true; shift ;;
     -h|--help)
-      echo "Usage: $0 [--non-interactive] [--force] [--domain <d>] [--ip <ip>] [--https] [--summary]"
+      cat <<'USAGE'
+Usage: setup.sh [--non-interactive] [--force] [--domain <d>] [--ip <ip>] [--https] [--summary]
+
+  --non-interactive   Skip prompts; use defaults + auto-detect for anything
+                      not provided via flags.
+  --force             Overwrite an existing docker/.env without prompting.
+  --domain <d>        Set OCTO_DOMAIN (default: octo.local).
+  --ip <ip>           Set OCTO_EXTERNAL_IP (skip auto-detect).
+  --https             HTTPS preparation flag. Sets OCTO_TLS_ENABLED=true and
+                      prints HTTPS activation instructions. This does NOT
+                      fully enable HTTPS — you still need to install certs
+                      and edit nginx + docker-compose manually. See
+                      docker/certs/README.md for the full procedure.
+  --summary           Enable the optional LLM summary services
+                      (COMPOSE_PROFILES=summary).
+
+When any of --domain / --ip / --https / --summary is given without
+--non-interactive, setup.sh treats the flags as your decisions and runs
+non-interactively so the documented one-liner forms (see docker/README.md)
+work as written.
+USAGE
       exit 0
       ;;
     *) fatal "Unknown argument: $1" ;;
   esac
 done
+
+# If the operator supplied any "decision" flag (--domain / --ip / --https
+# / --summary) but did not pass --non-interactive, treat those flags as
+# the decision and skip the prompts. Otherwise the interactive section
+# would silently overwrite --ip with the auto-detected value, and would
+# reset --https / --summary to false unless the user re-entered "y" at
+# the prompt — exactly the breakage Jerry-Xin flagged in PR#18 R5.
+if [[ "${NON_INTERACTIVE}" == "false" ]]; then
+  if [[ "${DOMAIN_SET_VIA_CLI}" == "true" \
+     || "${IP_SET_VIA_CLI}" == "true" \
+     || "${HTTPS_SET_VIA_CLI}" == "true" \
+     || "${SUMMARY_SET_VIA_CLI}" == "true" ]]; then
+    info "CLI flags supplied; switching to non-interactive mode."
+    info "(Pass no flags, or only --force, to get the interactive prompts.)"
+    NON_INTERACTIVE=true
+  fi
+fi
 
 # ── Pre-flight checks ───────────────────────────────────────────────────────
 info "Checking prerequisites…"
@@ -200,13 +248,21 @@ OCTO_ADMIN_PWD="$(openssl rand -base64 18)"
 # ── Build .env from template ────────────────────────────────────────────────
 info "Generating docker/.env from template…"
 
-cp "${ENV_EXAMPLE}" "${ENV_OUT}"
 # The .env file holds DB passwords, admin password, MinIO root credentials
-# and notify/manager tokens. `cp` honors the inherited umask (typically
-# 022 → 0644 = world-readable), which would let any local user on the
-# host read every secret in the stack. Lock the file down to the owner
-# only before we write the generated values into it.
-chmod 600 "${ENV_OUT}"
+# and notify/manager tokens. A naive `cp` honors the inherited umask
+# (typically 022 → 0644 = world-readable), and `cp` followed by a
+# separate `chmod 600` leaves a brief window during which any local user
+# can read every secret in the stack. Prefer `install -m 600` because it
+# creates the destination with the target mode in a single step. Fall
+# back to a `umask`-scoped `cp` for environments without GNU/BSD
+# coreutils (e.g. some Alpine/busybox base images) — that path is still
+# atomic with respect to the permissions race because the umask is
+# applied before the file is created.
+if command -v install &>/dev/null; then
+  install -m 600 "${ENV_EXAMPLE}" "${ENV_OUT}"
+else
+  ( umask 077 && cp "${ENV_EXAMPLE}" "${ENV_OUT}" )
+fi
 
 # Replace domain and IP
 sed_inplace "s|^OCTO_DOMAIN=.*|OCTO_DOMAIN=${DOMAIN}|" "${ENV_OUT}"
@@ -239,11 +295,9 @@ else
 fi
 
 # Summary setting
-# OCTO_ENABLE_SUMMARY itself is just an informational comment in
-# .env.example (Compose profiles are the real on/off switch), so we
-# only flip COMPOSE_PROFILES below — no sed against OCTO_ENABLE_SUMMARY
-# is needed (and any such sed would be a no-op against the commented
-# template line).
+# COMPOSE_PROFILES is the single source of truth for whether the summary
+# services run (see docker-compose.yaml — summary-api/summary-worker are
+# gated by the `summary` profile). --summary just flips that switch.
 if [[ "${ENABLE_SUMMARY}" == "true" ]]; then
   # Activate the summary Docker Compose profile so that
   # `docker compose up -d` (without --profile) starts summary services.
@@ -269,12 +323,19 @@ printf '  Admin password: %s%s%s\n' "${BOLD}" "${OCTO_ADMIN_PWD}" "${RESET}"
 echo ""
 
 if [[ "${ENABLE_HTTPS}" == "true" ]]; then
-  warn "HTTPS enabled. Place your certificates in docker/certs/:"
-  echo "  - docker/certs/fullchain.pem"
-  echo "  - docker/certs/privkey.pem"
+  warn "HTTPS preparation flag set (OCTO_TLS_ENABLED=true)."
+  warn "HTTPS is NOT yet active — --https only flips one env var. To actually"
+  warn "serve HTTPS you still need the following manual steps:"
+  echo "  1. Place certificates in docker/certs/:"
+  echo "       - docker/certs/fullchain.pem"
+  echo "       - docker/certs/privkey.pem"
+  echo "  2. Uncomment the HTTPS server block in"
+  echo "       docker/nginx/conf.d/octo.conf.template"
+  echo "  3. Uncomment the 443 port mapping + certs volume in"
+  echo "       docker/docker-compose.yaml"
+  echo "  4. Restart: cd docker && docker compose up -d"
   echo ""
-  warn "Then uncomment the HTTPS server block in docker/nginx/conf.d/octo.conf.template"
-  warn "and the 443 port + certs volume in docker/docker-compose.yaml."
+  warn "Full procedure: docker/certs/README.md"
   echo ""
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# OCTO Deployment · Interactive Setup Script
+# -----------------------------------------------------------------------------
+# Generates docker/.env from docker/.env.example with rotated secrets,
+# user-chosen domain/IP, and optional TLS / LLM summary toggles.
+#
+# Usage:
+#   ./setup.sh                        # interactive mode
+#   ./setup.sh --non-interactive      # all defaults + auto-detect
+#   ./setup.sh --domain octo.example.com --ip 1.2.3.4 --https --summary
+#
+# Requires: bash ≥4, openssl, docker, docker compose
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+DOMAIN="octo.local"
+EXTERNAL_IP=""
+ENABLE_HTTPS=false
+ENABLE_SUMMARY=false
+NON_INTERACTIVE=false
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_EXAMPLE="${SCRIPT_DIR}/docker/.env.example"
+ENV_OUT="${SCRIPT_DIR}/docker/.env"
+
+# ── Colours / helpers ────────────────────────────────────────────────────────
+if [[ -t 1 ]]; then
+  GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; BOLD='\033[1m'; RESET='\033[0m'
+else
+  GREEN=''; YELLOW=''; RED=''; BOLD=''; RESET=''
+fi
+
+info()  { printf '%s[setup]%s %s\n' "${GREEN}" "${RESET}" "$*"; }
+warn()  { printf '%s[setup]%s %s\n' "${YELLOW}" "${RESET}" "$*"; }
+err()   { printf '%s[setup]%s %s\n' "${RED}" "${RESET}" "$*" >&2; }
+fatal() { err "$@"; exit 1; }
+
+# ── Parse CLI arguments ─────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --non-interactive) NON_INTERACTIVE=true; shift ;;
+    --domain)   DOMAIN="${2:?--domain requires a value}";   shift 2 ;;
+    --ip)       EXTERNAL_IP="${2:?--ip requires a value}";  shift 2 ;;
+    --https)    ENABLE_HTTPS=true;   shift ;;
+    --summary)  ENABLE_SUMMARY=true; shift ;;
+    -h|--help)
+      echo "Usage: $0 [--non-interactive] [--domain <d>] [--ip <ip>] [--https] [--summary]"
+      exit 0
+      ;;
+    *) fatal "Unknown argument: $1" ;;
+  esac
+done
+
+# ── Pre-flight checks ───────────────────────────────────────────────────────
+info "Checking prerequisites…"
+
+if ! command -v docker &>/dev/null; then
+  fatal "docker is not installed. Install Docker first: https://docs.docker.com/get-docker/"
+fi
+
+DOCKER_VERSION="$(docker --version 2>/dev/null || true)"
+info "Docker: ${DOCKER_VERSION}"
+
+if docker compose version &>/dev/null; then
+  COMPOSE_VERSION="$(docker compose version 2>/dev/null || true)"
+  info "Compose: ${COMPOSE_VERSION}"
+elif command -v docker-compose &>/dev/null; then
+  COMPOSE_VERSION="$(docker-compose --version 2>/dev/null || true)"
+  info "Compose (standalone): ${COMPOSE_VERSION}"
+else
+  fatal "docker compose is not available. Install the Compose plugin: https://docs.docker.com/compose/install/"
+fi
+
+if ! command -v openssl &>/dev/null; then
+  fatal "openssl is not installed. Install it before running setup."
+fi
+
+if [[ ! -f "${ENV_EXAMPLE}" ]]; then
+  fatal "Cannot find ${ENV_EXAMPLE}. Run this script from the repository root."
+fi
+
+# ── Detect external IP ──────────────────────────────────────────────────────
+detect_ip() {
+  local ip=""
+  ip="$(curl -s --max-time 5 ifconfig.me 2>/dev/null || true)"
+  if [[ -z "${ip}" ]]; then
+    ip="$(curl -s --max-time 5 icanhazip.com 2>/dev/null || true)"
+  fi
+  if [[ -z "${ip}" ]]; then
+    ip="127.0.0.1"
+  fi
+  echo "${ip}"
+}
+
+# ── Interactive prompts ─────────────────────────────────────────────────────
+if [[ "${NON_INTERACTIVE}" == "false" ]]; then
+  echo ""
+  printf '%sOCTO Deployment Setup%s\n' "${BOLD}" "${RESET}"
+  echo "This script generates docker/.env with secure random secrets."
+  echo ""
+
+  # Domain
+  read -rp "Domain name [${DOMAIN}]: " user_domain
+  DOMAIN="${user_domain:-${DOMAIN}}"
+
+  # External IP
+  info "Detecting external IP…"
+  detected_ip="$(detect_ip)"
+  read -rp "External IP [${detected_ip}]: " user_ip
+  EXTERNAL_IP="${user_ip:-${detected_ip}}"
+
+  # HTTPS
+  read -rp "Enable HTTPS? [y/N]: " user_https
+  case "${user_https}" in
+    [yY]|[yY][eE][sS]) ENABLE_HTTPS=true ;;
+    *) ENABLE_HTTPS=false ;;
+  esac
+
+  # Summary (LLM)
+  read -rp "Enable LLM summary service? [y/N]: " user_summary
+  case "${user_summary}" in
+    [yY]|[yY][eE][sS]) ENABLE_SUMMARY=true ;;
+    *) ENABLE_SUMMARY=false ;;
+  esac
+else
+  # Non-interactive: auto-detect IP if not provided via --ip
+  if [[ -z "${EXTERNAL_IP}" ]]; then
+    info "Auto-detecting external IP…"
+    EXTERNAL_IP="$(detect_ip)"
+  fi
+fi
+
+info "Domain:     ${DOMAIN}"
+info "External IP: ${EXTERNAL_IP}"
+info "HTTPS:      ${ENABLE_HTTPS}"
+info "Summary:    ${ENABLE_SUMMARY}"
+
+# ── Generate secrets ────────────────────────────────────────────────────────
+info "Generating random secrets…"
+
+MYSQL_ROOT_PASSWORD="$(openssl rand -hex 16)"
+MINIO_ROOT_PASSWORD="$(openssl rand -hex 16)"
+OCTO_MINIO_APP_PASSWORD="$(openssl rand -hex 24)"
+OCTO_MATTER_DB_PASSWORD="$(openssl rand -hex 16)"
+OCTO_SUMMARY_DB_PASSWORD="$(openssl rand -hex 16)"
+OCTO_SUMMARY_READER_PASSWORD="$(openssl rand -hex 16)"
+OCTO_MASTER_KEY="$(openssl rand -hex 16)"
+OCTO_NOTIFY_INTERNAL_TOKEN="$(openssl rand -hex 32)"
+OCTO_WUKONGIM_MANAGER_TOKEN="$(openssl rand -hex 32)"
+OCTO_ADMIN_PWD="$(openssl rand -base64 18)"
+
+# ── Build .env from template ────────────────────────────────────────────────
+info "Generating docker/.env from template…"
+
+cp "${ENV_EXAMPLE}" "${ENV_OUT}"
+
+# Replace domain and IP
+sed -i "s|^OCTO_DOMAIN=.*|OCTO_DOMAIN=${DOMAIN}|" "${ENV_OUT}"
+sed -i "s|^OCTO_EXTERNAL_IP=.*|OCTO_EXTERNAL_IP=${EXTERNAL_IP}|" "${ENV_OUT}"
+
+# Replace all CHANGE_ME / placeholder passwords
+sed -i "s|^MYSQL_ROOT_PASSWORD=.*|MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}|" "${ENV_OUT}"
+sed -i "s|^MINIO_ROOT_PASSWORD=.*|MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}|" "${ENV_OUT}"
+sed -i "s|^OCTO_MINIO_APP_PASSWORD=.*|OCTO_MINIO_APP_PASSWORD=${OCTO_MINIO_APP_PASSWORD}|" "${ENV_OUT}"
+sed -i "s|^OCTO_MATTER_DB_PASSWORD=.*|OCTO_MATTER_DB_PASSWORD=${OCTO_MATTER_DB_PASSWORD}|" "${ENV_OUT}"
+sed -i "s|^OCTO_SUMMARY_DB_PASSWORD=.*|OCTO_SUMMARY_DB_PASSWORD=${OCTO_SUMMARY_DB_PASSWORD}|" "${ENV_OUT}"
+sed -i "s|^OCTO_SUMMARY_READER_PASSWORD=.*|OCTO_SUMMARY_READER_PASSWORD=${OCTO_SUMMARY_READER_PASSWORD}|" "${ENV_OUT}"
+sed -i "s|^OCTO_MASTER_KEY=.*|OCTO_MASTER_KEY=${OCTO_MASTER_KEY}|" "${ENV_OUT}"
+sed -i "s|^OCTO_NOTIFY_INTERNAL_TOKEN=.*|OCTO_NOTIFY_INTERNAL_TOKEN=${OCTO_NOTIFY_INTERNAL_TOKEN}|" "${ENV_OUT}"
+sed -i "s|^OCTO_WUKONGIM_MANAGER_TOKEN=.*|OCTO_WUKONGIM_MANAGER_TOKEN=${OCTO_WUKONGIM_MANAGER_TOKEN}|" "${ENV_OUT}"
+
+# Set WK_MODE to release
+sed -i "s|^WK_MODE=.*|WK_MODE=release|" "${ENV_OUT}"
+
+# Replace admin password
+sed -i "s|^OCTO_ADMIN_PWD=.*|OCTO_ADMIN_PWD=${OCTO_ADMIN_PWD}|" "${ENV_OUT}"
+# If the line was commented, uncomment it
+sed -i "s|^# *OCTO_ADMIN_PWD=.*|OCTO_ADMIN_PWD=${OCTO_ADMIN_PWD}|" "${ENV_OUT}"
+
+# TLS setting
+if [[ "${ENABLE_HTTPS}" == "true" ]]; then
+  sed -i "s|^OCTO_TLS_ENABLED=.*|OCTO_TLS_ENABLED=true|" "${ENV_OUT}"
+else
+  sed -i "s|^OCTO_TLS_ENABLED=.*|OCTO_TLS_ENABLED=false|" "${ENV_OUT}"
+fi
+
+# Summary setting
+if [[ "${ENABLE_SUMMARY}" == "true" ]]; then
+  sed -i "s|^OCTO_ENABLE_SUMMARY=.*|OCTO_ENABLE_SUMMARY=true|" "${ENV_OUT}"
+else
+  sed -i "s|^OCTO_ENABLE_SUMMARY=.*|OCTO_ENABLE_SUMMARY=false|" "${ENV_OUT}"
+fi
+
+# ── Print summary ───────────────────────────────────────────────────────────
+echo ""
+printf '%s════════════════════════════════════════════════════════════════%s\n' "${BOLD}" "${RESET}"
+printf '%s  docker/.env generated successfully!%s\n' "${GREEN}" "${RESET}"
+printf '%s════════════════════════════════════════════════════════════════%s\n' "${BOLD}" "${RESET}"
+echo ""
+printf '  Domain:         %s%s%s\n' "${BOLD}" "${DOMAIN}" "${RESET}"
+printf '  External IP:    %s%s%s\n' "${BOLD}" "${EXTERNAL_IP}" "${RESET}"
+printf '  Admin user:     %ssuperAdmin%s\n' "${BOLD}" "${RESET}"
+printf '  Admin password: %s%s%s\n' "${BOLD}" "${OCTO_ADMIN_PWD}" "${RESET}"
+echo ""
+
+if [[ "${ENABLE_HTTPS}" == "true" ]]; then
+  warn "HTTPS enabled. Place your certificates in docker/certs/:"
+  echo "  - docker/certs/fullchain.pem"
+  echo "  - docker/certs/privkey.pem"
+  echo ""
+  warn "Then uncomment the HTTPS server block in docker/nginx/conf.d/octo.conf.template"
+  warn "and the 443 port + certs volume in docker/docker-compose.yaml."
+  echo ""
+fi
+
+if [[ "${ENABLE_SUMMARY}" == "true" ]]; then
+  info "Summary service enabled. Set LLM_API_KEY in docker/.env before using."
+  echo "  Start with: cd docker && docker compose --profile summary up -d"
+else
+  info "Summary service disabled. Start without LLM:"
+  echo "  cd docker && docker compose up -d"
+fi
+
+echo ""
+info "Next steps:"
+echo "  1. Review docker/.env and adjust as needed"
+
+if [[ "${ENABLE_SUMMARY}" == "true" ]]; then
+  echo "  2. cd docker && docker compose --profile summary up -d"
+else
+  echo "  2. cd docker && docker compose up -d"
+fi
+
+echo "  3. Visit http://${DOMAIN}:28080"
+echo ""
+printf '%s  ⚠  Save the admin password above — it is NOT stored elsewhere.%s\n' "${YELLOW}" "${RESET}"
+echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -20,6 +20,7 @@ EXTERNAL_IP=""
 ENABLE_HTTPS=false
 ENABLE_SUMMARY=false
 NON_INTERACTIVE=false
+FORCE_OVERWRITE=false
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_EXAMPLE="${SCRIPT_DIR}/docker/.env.example"
@@ -41,12 +42,13 @@ fatal() { err "$@"; exit 1; }
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --non-interactive) NON_INTERACTIVE=true; shift ;;
+    --force)   FORCE_OVERWRITE=true; shift ;;
     --domain)   DOMAIN="${2:?--domain requires a value}";   shift 2 ;;
     --ip)       EXTERNAL_IP="${2:?--ip requires a value}";  shift 2 ;;
     --https)    ENABLE_HTTPS=true;   shift ;;
     --summary)  ENABLE_SUMMARY=true; shift ;;
     -h|--help)
-      echo "Usage: $0 [--non-interactive] [--domain <d>] [--ip <ip>] [--https] [--summary]"
+      echo "Usage: $0 [--non-interactive] [--force] [--domain <d>] [--ip <ip>] [--https] [--summary]"
       exit 0
       ;;
     *) fatal "Unknown argument: $1" ;;
@@ -79,6 +81,26 @@ fi
 
 if [[ ! -f "${ENV_EXAMPLE}" ]]; then
   fatal "Cannot find ${ENV_EXAMPLE}. Run this script from the repository root."
+fi
+
+# ── Guard against overwriting an existing .env ─────────────────────────────
+# Re-running setup.sh regenerates ALL secrets (MySQL root password, MinIO
+# credentials, admin password, etc.). If the stack has already been started,
+# the MySQL volume keeps the ORIGINAL passwords from the first `docker compose
+# up`; overwriting .env makes every service fail to connect. The guard below
+# prevents accidental overwrites; use --force to bypass.
+if [[ -f "${ENV_OUT}" ]] && [[ "${FORCE_OVERWRITE}" != "true" ]]; then
+  if [[ "${NON_INTERACTIVE}" == "true" ]]; then
+    fatal "docker/.env already exists. Use --force to overwrite."
+  else
+    warn "docker/.env already exists. Overwriting will regenerate ALL secrets."
+    warn "If the stack has been started, this will break database connections."
+    read -rp "Overwrite? [y/N]: " confirm
+    case "${confirm}" in
+      [yY]|[yY][eE][sS]) info "Overwriting..." ;;
+      *) info "Aborted."; exit 0 ;;
+    esac
+  fi
 fi
 
 # ── Detect external IP ──────────────────────────────────────────────────────
@@ -189,6 +211,15 @@ fi
 # Summary setting
 if [[ "${ENABLE_SUMMARY}" == "true" ]]; then
   sed -i "s|^OCTO_ENABLE_SUMMARY=.*|OCTO_ENABLE_SUMMARY=true|" "${ENV_OUT}"
+  # Activate the summary Docker Compose profile so that
+  # `docker compose up -d` (without --profile) starts summary services.
+  if grep -q '^COMPOSE_PROFILES=' "${ENV_OUT}"; then
+    sed -i "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=summary|" "${ENV_OUT}"
+  elif grep -q '^# *COMPOSE_PROFILES=' "${ENV_OUT}"; then
+    sed -i "s|^# *COMPOSE_PROFILES=.*|COMPOSE_PROFILES=summary|" "${ENV_OUT}"
+  else
+    printf '\n# Activate summary services (summary-api + summary-worker)\nCOMPOSE_PROFILES=summary\n' >> "${ENV_OUT}"
+  fi
 else
   sed -i "s|^OCTO_ENABLE_SUMMARY=.*|OCTO_ENABLE_SUMMARY=false|" "${ENV_OUT}"
 fi
@@ -217,7 +248,7 @@ fi
 
 if [[ "${ENABLE_SUMMARY}" == "true" ]]; then
   info "Summary service enabled. Set LLM_API_KEY in docker/.env before using."
-  echo "  Start with: cd docker && docker compose --profile summary up -d"
+  echo "  Start with: cd docker && docker compose up -d"
 else
   info "Summary service disabled. Start without LLM:"
   echo "  cd docker && docker compose up -d"
@@ -226,12 +257,7 @@ fi
 echo ""
 info "Next steps:"
 echo "  1. Review docker/.env and adjust as needed"
-
-if [[ "${ENABLE_SUMMARY}" == "true" ]]; then
-  echo "  2. cd docker && docker compose --profile summary up -d"
-else
-  echo "  2. cd docker && docker compose up -d"
-fi
+echo "  2. cd docker && docker compose up -d"
 
 echo "  3. Visit http://${DOMAIN}:28080"
 echo ""


### PR DESCRIPTION
## Summary

Makes the Docker Compose deployment truly out-of-the-box by adding an interactive setup script and hardening the default configuration.

Fixes Mininglamp-OSS/octo-deployment#17

## Changes

### 1. `setup.sh` (new file, repo root)
Interactive bash script that generates `docker/.env` from `.env.example`:
- Checks docker / docker compose / openssl prerequisites
- Prompts for domain, external IP (auto-detected), HTTPS, and LLM summary toggles
- Generates 9 random secrets + admin password with `openssl rand`
- Supports `--non-interactive` mode and CLI params (`--domain`, `--ip`, `--https`, `--summary`)
- Passes `shellcheck` cleanly

### 2. `.env.example` — new fields
- `OCTO_ADMIN_PWD=CHANGE_ME_ADMIN_PASSWORD` — admin bootstrap password
- `OCTO_TLS_ENABLED=false` — TLS flag for setup.sh
- `OCTO_ENABLE_SUMMARY=true` — summary service toggle

### 3. Summary services made optional via profiles
- `summary-api` and `summary-worker` get `profiles: ["summary"]`
- Default `docker compose up -d` skips them (no LLM needed)
- Enable with `docker compose --profile summary up -d`

### 4. HTTPS nginx template expanded
- Full commented HTTPS server block with all location rules copied from HTTP block
- HTTP → HTTPS redirect block
- HSTS header included
- `docker/certs/` directory with `.gitkeep` and `README.md`

### 5. `wk.yaml` mode → release
Changed from `mode: "debug"` to `mode: "release"`.

### 6. Other
- `.gitignore` updated to exclude `docker/certs/*.pem` etc.
- `WK_MANAGERTOKEN` and `octo-server.yaml managerToken` were already correct (fixed in prior PRs)

## Verification

All 8 acceptance criteria pass:
1. ✅ `setup.sh` executable, shellcheck clean
2. ✅ `./setup.sh --non-interactive` generates correct `.env` with all 9 secrets + admin password + domain/IP
3. ✅ `WK_MANAGERTOKEN` references env var in compose
4. ✅ `.env.example` contains `OCTO_ADMIN_PWD` / `OCTO_TLS_ENABLED` / `OCTO_ENABLE_SUMMARY`
5. ✅ nginx HTTPS block present (commented)
6. ✅ summary services have `profiles` marker
7. ✅ `octo-server.yaml` has no hardcoded token
8. ✅ `wk.yaml` mode is `release`