### PR TITLE
fix(docker): wukongim healthcheck pass managerToken header

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -410,7 +410,14 @@ services:
       - wukongim-data:/root/wukongim
       - ./configs/wk.yaml:/root/wukongim/wk.yaml:ro
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O - http://localhost:5001/health >/dev/null 2>&1 || wget -q -O - http://localhost:5001/varz >/dev/null 2>&1"]
+      # WuKongIM has tokenAuthOn:true in wk.yaml; /health and /varz both
+      # require the manager token. Inject it via wget --header using the
+      # WK_MANAGERTOKEN env var already passed to this container above.
+      # `$$WK_MANAGERTOKEN` (double-dollar) defers expansion to the
+      # in-container shell so compose doesn't substitute it at parse time.
+      # The wukongim image bundles wget (busybox) so no extra deps needed.
+      # header name is lowercase `token` (WuKongIM accepts that form).
+      test: ["CMD-SHELL", "wget -q -O - --header=\"token: $$WK_MANAGERTOKEN\" http://localhost:5001/health >/dev/null 2>&1 || wget -q -O - --header=\"token: $$WK_MANAGERTOKEN\" http://localhost:5001/varz >/dev/null 2>&1"]
       interval: 10s
       timeout: 5s
       retries: 12


### PR DESCRIPTION
## Root cause

`docker/docker-compose.yaml`'s wukongim healthcheck called `/health` (and
`/varz` as fallback) without a token header. Because `configs/wk.yaml`
ships with `tokenAuthOn: true` (safe default), both endpoints reply HTTP
401 → wget exits 1 → `octo-wukongim` is permanently `unhealthy` after a
clean `setup.sh --non-interactive && docker compose up -d`. This is a
real OOTB bug surfaced by the from-zero E2E test after PR #18.

## Fix

Inject the manager token via `wget --header`, reading from the
`WK_MANAGERTOKEN` env var that is already wired into the container
(`docker-compose.yaml:382 — WK_MANAGERTOKEN: ${OCTO_WUKONGIM_MANAGER_TOKEN}`).
Use `$$WK_MANAGERTOKEN` (double-dollar) so compose passes the literal
`$WK_MANAGERTOKEN` through to the container shell instead of expanding
it at parse-time on the host (where the variable is not defined).
busybox `wget` is bundled in the wukongim image — no new deps.

`/varz` fallback preserved. Header name `token` lowercase (accepted by
WuKongIM).

## Verification

**Before** (octo-wukongim container, current `main`):
```text
$ wget /health                                          → 401 Unauthorized
$ docker compose ps | grep wukongim
octo-wukongim   ... Up 2 minutes (unhealthy)
```

**After (this PR)**:
```text
$ wget --header="token: <OCTO_WUKONGIM_MANAGER_TOKEN>" /health
  → {"status":"ok"}
$ docker compose ps | grep wukongim
octo-wukongim   ... Up 30 seconds (healthy)
```

`docker compose -f docker/docker-compose.yaml config --quiet` passes.

The compose `$$` escape was confirmed with a minimal probe:
```yaml
services:
  test:
    image: busybox
    environment: { MY_TOKEN: hello123 }
    command: ["sh","-c","echo TOKEN=$$MY_TOKEN; echo direct=${MY_TOKEN}"]
```
Output: `TOKEN=hello123 / direct=` — confirming `$$` defers expansion to
the container shell and `${VAR}` would be (incorrectly) consumed by
compose at parse time.

## Scope

- Single file, +8 / -1
- Does NOT change `wk.yaml` (`tokenAuthOn: true` stays as the safe default)
- Does NOT touch any other service
- review-tier: low-risk

Fixes #19
Related: #17