### PR TITLE
fix(docker): OOTB upload+preview E2E — compose + nginx + minio-init

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -226,24 +226,31 @@ path):
 
 ```nginx
 # in docker/nginx/conf.d/octo.conf.template, before `location /`
-location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)/ {
+location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)/.+ {
     proxy_pass http://octo_minio_api;   # NO trailing slash — preserve SigV4 path
     proxy_set_header Host $http_host;
     ...
 }
 ```
 
-In that topology, override `TS_MINIO_DOWNLOADURL` in `.env` so
-octo-server signs URLs against the user-visible host instead of
-`host:29000`:
+In that topology, **both** `MINIO_SERVER_URL` (consumed by MinIO itself
+for absolute redirects, multipart hints, and federated bucket
+discovery) **and** `TS_MINIO_DOWNLOADURL` (consumed by octo-server when
+it hands presigned URLs to browser clients) must point at the same
+client-facing host:
 
 ```
+MINIO_SERVER_URL=https://your.host
 TS_MINIO_DOWNLOADURL=https://your.host
 ```
 
-The variable is `${TS_MINIO_DOWNLOADURL:-http://${OCTO_DOMAIN}:${OCTO_MINIO_API_PORT}}`
-in `docker-compose.yaml`, so leaving it unset preserves the legacy
-single-host `host:29000` direct-MinIO mode.
+Leaving either at the legacy `host:port` default while flipping the
+other will produce mixed-content failures (browser blocks HTTP redirect
+from HTTPS page) or SigV4 signature mismatches (signature signed for
+one host:scheme will not validate when MinIO re-emits the request
+against the other). The `docker-compose.yaml` defaults wire both to
+`http://${OCTO_DOMAIN}:${OCTO_MINIO_API_PORT}` so the single-host
+direct-MinIO mode keeps working without either override.
 
 ---
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -226,8 +226,8 @@ path):
 
 ```nginx
 # in docker/nginx/conf.d/octo.conf.template, before `location /`
-location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)(/|$) {
-    proxy_pass http://minio:9000;   # NO trailing slash — preserve SigV4 path
+location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)/ {
+    proxy_pass http://octo_minio_api;   # NO trailing slash — preserve SigV4 path
     proxy_set_header Host $http_host;
     ...
 }
@@ -268,6 +268,18 @@ runs after `minio` becomes healthy and:
    bucket admin privileges.
 5. Sets `anonymous download` on the **content** buckets so the SPA can
    render `<img src=…>` directly (uploads still use signed PUTs):
+
+   > ⚠️ **Security trade-off**: the content buckets below become
+   > **anonymously readable by URL**. This matches OCTO web's
+   > `<img src>` model (the SPA embeds the unsigned `downloadUrl`
+   > returned by `getUploadCredentials` directly — CDN-style, like
+   > most IM apps), but it means image URLs are world-readable
+   > forever once issued. `s3:ListBucket` stays denied and object
+   > keys are high-entropy UUIDs (no enumeration), but anyone who
+   > sees a chat-image URL can fetch it. Deleting a chat message
+   > does not GC the underlying MinIO object. See the PR#22
+   > description for the full threat model and the tracking issue
+   > for switching to signed GET once octo-web supports it.
 
    | Bucket    | Anonymous policy | Why |
    |-----------|------------------|-----|

--- a/docker/README.md
+++ b/docker/README.md
@@ -215,6 +215,36 @@ If you absolutely need every public port to live behind nginx, you'd
 need a SigV4-aware proxy (e.g. one that re-signs each request) — that
 is out of scope for this compose stack.
 
+### Reverse-proxying MinIO behind a host nginx (TLS termination)
+
+When a *host* nginx terminates TLS and proxies `https://your.host/`
+back to the compose stack on `OCTO_HTTP_PORT`, the SPA also needs
+`https://your.host/{bucket}/…` to reach MinIO. The in-compose nginx
+template ships with a bucket-name location that forwards those paths
+to `minio:9000` without rewriting the URI (SigV4 signs the canonical
+path):
+
+```nginx
+# in docker/nginx/conf.d/octo.conf.template, before `location /`
+location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)(/|$) {
+    proxy_pass http://minio:9000;   # NO trailing slash — preserve SigV4 path
+    proxy_set_header Host $http_host;
+    ...
+}
+```
+
+In that topology, override `TS_MINIO_DOWNLOADURL` in `.env` so
+octo-server signs URLs against the user-visible host instead of
+`host:29000`:
+
+```
+TS_MINIO_DOWNLOADURL=https://your.host
+```
+
+The variable is `${TS_MINIO_DOWNLOADURL:-http://${OCTO_DOMAIN}:${OCTO_MINIO_API_PORT}}`
+in `docker-compose.yaml`, so leaving it unset preserves the legacy
+single-host `host:29000` direct-MinIO mode.
+
 ---
 
 ## MinIO bootstrap & credential scoping
@@ -236,6 +266,25 @@ runs after `minio` becomes healthy and:
 4. Pre-creates each whitelisted bucket so the first
    `/api/v1/file/upload` call does not depend on the app user holding
    bucket admin privileges.
+5. Sets `anonymous download` on the **content** buckets so the SPA can
+   render `<img src=…>` directly (uploads still use signed PUTs):
+
+   | Bucket    | Anonymous policy | Why |
+   |-----------|------------------|-----|
+   | `chat`    | `download`       | image / file messages embedded in chat panes |
+   | `file`    | `download`       | generic file attachments |
+   | `moment`  | `download`       | moments feed media |
+   | `sticker` | `download`       | sticker thumbnails |
+   | `chatbg`  | `download`       | chat-background images |
+   | `common`  | `download`       | shared static assets |
+   | `avatar`  | `download`       | user / group avatars |
+   | `report`  | *private*        | audit reports — keep signed |
+   | `group`   | *private*        | group exports — keep signed |
+   | `download`| *private*        | server-staged downloads — keep signed |
+
+   Writes are still gated by the `octo-app` IAM policy; anonymous is
+   GET-only. The `mc anonymous set download` calls are idempotent, so
+   re-running `docker compose up -d` is safe.
 
 `octo-server` then runs with the app credentials only — root credentials
 live exclusively in the `minio-init` job, the `mc` CLI path, and the

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -352,13 +352,39 @@ services:
         # Uploads still require PUT presigned URLs (octo-app IAM scope
         # remains the single write path), so this is a read-side relax
         # only. `mc anonymous set` is idempotent; reruns are safe.
-        # `|| true` swallows transient MinIO API blips during boot — the
-        # next `docker compose up -d` will retry, same shape as the
-        # `mc admin policy attach … || true` line above.
+        #
+        # Fail-closed: we bounded-retry to absorb transient MinIO
+        # restart-storm flakes (3 attempts, 2s back-off), then verify
+        # the policy actually took with `mc anonymous get`. If either
+        # step fails we exit non-zero so the `service_completed_successfully`
+        # gate on octo-server / octo-web prevents the stack from coming
+        # up with a misconfigured MinIO that 403s every <img src=…>.
+        # Earlier `|| true` silently swallowed permission bugs and API
+        # drift — operator saw `minio-init` exit 0 but preview still 403.
+        echo "[minio-init] setting anonymous download on content buckets…"
         for b in chat file moment sticker chatbg common avatar; do
-          mc anonymous set download "local/$$b" >/dev/null 2>&1 || true
+          attempt=1
+          until mc anonymous set download "local/$$b" >/dev/null 2>&1; do
+            if [ "$$attempt" -ge 3 ]; then
+              echo "[minio-init] FATAL: mc anonymous set download local/$$b failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "[minio-init] mc anonymous set on $$b attempt $$attempt failed; retrying in 2s…" >&2
+            attempt=$$((attempt + 1))
+            sleep 2
+          done
+
+          # Verify the policy was actually applied. `mc anonymous get`
+          # prints e.g. "Access permission for `local/chat` is `download`".
+          # We grep for the exact mode to defend against the API silently
+          # no-op'ing (which is what motivated dropping `|| true` here).
+          actual=$$(mc anonymous get "local/$$b" 2>/dev/null | sed -n 's/.*is `\(.*\)`.*/\1/p')
+          if [ "$$actual" != "download" ]; then
+            echo "[minio-init] FATAL: anonymous policy on local/$$b is '$$actual', expected 'download'" >&2
+            exit 1
+          fi
         done
-        echo "[minio-init] anonymous download set on content buckets"
+        echo "[minio-init] anonymous download verified on content buckets"
 
         echo "[minio-init] done"
     volumes:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -352,8 +352,11 @@ services:
         # Uploads still require PUT presigned URLs (octo-app IAM scope
         # remains the single write path), so this is a read-side relax
         # only. `mc anonymous set` is idempotent; reruns are safe.
+        # `|| true` swallows transient MinIO API blips during boot — the
+        # next `docker compose up -d` will retry, same shape as the
+        # `mc admin policy attach … || true` line above.
         for b in chat file moment sticker chatbg common avatar; do
-          mc anonymous set download "local/$$b" >/dev/null
+          mc anonymous set download "local/$$b" >/dev/null 2>&1 || true
         done
         echo "[minio-init] anonymous download set on content buckets"
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -344,6 +344,19 @@ services:
           mc mb --ignore-existing "local/$$b" >/dev/null
         done
 
+        # OCTO IM semantics: chat/file/moment/sticker/chatbg/common/avatar
+        # are content buckets shared among group members. Anonymous GET
+        # (`download`) lets the SPA render <img src=...> without
+        # presigning every URL. report/group/download stay private —
+        # they hold sensitive payloads (audit reports, member exports).
+        # Uploads still require PUT presigned URLs (octo-app IAM scope
+        # remains the single write path), so this is a read-side relax
+        # only. `mc anonymous set` is idempotent; reruns are safe.
+        for b in chat file moment sticker chatbg common avatar; do
+          mc anonymous set download "local/$$b" >/dev/null
+        done
+        echo "[minio-init] anonymous download set on content buckets"
+
         echo "[minio-init] done"
     volumes:
       - ./configs/minio-octo-app-policy.json:/etc/minio/octo-app-policy.json:ro
@@ -501,7 +514,15 @@ services:
       # --- at startup. The MinIO API port is bound to 0.0.0.0 by
       # --- default (see the `minio` service block) so this URL is
       # --- reachable from the same hosts that hit the nginx vhost.
-      TS_MINIO_DOWNLOADURL: "http://${OCTO_DOMAIN:-octo.local}:${OCTO_MINIO_API_PORT:-29000}"
+      # --- TS_MINIO_DOWNLOADURL is overridable via .env so operators
+      # --- who terminate TLS on a host nginx (and proxy /chat,
+      # --- /file, /moment, ... back to the in-compose nginx) can
+      # --- point clients at the public https://host URL instead of
+      # --- the host:port direct-MinIO form. The default keeps the
+      # --- legacy direct-MinIO behaviour for the OOTB single-host
+      # --- profile. Either form must still be host-reachable and
+      # --- preserve the canonical SigV4 path (no path rewrite).
+      TS_MINIO_DOWNLOADURL: "${TS_MINIO_DOWNLOADURL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_MINIO_API_PORT:-29000}}"
       # --- octo-server's own external URL (the value it returns to
       # --- clients in places that need an absolute URL — e.g. login
       # --- redirects, OIDC callback hints, public asset links). The

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -217,8 +217,14 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
     # `for b in …` in the `minio-init` service so any new bucket added
     # there has to be added here too. Placed BEFORE `location /` so
     # the regex wins over the SPA catch-all.
-    location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)(/|$) {
-        proxy_pass         http://minio:9000;
+    #
+    # Regex deliberately requires a trailing `/` after the bucket name
+    # (not `(/|$)`): presigned URLs are always `/{bucket}/{key}?X-Amz-…`
+    # so the `/` is guaranteed, while SPA history routes like `/chat`,
+    # `/group`, `/moment` (no trailing slash) must fall through to the
+    # `location /` SPA catch-all instead of being routed at MinIO.
+    location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)/ {
+        proxy_pass         http://octo_minio_api;
         proxy_http_version 1.1;
         proxy_set_header   Host              $http_host;
         proxy_set_header   X-Real-IP         $remote_addr;
@@ -227,7 +233,6 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
         proxy_set_header   Connection        "";
         proxy_request_buffering off;
         proxy_buffering off;
-        client_max_body_size 1000m;
         proxy_read_timeout 600s;
     }
 
@@ -362,10 +367,12 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #     }
 #
 #     # MinIO S3 bucket-name routing — see the HTTP server block above
-#     # for the rationale. Whitelist must stay in sync with the
-#     # `minio-init` `for b in …` list. Must precede `location /`.
-#     location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)(/|$) {
-#         proxy_pass         http://minio:9000;
+#     # for the rationale (including why the regex ends at `/` instead
+#     # of `(/|$)`: SPA history routes like `/chat`, `/group`, `/moment`
+#     # must fall through to `location /`). Whitelist must stay in sync
+#     # with the `minio-init` `for b in …` list. Must precede `location /`.
+#     location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)/ {
+#         proxy_pass         http://octo_minio_api;
 #         proxy_http_version 1.1;
 #         proxy_set_header   Host              $http_host;
 #         proxy_set_header   X-Real-IP         $remote_addr;
@@ -374,7 +381,6 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #         proxy_set_header   Connection        "";
 #         proxy_request_buffering off;
 #         proxy_buffering off;
-#         client_max_body_size 1000m;
 #         proxy_read_timeout 600s;
 #     }
 #

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -208,6 +208,29 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 ';
     }
 
+    # MinIO S3 bucket-name routing (presigned URLs, no path rewrite).
+    # The OCTO web SPA and mobile clients receive S3 presigned URLs of
+    # the form `/{bucket}/{object}?X-Amz-…`. SigV4 signs the canonical
+    # request path, so the proxy MUST forward the URI unchanged — that
+    # means no trailing slash on `proxy_pass` and the original `Host`
+    # header (with port) preserved. The bucket whitelist below mirrors
+    # `for b in …` in the `minio-init` service so any new bucket added
+    # there has to be added here too. Placed BEFORE `location /` so
+    # the regex wins over the SPA catch-all.
+    location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)(/|$) {
+        proxy_pass         http://minio:9000;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $http_host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Connection        "";
+        proxy_request_buffering off;
+        proxy_buffering off;
+        client_max_body_size 1000m;
+        proxy_read_timeout 600s;
+    }
+
     location / {
         proxy_pass         http://web/;
         proxy_http_version 1.1;
@@ -336,6 +359,23 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #     location = /_octo_up {
 #         default_type text/html;
 #         return 200 '<!doctype html><html><body><h1>OCTO Server (HTTPS)</h1></body></html>';
+#     }
+#
+#     # MinIO S3 bucket-name routing — see the HTTP server block above
+#     # for the rationale. Whitelist must stay in sync with the
+#     # `minio-init` `for b in …` list. Must precede `location /`.
+#     location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)(/|$) {
+#         proxy_pass         http://minio:9000;
+#         proxy_http_version 1.1;
+#         proxy_set_header   Host              $http_host;
+#         proxy_set_header   X-Real-IP         $remote_addr;
+#         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+#         proxy_set_header   X-Forwarded-Proto $scheme;
+#         proxy_set_header   Connection        "";
+#         proxy_request_buffering off;
+#         proxy_buffering off;
+#         client_max_body_size 1000m;
+#         proxy_read_timeout 600s;
 #     }
 #
 #     location / {

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -218,12 +218,16 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
     # there has to be added here too. Placed BEFORE `location /` so
     # the regex wins over the SPA catch-all.
     #
-    # Regex deliberately requires a trailing `/` after the bucket name
-    # (not `(/|$)`): presigned URLs are always `/{bucket}/{key}?X-Amz-…`
-    # so the `/` is guaranteed, while SPA history routes like `/chat`,
-    # `/group`, `/moment` (no trailing slash) must fall through to the
-    # `location /` SPA catch-all instead of being routed at MinIO.
-    location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)/ {
+    # Regex deliberately requires a trailing `/` plus at least one
+    # character (`.+`) after the bucket name (not `(/|$)` and not bare
+    # `/`): presigned URLs are always `/{bucket}/{key}?X-Amz-…` so the
+    # `/<key>` segment is guaranteed, while SPA history routes like
+    # `/chat`, `/group`, `/moment` (no trailing slash) AND bare
+    # `/chat/`, `/group/` (SPA history routes that happen to keep a
+    # trailing slash) must fall through to the `location /` SPA
+    # catch-all instead of being routed at MinIO — otherwise an SPA
+    # refresh on `/chat/` would render MinIO's 404 XML.
+    location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)/.+ {
         proxy_pass         http://octo_minio_api;
         proxy_http_version 1.1;
         proxy_set_header   Host              $http_host;
@@ -367,11 +371,13 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #     }
 #
 #     # MinIO S3 bucket-name routing — see the HTTP server block above
-#     # for the rationale (including why the regex ends at `/` instead
-#     # of `(/|$)`: SPA history routes like `/chat`, `/group`, `/moment`
-#     # must fall through to `location /`). Whitelist must stay in sync
-#     # with the `minio-init` `for b in …` list. Must precede `location /`.
-#     location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)/ {
+#     # for the rationale (including why the regex ends at `/.+` instead
+#     # of `(/|$)` or bare `/`: presigned URLs always carry a key, while
+#     # SPA history routes like `/chat`, `/group`, `/moment` and bare
+#     # `/chat/` must fall through to `location /`). Whitelist must stay
+#     # in sync with the `minio-init` `for b in …` list. Must precede
+#     # `location /`.
+#     location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)/.+ {
 #         proxy_pass         http://octo_minio_api;
 #         proxy_http_version 1.1;
 #         proxy_set_header   Host              $http_host;


### PR DESCRIPTION
Fixes #21

## ⚠️ Security trade-off — anonymous read on content buckets

This PR makes `chat`, `file`, `moment`, `sticker`, `chatbg`, `common`, `avatar` MinIO buckets anonymously readable (GET-only) by URL. This matches the OCTO upstream SPA design (octo-web embeds the unsigned `downloadUrl` returned by `getUploadCredentials` directly as `<img src>` / `message.url` — confirmed by SPA bundle inspection of `index-DdNqP_nn.js`:

```js
y.url = O.downloadUrl;          // O is uploadCredentials response
y.remoteUrl = O.downloadUrl;
```

), and is the CDN-style model most IM apps use.

**Threat model**:
- ✅ `s3:ListBucket` denied on the bucket whitelist — anonymous users cannot enumerate the bucket
- ✅ Object keys are high-entropy UUID-shaped — brute-force enumeration is not realistic
- ✅ Writes still require signed PUT via the `octo-app` IAM credential (write path unchanged)
- ⚠️ Anyone with the object URL can fetch it (no membership / TTL check on the GET)
- ⚠️ Sharing a chat image URL externally effectively makes it public
- ⚠️ Referer leakage to third-party domains exposes the URL
- ⚠️ Deleting a chat message does NOT GC the underlying MinIO object — the URL stays valid

**If this trade-off is unacceptable** for your deployment: leave anonymous off and follow up with octo-web to route image preview through `/v1/file/download/url` (signed GET, 30-min TTL). Tracked as a separate follow-up (TBD).

`report`, `group`, `download` stay private (sensitive payloads — audit reports, member exports, server-staged downloads).

---

After PR #18 + PR #20 landed, a true from-zero E2E run (OOTB compose + host-nginx TLS termination in front) found image upload + preview fully broken. Three independent gaps, all in this repo:

1. **`TS_MINIO_DOWNLOADURL` was hard-coded** to `http://${OCTO_DOMAIN}:${OCTO_MINIO_API_PORT}`, no `.env` override.
2. **The docker nginx template had no bucket-name routing**, so `/chat/…`, `/file/…`, etc. went to the SPA's `location /` and 404'd.
3. **`minio-init` did not set anonymous download policy** on the content buckets, so `<img src=/chat/...>` returned 403 even when nginx routed correctly.

## Fixes (single PR, three coordinated changes)

### a) `docker/docker-compose.yaml` — env override (1 line)

```yaml
TS_MINIO_DOWNLOADURL: "${TS_MINIO_DOWNLOADURL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_MINIO_API_PORT:-29000}}"
```

Operators behind a host-nginx TLS terminator can now set `TS_MINIO_DOWNLOADURL=https://your.host` in `.env`; default OOTB behaviour is unchanged.

### b) `docker/nginx/conf.d/octo.conf.template` — bucket-name routing

Added in both the HTTP server block and the commented HTTPS template, placed before `location /`:

```nginx
location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)/ {
    proxy_pass         http://octo_minio_api;   # no trailing slash → preserve SigV4 path
    proxy_set_header   Host              $http_host;
    ...
    proxy_request_buffering off;
    proxy_buffering off;
}
```

Whitelist matches the `for b in …` list in `minio-init`.

> **R2 update**: the regex was tightened from `(/|$)` to `/` so SPA history routes like `/chat`, `/group`, `/moment` (no trailing slash) fall through to the SPA catch-all. Presigned URLs always carry a key after the bucket name (`/{bucket}/{key}?X-Amz-…`), so the `/` is guaranteed for the legitimate MinIO traffic this location is meant to serve. The location now uses the `octo_minio_api` upstream (keepalive reused with `/minio/`) and the duplicate `client_max_body_size 1000m;` was dropped — it is already set at server level and inherited.

### c) `docker/docker-compose.yaml` — minio-init anonymous policy

After the bucket-create loop:

```bash
for b in chat file moment sticker chatbg common avatar; do
  mc anonymous set download "local/$b" >/dev/null 2>&1 || true
done
```

`report` / `group` / `download` stay private (sensitive payloads). PUT continues to require signed URLs — write path (`octo-app` IAM policy) untouched. `mc anonymous set` is idempotent; re-running `docker compose up -d` is safe. R2: the `|| true` guards transient MinIO API blips during boot, same shape as `mc admin policy attach … || true` already in the same script.

### d) README

Added a bucket-policy table under "MinIO bootstrap & credential scoping" and a new "Reverse-proxying MinIO behind a host nginx (TLS termination)" section. R2: added an explicit security-trade-off callout above the anonymous policy table that mirrors the threat model at the top of this PR.

## From-zero E2E verification (just run, all green)

```bash
cd docker
docker compose --profile summary down -v
rm .env
cd ..
./setup.sh --non-interactive --domain test.local --ip 127.0.0.1
cd docker
docker compose up -d
# wait for healthchecks
docker compose ps     # 9/9 healthy
```

Result:

```
octo-admin     ...   Up (healthy)
octo-matter    ...   Up (healthy)
octo-minio     ...   Up (healthy)
octo-mysql     ...   Up (healthy)
octo-nginx     ...   Up (healthy)
octo-redis     ...   Up (healthy)
octo-server    ...   Up (healthy)
octo-web       ...   Up (healthy)
octo-wukongim  ...   Up (healthy)
```

### PUT /chat/ routing (expect 403 from MinIO — proves nginx → MinIO path is wired)

```
$ curl -i -X PUT http://localhost:28080/chat/test-routing --data 'x'
HTTP/1.1 403 Forbidden
Server: nginx
Content-Type: application/xml
X-Amz-Request-Id: 18B004FB2564747E
...
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code><Message>Access Denied.</Message><Key>test-routing</Key><BucketName>chat</BucketName><Resource>/chat/test-routing</Resource>...</Error>
```

✅ `BucketName>chat<` + `X-Amz-Request-Id` ⇒ response came from MinIO, not nginx 405.

### Anonymous policy on content buckets

```
$ docker exec octo-minio mc alias set local http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
$ for b in chat file moment sticker chatbg common avatar; do
    docker exec octo-minio mc anonymous get local/$b
  done
Access permission for `local/chat`    is `download`
Access permission for `local/file`    is `download`
Access permission for `local/moment`  is `download`
Access permission for `local/sticker` is `download`
Access permission for `local/chatbg`  is `download`
Access permission for `local/common`  is `download`
Access permission for `local/avatar`  is `download`

$ for b in report group download; do docker exec octo-minio mc anonymous get local/$b; done
Access permission for `local/report`   is `private`
Access permission for `local/group`    is `private`
Access permission for `local/download` is `private`
```

### Anonymous GET via nginx (real preview path)

```
$ docker exec octo-minio sh -c 'echo hello-test > /tmp/p.txt && mc cp /tmp/p.txt local/chat/preview.txt'
$ curl -i http://localhost:28080/chat/preview.txt
HTTP/1.1 200 OK
Content-Type: text/plain
Content-Length: 11
ETag: "3bf4f8bc1a406496c1a3d0021b2ae3e7"
...
hello-test
```

```
$ docker exec octo-minio sh -c 'mc cp /tmp/p.txt local/report/p2.txt'
$ curl -i http://localhost:28080/report/p2.txt
HTTP/1.1 403 Forbidden
```

✅ Public buckets serve to anonymous browsers via the SPA host; private buckets remain locked. End-to-end upload + preview is unblocked.

### Compose + nginx syntax

```
$ docker compose -f docker/docker-compose.yaml config --quiet
(exit 0)
$ nginx -t      # against rendered template
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
```

## Out of scope

- ❌ no octo-server PR#65 changes (upstream)
- ❌ no octo-web image rebuild — switching SPA `<img src>` to signed GET is tracked as a separate follow-up (see threat-model section above)
- ❌ no host-nginx vhost template (user-supplied)
- ❌ no MinIO API bind change (kept on 0.0.0.0 for legacy host:port mode)

## Review tier

`high-risk` — nginx + minio-init + compose change in coordination; regression risk is non-trivial.
