### PR TITLE
fix(docker): minio-init verify uses grep instead of missing sed (R4 hotfix)

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -374,15 +374,25 @@ services:
             sleep 2
           done
 
-          # Verify the policy was actually applied. `mc anonymous get`
-          # prints e.g. "Access permission for `local/chat` is `download`".
-          # We grep for the exact mode to defend against the API silently
-          # no-op'ing (which is what motivated dropping `|| true` here).
-          actual=$$(mc anonymous get "local/$$b" 2>/dev/null | sed -n 's/.*is `\(.*\)`.*/\1/p')
-          if [ "$$actual" != "download" ]; then
-            echo "[minio-init] FATAL: anonymous policy on local/$$b is '$$actual', expected 'download'" >&2
-            exit 1
-          fi
+          # Verify the policy was actually applied. The minio/mc image
+          # is distroless-style and ships **no text-processing tools** —
+          # no sed, no awk, no grep, no jq (R3 used sed → exit 127; an
+          # earlier version of this R4 hotfix tried grep → also 127).
+          # The shell is bash 5.x though, so we ask mc for one-line JSON
+          # via `--json` and use a bash `case` glob against the literal
+          # `"permission":"download"` substring. This defends against
+          # the API silently no-op'ing (the original motivation for
+          # dropping `|| true` in R3) without depending on any external
+          # binary outside the mc image itself.
+          json=$$(mc anonymous get --json "local/$$b" 2>/dev/null)
+          case "$$json" in
+            *'"permission":"download"'*)
+              ;;
+            *)
+              echo "[minio-init] FATAL: anonymous policy on local/$$b verify failed: $$json" >&2
+              exit 1
+              ;;
+          esac
         done
         echo "[minio-init] anonymous download verified on content buckets"
 


### PR DESCRIPTION
## Root cause

R3 (PR #22, merged as `b2cd0f4`) tightened the anonymous-policy verification in `minio-init` to fail-closed by parsing `mc anonymous get` output with `sed`:

```bash
actual=$(mc anonymous get "local/$b" 2>/dev/null | sed -n 's/.*is `\(.*\)`.*/\1/p')
```

The `minio/mc:RELEASE.2025-04-16T18-13-26Z` image is distroless-style. Inspecting `/bin` and `/usr/bin` shows it ships **no `sed`**, and additionally no `awk`, no `grep`, no `jq` — only bash 5.x plus a handful of coreutils (`cat`, `cut`, `tr`, `head`, `tail`, `wc`, etc.). The verify pipeline therefore aborts:

```
/bin/sh: line 112: sed: command not found
service "minio-init" didn't complete successfully: exit 127
```

`octo-server` then sits in `starting` indefinitely because its `service_completed_successfully` gate on `minio-init` never fires.

## Fix

Switch verification to `mc anonymous get --json` and substring-match the literal `"permission":"download"` with a bash `case` glob:

```bash
json=$(mc anonymous get --json "local/$b" 2>/dev/null)
case "$json" in
  *'"permission":"download"'*) ;;
  *)
    echo "[minio-init] FATAL: anonymous policy on local/$b verify failed: $json" >&2
    exit 1
    ;;
esac
```

- No external binary required (bash + `mc` only — both already in the image).
- R3 fail-closed posture preserved: if the API silently no-ops or the field is absent, we still exit non-zero.
- Original issue body suggested `grep -q` as the simpler path; **also doesn't work** — busybox `grep` is not in the mc image either. This was confirmed empirically (first hotfix attempt got `grep: command not found`), so the JSON `case` glob is the actual minimum-dependency fix.

## Before / after — measured `minio-init` logs

**Before this PR (`main` @ b2cd0f4):**

```
octo-minio-init  | [minio-init] (re)installing octo-app policy
octo-minio-init  | Created policy `octo-app` successfully.
octo-minio-init  | [minio-init] attaching octo-app policy to octo-app
octo-minio-init  | Attached Policies: [octo-app]
octo-minio-init  | To User: octo-app
octo-minio-init  | [minio-init] setting anonymous download on content buckets…
octo-minio-init  | /bin/sh: line 112: sed: command not found
service "minio-init" didn't complete successfully: exit 127
```

`docker compose ps minio-init` → `Exited (127)`.

**After this PR (this branch):**

```
octo-minio-init  | [minio-init] waiting for MinIO root alias…
octo-minio-init  | [minio-init] ensuring application user exists
octo-minio-init  | [minio-init] (re)installing octo-app policy
octo-minio-init  | Created policy `octo-app` successfully.
octo-minio-init  | [minio-init] attaching octo-app policy to octo-app
octo-minio-init  | Attached Policies: [octo-app]
octo-minio-init  | To User: octo-app
octo-minio-init  | [minio-init] setting anonymous download on content buckets…
octo-minio-init  | [minio-init] anonymous download verified on content buckets
octo-minio-init  | [minio-init] done
```

`docker compose ps -a minio-init` → `Exited (0)`. Full stack reaches **9/9 healthy**:

```
NAME            SERVICE       STATUS
octo-admin      admin         Up (healthy)
octo-matter     matter        Up (healthy)
octo-minio      minio         Up (healthy)
octo-mysql      mysql         Up (healthy)
octo-nginx      nginx         Up (healthy)
octo-redis      redis         Up (healthy)
octo-server     octo-server   Up (healthy)
octo-web        web           Up (healthy)
octo-wukongim   wukongim      Up (healthy)
```

## Validation

From-zero E2E on a clean checkout of this branch:

```bash
docker compose --profile summary down -v
rm docker/.env
./setup.sh --non-interactive
cd docker && docker compose up -d
# minio-init exits 0; rerun `up -d` once after healthchecks stabilise
docker compose up -d
docker compose ps   # 9/9 healthy
```

## Scope / non-scope

- ✅ Single-file change in `docker/docker-compose.yaml` (+19/-9, comments included).
- ❌ R3's fail-closed design is unchanged.
- ❌ Retry / back-off logic is unchanged.
- ❌ nginx and README are untouched.

## Review tier

`low-risk` — single-file shell substitution with measured before/after.

Fixes #23
Refs #21, #22
