### PR TITLE
feat(ootb): isolate volumes/containers + nginx upstream resilience (Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # OCTO Deployment
 
-Kubernetes deployment manifests for the [OCTO](https://github.com/Mininglamp-OSS) platform.
+**The official OOTB ("out of the box") deployment for OCTO** — both the
+single-node Docker Compose stack under [`docker/`](./docker/) and the
+multi-node Kubernetes manifests under [`kustomize/`](./kustomize/) for
+the [OCTO](https://github.com/Mininglamp-OSS) platform.
+
+This repository is the single source of truth for OCTO deployment. The
+deployment artefacts that previously lived inside `Mininglamp-OSS/octo-server`
+(`docker/octo/`, `docker/tsdd/`) are now retired; consume them from
+here instead.
 
 ---
 
@@ -97,6 +105,27 @@ kustomize/
 ```
 
 ## Quick Start
+
+> **For single-node Docker Compose evaluation, go to
+> [`docker/README.md`](./docker/README.md)** — it owns the prerequisites
+> checklist (Docker daemon, ports, RAM/disk, image-pull network access),
+> the `setup.sh` one-liner, and the pre-flight warning for hosts that
+> already run another OCTO stack.
+>
+> The walkthrough below is for the **Kubernetes / kustomize** path.
+
+### Prerequisites (Kubernetes path)
+
+- A Kubernetes cluster you can `kubectl apply` against (≥ 1 worker
+  node; production overlay assumes a multi-node cluster).
+- `kubectl` ≥ 1.27 on your shell with kubeconfig pointing at the
+  target cluster.
+- An Ingress controller (NGINX / Traefik / cloud-managed) — this repo
+  does NOT ship one; see the open item below.
+- External infrastructure already provisioned: MySQL 8 (three DBs:
+  `octo`, `octo_matter`, `octo_summary`), Redis 7, WuKongIM ≥ v2,
+  and an S3-compatible object store. The base manifests reference
+  these via Secrets / ConfigMaps and assume you bring them yourself.
 
 Namespace is **not** hardcoded — specify it on the CLI.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,7 +16,96 @@ DB / cache / object store.
 
 ---
 
+## ⚠ Pre-flight: existing OCTO deployments on this host
+
+> **READ THIS BEFORE EVERY `docker compose up -d` / `docker compose down -v`
+> if there is any chance another OCTO stack already lives on this host.**
+
+`docker-compose.yaml` pins the Compose project name to `octo` (top-level
+`name: octo`). That stabilises the in-stack DNS names (`mysql`, `redis`,
+`octo-server`, …) so the rest of the config can reference them by literal
+hostname. The side effect is that **two independent clones of this repo
+on the same host default to the same project name** — meaning a
+`docker compose down -v` from a "fresh" clone in `/tmp/foo` will erase the
+named volumes (and therefore the MySQL data, MinIO objects, WuKongIM
+message queues, etc.) belonging to a production clone in
+`/opt/octo-deployment`. That is exactly how `im-test` lost its entire
+user database on 2026-05-16 (INCIDENT-2026-05-16-001).
+
+To make this safe, the named volumes are now templated on
+`${COMPOSE_PROJECT_NAME:-octo}` (see the `volumes:` block in
+`docker-compose.yaml`). An operator who wants a second, isolated stack
+on a host that already runs OCTO only needs to override the project
+name before bringing it up:
+
+```bash
+# Before bringing up a SECOND stack on a host that already runs OCTO:
+export COMPOSE_PROJECT_NAME=octo-fz   # any unique suffix
+./setup.sh --non-interactive --domain octo-fz.local --ip 127.0.0.1
+cd docker
+docker compose up -d                  # volumes: octo-fz-mysql-data, …
+```
+
+The two stacks then have fully separate Docker volumes
+(`octo-mysql-data` vs `octo-fz-mysql-data`), networks
+(`octo_octo-net` vs `octo-fz_octo-net`), and container names
+(`octo-mysql-1` vs `octo-fz-mysql-1`). A `down -v` on either one only
+removes its own state.
+
+### Before any `docker compose down -v` — verify what you are about to delete
+
+`down -v` is destructive and irreversible. Run these two probes first
+and confirm the output only references the stack you mean to wipe:
+
+```bash
+# 1. List Docker volumes that would be removed (must all belong to YOUR project)
+docker compose config --volumes        # the volume keys this file declares
+docker volume ls | grep -E '(^|-)octo' # the actual on-disk volumes touched
+
+# 2. List containers in the OCTO namespace (must all belong to YOUR project)
+docker ps --filter 'name=octo' --format '{{.Names}}'
+
+# 3. If anything in (1) or (2) is NOT yours, STOP. Set
+#    COMPOSE_PROJECT_NAME to your stack's suffix and re-check:
+#       COMPOSE_PROJECT_NAME=octo-fz docker compose config --volumes
+#       COMPOSE_PROJECT_NAME=octo-fz docker ps
+```
+
+`setup.sh` runs an equivalent check at the top of each invocation and
+warns when it finds existing OCTO containers / volumes on the host.
+The warning is informational, NOT a block — you still have to be the
+one who chooses the project name. Treat the prompt as the "did you
+mean to do this on this host?" gate.
+
+> 💡 **The 100% safe option for a clean from-zero E2E test is an
+> ephemeral VM or a host with no existing OCTO deployment.** Volume
+> isolation via `COMPOSE_PROJECT_NAME` protects against `down -v`
+> collisions, but a single typo (`COMPOSE_PROJECT_NAME=octo` instead of
+> `octo-fz`) is enough to break that protection. When in doubt, spin up
+> a throwaway machine.
+
+---
+
 ## Quick start
+
+### Prerequisites checklist
+
+- Linux or macOS host with `bash` ≥4, `openssl`, and either the Docker
+  Compose v2 plugin (`docker compose`) or the standalone `docker-compose`
+  binary on `$PATH`.
+- The Docker daemon is running and the invoking user can reach it
+  (`docker info` succeeds without `sudo`).
+- Ports `28080` (nginx HTTP) and `28083` (octo-web) free on the host,
+  plus `127.0.0.1:28081 / :28082 / :28086 / :23306 / :26379 / :29000 /
+  :29001` for the loopback-bound backing services. Override the port
+  numbers via `OCTO_*_PORT` in `docker/.env` if any of those clash.
+- ≥ 4 GiB RAM, ≥ 10 GiB free disk for the named volumes.
+- Outbound network access to `docker.io` (or a configured mirror) for
+  pulling the `mininglamposs/*`, `mysql:8`, `redis:7-alpine`,
+  `minio/minio`, `wukongim/wukongim`, and `nginx:1.27-alpine` images.
+- **If another OCTO stack already runs on this host:** read the
+  pre-flight section above and decide on a non-default
+  `COMPOSE_PROJECT_NAME` before continuing.
 
 Recommended (interactive setup):
 
@@ -52,6 +141,7 @@ Add an `/etc/hosts` entry for `octo.local` if you keep the default domain.
 Tear-down (drops the named volumes too — destructive):
 
 ```bash
+# ⚠ Read "Pre-flight: existing OCTO deployments on this host" above first.
 docker compose down -v
 ```
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -43,14 +43,32 @@ name before bringing it up:
 export COMPOSE_PROJECT_NAME=octo-fz   # any unique suffix
 ./setup.sh --non-interactive --domain octo-fz.local --ip 127.0.0.1
 cd docker
-docker compose up -d                  # volumes: octo-fz-mysql-data, …
+docker compose up -d                  # volumes: octo-fz_mysql-data, …
 ```
 
 The two stacks then have fully separate Docker volumes
-(`octo-mysql-data` vs `octo-fz-mysql-data`), networks
+(`octo_mysql-data` vs `octo-fz_mysql-data`), networks
 (`octo_octo-net` vs `octo-fz_octo-net`), and container names
 (`octo-mysql-1` vs `octo-fz-mysql-1`). A `down -v` on either one only
 removes its own state.
+
+> ⚠️ **Running both stacks live at the same time also requires unique
+> host ports + subnet.** `COMPOSE_PROJECT_NAME` only isolates the
+> Docker objects (volumes, networks, container names); the compose
+> file still publishes the same host ports
+> (`OCTO_HTTP_PORT`, `OCTO_HTTPS_PORT`, `OCTO_MYSQL_PORT`,
+> `OCTO_REDIS_PORT`, `OCTO_MINIO_API_PORT`, `OCTO_MINIO_CONSOLE_PORT`,
+> `OCTO_WUKONGIM_PORT`, `OCTO_WUKONGIM_WS_PORT`,
+> `OCTO_WUKONGIM_TCP_PORT`, `OCTO_SUMMARY_PORT`) and uses the same
+> default bridge subnet (`OCTO_NETWORK_SUBNET=172.28.0.0/24`). Two
+> live stacks on one host will fail with port-bind / IPAM-overlap
+> errors unless the second stack's `.env` also overrides every
+> `*_PORT` it cares about and gives `OCTO_NETWORK_SUBNET` a non-
+> overlapping CIDR (for example `172.29.0.0/24`). If your use case
+> is "one stack live at a time, the second clone is just for a
+> from-zero verification run", that is fine — bring down stack #1
+> (`docker compose stop` — do NOT `down -v`) before bringing stack #2
+> up, and the isolated volumes keep each stack's data safe.
 
 ### Before any `docker compose down -v` — verify what you are about to delete
 
@@ -60,7 +78,7 @@ and confirm the output only references the stack you mean to wipe:
 ```bash
 # 1. List Docker volumes that would be removed (must all belong to YOUR project)
 docker compose config --volumes        # the volume keys this file declares
-docker volume ls | grep -E '(^|-)octo' # the actual on-disk volumes touched
+docker volume ls | grep -E '^octo([-_]|$)' # the actual on-disk volumes touched
 
 # 2. List containers in the OCTO namespace (must all belong to YOUR project)
 docker ps --filter 'name=octo' --format '{{.Names}}'
@@ -605,6 +623,34 @@ every public-facing port (`OCTO_HTTP_PORT`, `OCTO_SERVER_PORT`,
 `docker/nginx/empty-default.conf` is mounted on top of the image's
 `default.conf` so the OCTO vhost wins. If you have customised the
 nginx mount, make sure that override is preserved.
+
+### After recreating `octo-server` or `wukongim`, nginx returns 502 until reload
+
+The four core upstreams that ship with the stack
+(`octo_api`, `octo_ws`, `octo_minio_api` → `octo-server` /
+`wukongim`) intentionally keep their `upstream {}` blocks so the
+nginx keepalive pools stay intact for steady-state traffic. The
+trade-off is that nginx resolves those hostnames once at worker
+boot and caches the IP for the life of the worker — so a targeted
+`docker compose up -d --force-recreate octo-server` or
+`--force-recreate wukongim` (image bump, config edit, IM-server
+version pin, etc.) leaves nginx routing to the dead IP until the
+worker is bounced.
+
+The leaf upstreams (`admin`, `web`, `matter`, `summary-api`) use
+the variable + Docker DNS resolver pattern and recover on their
+own. For the four core upstreams, after recreating
+`octo-server` or `wukongim` run:
+
+```bash
+docker compose exec nginx nginx -s reload
+```
+
+Reload is online (no dropped connections) and takes <1s. This is
+not needed when the *full* stack is restarted via
+`docker compose up -d` without `--force-recreate` on a specific
+service, because nginx itself is recreated alongside the dependency
+and re-resolves at boot.
 
 ### Image upload returns 500 / "PresignedPutter is nil"
 

--- a/docker/configs/wk.yaml
+++ b/docker/configs/wk.yaml
@@ -1,6 +1,6 @@
 # -----------------------------------------------------------------------------
 # WuKongIM configuration for the OCTO stack.
-# Mounted at /root/wukongim/wk.yaml inside the octo-wukongim container.
+# Mounted at /root/wukongim/wk.yaml inside the `wukongim` service container.
 # -----------------------------------------------------------------------------
 
 # debug | release | bench

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -44,15 +44,17 @@ volumes:
   # Docker volume objects. That is exactly how INCIDENT-2026-05-16-001
   # erased im-test's entire user table during a routine from-zero test.
   #
-  # Setting `name: ${COMPOSE_PROJECT_NAME:-octo}-<vol>` makes the volume name
-  # follow the COMPOSE_PROJECT_NAME env var:
-  #   - default (`COMPOSE_PROJECT_NAME` unset): `octo-mysql-data`, etc. —
-  #     preserves the existing on-disk volume names for users who already
-  #     have a running stack, so this change does NOT trigger a data
-  #     migration on upgrade.
+  # Setting `name: ${COMPOSE_PROJECT_NAME:-octo}_<vol>` (note the UNDERSCORE
+  # separator — see below) makes the volume name follow the
+  # COMPOSE_PROJECT_NAME env var:
+  #   - default (`COMPOSE_PROJECT_NAME` unset): `octo_mysql-data`, etc. —
+  #     BIT-FOR-BIT identical to the names Compose was already producing
+  #     for `name: octo` on `main`, so existing on-disk volumes remain
+  #     attached and this change does NOT trigger a data migration on
+  #     upgrade.
   #   - operator runs `COMPOSE_PROJECT_NAME=octo-fz docker compose up -d`
-  #     on a second clone: volumes become `octo-fz-mysql-data`, etc., fully
-  #     isolated from the original `octo-*` set. `down -v` on either stack
+  #     on a second clone: volumes become `octo-fz_mysql-data`, etc., fully
+  #     isolated from the original `octo_*` set. `down -v` on either stack
   #     only touches its own volumes.
   #
   # IMPORTANT: changing `name: octo` at the top of this file to
@@ -62,18 +64,26 @@ volumes:
   # We deliberately keep the project hardcoded to `octo` and only allow the
   # volume names to drift, so the existing on-disk volumes remain reachable
   # for everyone on `main`.
+  #
+  # SEPARATOR NOTE: Compose v2 names project-scoped volumes / networks with an
+  # UNDERSCORE between project and key (`<project>_<key>`) — that legacy
+  # behavior was kept from Compose v1, even though container names switched
+  # to `-`. We mirror the underscore here so the explicit `name:` matches
+  # exactly what Compose would have generated for the default project on
+  # `main`. Do NOT change `_` to `-` here; that would silently re-alias every
+  # named volume on disk on the next `up -d` and look like data loss.
   mysql-data:
-    name: ${COMPOSE_PROJECT_NAME:-octo}-mysql-data
+    name: ${COMPOSE_PROJECT_NAME:-octo}_mysql-data
   redis-data:
-    name: ${COMPOSE_PROJECT_NAME:-octo}-redis-data
+    name: ${COMPOSE_PROJECT_NAME:-octo}_redis-data
   minio-data:
-    name: ${COMPOSE_PROJECT_NAME:-octo}-minio-data
+    name: ${COMPOSE_PROJECT_NAME:-octo}_minio-data
   wukongim-data:
-    name: ${COMPOSE_PROJECT_NAME:-octo}-wukongim-data
+    name: ${COMPOSE_PROJECT_NAME:-octo}_wukongim-data
   server-logs:
-    name: ${COMPOSE_PROJECT_NAME:-octo}-server-logs
+    name: ${COMPOSE_PROJECT_NAME:-octo}_server-logs
   nginx-logs:
-    name: ${COMPOSE_PROJECT_NAME:-octo}-nginx-logs
+    name: ${COMPOSE_PROJECT_NAME:-octo}_nginx-logs
 
 services:
   # ---------------------------------------------------------------------------
@@ -505,15 +515,23 @@ services:
       timeout: 5s
       retries: 12
       # Bumped from 20s -> 40s after the 2026-05-16 from-zero E2E showed
-      # octo-server's `depends_on: wukongim service_healthy` could fire
-      # before WuKongIM finished its in-container init within the previous
-      # 20s window. WuKongIM's first boot writes the cluster metadata
-      # under /root/wukongim and binds the manager listener; on slower
-      # hosts (or under heavy concurrent first-boots like the MinIO +
-      # MySQL bootstrap that runs alongside) this can comfortably exceed
-      # 20s. The retries/interval budget already covers steady-state
-      # restarts; widening start_period only changes how long the first
-      # health probe waits before failures count toward `retries`.
+      # WuKongIM could need more than 20s to finish its in-container init
+      # before the first health probe started counting failures. WuKongIM's
+      # first boot writes the cluster metadata under /root/wukongim and
+      # binds the manager listener; on slower hosts (or under heavy
+      # concurrent first-boots like the MinIO + MySQL bootstrap that runs
+      # alongside) this can comfortably exceed 20s. The retries/interval
+      # budget already covers steady-state restarts; widening start_period
+      # only changes how long the first health probe waits before failures
+      # count toward `retries`.
+      #
+      # NOTE: octo-server's `depends_on` on wukongim is `service_started`
+      # (see the octo-server block below at the `depends_on:` key), NOT
+      # `service_healthy`, so this start_period bump does NOT gate
+      # octo-server boot. It just gives WuKongIM itself a longer first-
+      # probe window before its OWN container is flagged unhealthy and
+      # restarted. The reason `service_started` was chosen on the
+      # octo-server side is documented next to that depends_on entry.
       start_period: 40s
     networks:
       - octo-net

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -31,12 +31,49 @@ networks:
         - subnet: ${OCTO_NETWORK_SUBNET:-172.28.0.0/24}
 
 volumes:
+  # ---------------------------------------------------------------------------
+  # Named-volume isolation via COMPOSE_PROJECT_NAME (INCIDENT-2026-05-16-001).
+  # ---------------------------------------------------------------------------
+  # `name: octo` (above) pins the Compose project to `octo` so the network /
+  # service names stay stable, but it ALSO removes the directory-based prefix
+  # Compose would otherwise put on volume names. Without an explicit `name:`
+  # on each volume, every clone of this repo on the same host would share the
+  # SAME unprefixed volumes (`mysql-data`, `redis-data`, …) — meaning a
+  # `docker compose down -v` from a "fresh" clone at /tmp/foo wipes the
+  # production stack's MySQL data because both clones map to the same
+  # Docker volume objects. That is exactly how INCIDENT-2026-05-16-001
+  # erased im-test's entire user table during a routine from-zero test.
+  #
+  # Setting `name: ${COMPOSE_PROJECT_NAME:-octo}-<vol>` makes the volume name
+  # follow the COMPOSE_PROJECT_NAME env var:
+  #   - default (`COMPOSE_PROJECT_NAME` unset): `octo-mysql-data`, etc. —
+  #     preserves the existing on-disk volume names for users who already
+  #     have a running stack, so this change does NOT trigger a data
+  #     migration on upgrade.
+  #   - operator runs `COMPOSE_PROJECT_NAME=octo-fz docker compose up -d`
+  #     on a second clone: volumes become `octo-fz-mysql-data`, etc., fully
+  #     isolated from the original `octo-*` set. `down -v` on either stack
+  #     only touches its own volumes.
+  #
+  # IMPORTANT: changing `name: octo` at the top of this file to
+  # `name: ${COMPOSE_PROJECT_NAME:-octo}` would let project-name overrides
+  # also rename the network / containers, but it would BREAK existing
+  # deployments whose persistent state lives under the literal `octo` project.
+  # We deliberately keep the project hardcoded to `octo` and only allow the
+  # volume names to drift, so the existing on-disk volumes remain reachable
+  # for everyone on `main`.
   mysql-data:
+    name: ${COMPOSE_PROJECT_NAME:-octo}-mysql-data
   redis-data:
+    name: ${COMPOSE_PROJECT_NAME:-octo}-redis-data
   minio-data:
+    name: ${COMPOSE_PROJECT_NAME:-octo}-minio-data
   wukongim-data:
+    name: ${COMPOSE_PROJECT_NAME:-octo}-wukongim-data
   server-logs:
+    name: ${COMPOSE_PROJECT_NAME:-octo}-server-logs
   nginx-logs:
+    name: ${COMPOSE_PROJECT_NAME:-octo}-nginx-logs
 
 services:
   # ---------------------------------------------------------------------------
@@ -69,7 +106,6 @@ services:
   # tokens that have no other guard.
   preflight:
     image: ${OCTO_PREFLIGHT_IMAGE:-busybox:1.36}
-    container_name: octo-preflight
     restart: "no"
     environment:
       OCTO_NOTIFY_INTERNAL_TOKEN: ${OCTO_NOTIFY_INTERNAL_TOKEN:-}
@@ -105,7 +141,6 @@ services:
 
   mysql:
     image: mysql:8.0
-    container_name: octo-mysql
     restart: unless-stopped
     command:
       - --default-authentication-plugin=mysql_native_password
@@ -145,7 +180,6 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: octo-redis
     restart: unless-stopped
     command: ["redis-server", "--save", "60", "1", "--loglevel", "warning"]
     # Backing service: loopback-only by default. See OCTO_MYSQL_BIND comment.
@@ -184,7 +218,6 @@ services:
     # test). Override via .env -> OCTO_MINIO_IMAGE, mirroring the
     # OCTO_WK_IMAGE / OCTO_MINIO_MC_IMAGE pattern.
     image: ${OCTO_MINIO_IMAGE:-minio/minio:RELEASE.2025-04-22T22-12-26Z}
-    container_name: octo-minio
     restart: unless-stopped
     command: ["server", "/data", "--console-address", ":9001"]
     environment:
@@ -254,7 +287,6 @@ services:
   # working across restarts of the stack.
   minio-init:
     image: ${OCTO_MINIO_MC_IMAGE:-minio/mc:RELEASE.2025-04-16T18-13-26Z}
-    container_name: octo-minio-init
     restart: "no"
     depends_on:
       minio:
@@ -410,7 +442,6 @@ services:
     # validating the new tag against `wk.yaml` (tokenAuthOn) and the
     # WK_MANAGERTOKEN binding below. Override via .env -> OCTO_WK_IMAGE.
     image: ${OCTO_WK_IMAGE:-wukongim/wukongim:v2.2.4-20260313}
-    container_name: octo-wukongim
     restart: unless-stopped
     environment:
       WK_MODE: ${WK_MODE:-debug}
@@ -473,14 +504,32 @@ services:
       interval: 10s
       timeout: 5s
       retries: 12
-      start_period: 20s
+      # Bumped from 20s -> 40s after the 2026-05-16 from-zero E2E showed
+      # octo-server's `depends_on: wukongim service_healthy` could fire
+      # before WuKongIM finished its in-container init within the previous
+      # 20s window. WuKongIM's first boot writes the cluster metadata
+      # under /root/wukongim and binds the manager listener; on slower
+      # hosts (or under heavy concurrent first-boots like the MinIO +
+      # MySQL bootstrap that runs alongside) this can comfortably exceed
+      # 20s. The retries/interval budget already covers steady-state
+      # restarts; widening start_period only changes how long the first
+      # health probe waits before failures count toward `retries`.
+      start_period: 40s
     networks:
       - octo-net
 
   octo-server:
     image: ${OCTO_SERVER_IMAGE:-mininglamposs/octo-server:latest}
-    container_name: octo-server
-    restart: unless-stopped
+    # `on-failure:5` instead of `unless-stopped` so the first-boot
+    # dependency race (octo-server's `depends_on: wukongim service_healthy`
+    # firing inside wukongim's start_period window) self-heals with up to
+    # five quick restart attempts instead of leaving the stack with one
+    # service in `(unhealthy)`. Five attempts span ~30-60s of additional
+    # wall-clock — comfortably more than the wukongim start_period bump
+    # above — and the failure budget caps runaway restart loops for real
+    # configuration errors (a missing TS_DB_MYSQLADDR will still surface
+    # within seconds rather than hammering forever).
+    restart: on-failure:5
     command: ["api"]
     # -------------------------------------------------------------------
     # Why this env block carries TWO names for the same value
@@ -632,7 +681,6 @@ services:
 
   nginx:
     image: nginx:1.27-alpine
-    container_name: octo-nginx
     restart: unless-stopped
     depends_on:
       octo-server:
@@ -667,7 +715,6 @@ services:
   # ---------------------------------------------------------------------------
   web:
     image: ${OCTO_WEB_IMAGE:-mininglamposs/octo-web:latest}
-    container_name: octo-web
     restart: unless-stopped
     depends_on:
       octo-server:
@@ -691,7 +738,6 @@ services:
   # ---------------------------------------------------------------------------
   admin:
     image: ${OCTO_ADMIN_IMAGE:-mininglamposs/octo-admin:latest}
-    container_name: octo-admin
     restart: unless-stopped
     depends_on:
       octo-server:
@@ -714,7 +760,6 @@ services:
   # ---------------------------------------------------------------------------
   matter:
     image: ${OCTO_MATTER_IMAGE:-mininglamposs/octo-matter:latest}
-    container_name: octo-matter
     restart: unless-stopped
     depends_on:
       preflight:
@@ -756,7 +801,6 @@ services:
   # ---------------------------------------------------------------------------
   summary-api:
     image: ${OCTO_SUMMARY_API_IMAGE:-mininglamposs/octo-smart-summary-api:latest}
-    container_name: octo-summary-api
     restart: unless-stopped
     profiles: ["summary"]
     depends_on:
@@ -813,7 +857,6 @@ services:
 
   summary-worker:
     image: ${OCTO_SUMMARY_WORKER_IMAGE:-mininglamposs/octo-smart-summary-worker:latest}
-    container_name: octo-summary-worker
     restart: unless-stopped
     profiles: ["summary"]
     depends_on:

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -27,13 +27,10 @@ upstream octo_minio_api {
 # To re-enable the public route (NOT recommended; only do this after
 # rotating MINIO_ROOT_PASSWORD and placing the proxy behind auth):
 #
-#     upstream octo_minio_console {
-#         server minio:9001;
-#         keepalive 8;
-#     }
 #     # add inside the server { } block:
 #     location /minio-console/ {
-#         proxy_pass         http://octo_minio_console/;
+#         set $upstream_minio_console minio;
+#         proxy_pass         http://$upstream_minio_console:9001/;
 #         proxy_http_version 1.1;
 #         proxy_set_header   Host              $host;
 #         proxy_set_header   X-Real-IP         $remote_addr;
@@ -45,6 +42,43 @@ server {
     listen       80 default_server;
     listen       [::]:80 default_server;
     server_name  ${OCTO_DOMAIN} localhost _;
+
+    # ----------------------------------------------------------------------
+    # Docker embedded DNS resolver — runtime upstream resolution.
+    # ----------------------------------------------------------------------
+    # Without `resolver` + a *variable* in `proxy_pass`, nginx resolves each
+    # upstream hostname (admin / matter / web / summary-api / wukongim /
+    # minio / octo-server) exactly once, at worker boot, and caches the
+    # IP forever. When `docker compose up -d` recreates one of those
+    # containers (different IP on octo-net), nginx keeps proxying to the
+    # dead IP and every request 502s until nginx itself is restarted.
+    # That is exactly the failure the 2026-05-16 from-zero E2E hit: a
+    # routine `docker compose up -d --force-recreate admin` made
+    # /admin/ return 502 until we bounced nginx.
+    #
+    # `resolver 127.0.0.11` points at Docker's internal DNS server (well-
+    # known fixed address on every user-defined bridge network like
+    # octo-net). `valid=10s` re-resolves every 10s so a recreated
+    # container is picked up within ~10s without nginx restart. `ipv6=off`
+    # avoids the spurious AAAA lookups against 127.0.0.11 that log noisy
+    # `no resolver defined to resolve …` warnings on hosts whose Docker
+    # daemon has no IPv6 stack.
+    #
+    # nginx only re-resolves hostnames that appear as VARIABLES in
+    # `proxy_pass` (e.g. `http://$upstream_admin/...`). A literal
+    # `proxy_pass http://admin/...` still gets the boot-time cached IP.
+    # Each location below therefore stages the upstream service name into
+    # a local `set $upstream_<name>` variable before `proxy_pass`.
+    #
+    # The /api/, ^~ /v1/, /ws and /minio/ locations intentionally keep
+    # their `upstream {}`-block targets (octo_api / octo_ws /
+    # octo_minio_api at the top of this file) because those services are
+    # part of the core stack that is never `--force-recreate`d in
+    # isolation; the upstream blocks also carry keepalive pools that the
+    # variable form cannot reuse. The locations that proxy to services
+    # commonly recreated by operators in-place (admin, web, matter,
+    # summary-api) are the ones that need the variable form.
+    resolver 127.0.0.11 valid=10s ipv6=off;
 
     client_max_body_size    1000m;
     client_body_buffer_size 8m;
@@ -132,7 +166,13 @@ server {
         return 301 /admin/;
     }
     location /admin/ {
-        proxy_pass         http://admin/admin/;
+        # Variable + resolver: see the `resolver` block at the top of this
+        # server {}. Required so a `docker compose up -d --force-recreate
+        # admin` does NOT leave nginx proxying to the dead IP for the
+        # lifetime of the worker. nginx re-resolves `$upstream_admin`
+        # against 127.0.0.11 within `valid=10s`.
+        set $upstream_admin admin;
+        proxy_pass         http://$upstream_admin/admin/;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
@@ -150,8 +190,13 @@ server {
         # as one of the three reasons direct ports are loopback) was
         # not actually true on these two routes. burst=20 absorbs
         # short page-load spikes without 503ing legitimate clients.
+        #
+        # Variable + resolver: matter is one of the services operators
+        # most commonly recreate on its own (LLM key rotation, image
+        # bump). The variable form survives that recreate.
         limit_req zone=octo_api burst=20 nodelay;
-        proxy_pass         http://matter:8080/;
+        set $upstream_matter matter;
+        proxy_pass         http://$upstream_matter:8080/;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
@@ -177,10 +222,9 @@ server {
         # and use a `proxy_pass` target that has NO URI component, so the
         # rewritten request URI (`/health`, `/foo`, …) is forwarded as-is.
         limit_req zone=octo_api burst=20 nodelay;
-        resolver 127.0.0.11 valid=10s ipv6=off;
-        set $summary_backend summary-api;
+        set $upstream_summary summary-api;
         rewrite ^/summary/(.*) /$1 break;
-        proxy_pass         http://$summary_backend:8080;
+        proxy_pass         http://$upstream_summary:8080;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
@@ -241,7 +285,12 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
     }
 
     location / {
-        proxy_pass         http://web/;
+        # Variable + resolver: web image is the most frequently bumped
+        # of the SPA containers; a `docker compose up -d --force-recreate
+        # web` previously left every `/` (and therefore /chat, /group,
+        # /moment SPA routes) returning 502 until nginx was bounced.
+        set $upstream_web web;
+        proxy_pass         http://$upstream_web/;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
@@ -261,6 +310,12 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #     listen       443 ssl http2 default_server;
 #     listen       [::]:443 ssl http2 default_server;
 #     server_name  ${OCTO_DOMAIN} _;
+#
+#     # Docker embedded DNS resolver — required so variable-form
+#     # proxy_pass below re-resolves admin / web / matter / summary-api
+#     # on container recreate. See the equivalent comment block in the
+#     # HTTP server {} above for the full rationale.
+#     resolver 127.0.0.11 valid=10s ipv6=off;
 #
 #     ssl_certificate     /etc/nginx/certs/fullchain.pem;
 #     ssl_certificate_key /etc/nginx/certs/privkey.pem;
@@ -334,7 +389,8 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #         return 301 /admin/;
 #     }
 #     location /admin/ {
-#         proxy_pass         http://admin/admin/;
+#         set $upstream_admin admin;
+#         proxy_pass         http://$upstream_admin/admin/;
 #         proxy_http_version 1.1;
 #         proxy_set_header   Host              $host;
 #         proxy_set_header   X-Real-IP         $remote_addr;
@@ -344,7 +400,8 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #
 #     location /matter/ {
 #         limit_req zone=octo_api burst=20 nodelay;
-#         proxy_pass         http://matter:8080/;
+#         set $upstream_matter matter;
+#         proxy_pass         http://$upstream_matter:8080/;
 #         proxy_http_version 1.1;
 #         proxy_set_header   Host              $host;
 #         proxy_set_header   X-Real-IP         $remote_addr;
@@ -354,10 +411,9 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #
 #     location /summary/ {
 #         limit_req zone=octo_api burst=20 nodelay;
-#         resolver 127.0.0.11 valid=10s ipv6=off;
-#         set $summary_backend summary-api;
+#         set $upstream_summary summary-api;
 #         rewrite ^/summary/(.*) /$1 break;
-#         proxy_pass         http://$summary_backend:8080;
+#         proxy_pass         http://$upstream_summary:8080;
 #         proxy_http_version 1.1;
 #         proxy_set_header   Host              $host;
 #         proxy_set_header   X-Real-IP         $remote_addr;
@@ -391,7 +447,8 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #     }
 #
 #     location / {
-#         proxy_pass         http://web/;
+#         set $upstream_web web;
+#         proxy_pass         http://$upstream_web/;
 #         proxy_http_version 1.1;
 #         proxy_set_header   Host              $host;
 #         proxy_set_header   X-Real-IP         $remote_addr;

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -171,8 +171,19 @@ server {
         # admin` does NOT leave nginx proxying to the dead IP for the
         # lifetime of the worker. nginx re-resolves `$upstream_admin`
         # against 127.0.0.11 within `valid=10s`.
+        #
+        # IMPORTANT: when `proxy_pass` contains a variable, nginx does NOT
+        # do the static-form prefix substitution (it would otherwise strip
+        # the matched location and prepend the directive's URI). With a
+        # variable target plus a URI component, nginx instead replaces the
+        # original request URI with the directive URI verbatim — so
+        # `/admin/foo/bar` would collapse to `/admin/` on the upstream.
+        # The admin backend already serves under `/admin/`, so we want an
+        # identity transform: drop the URI component from `proxy_pass` and
+        # let nginx forward the original request URI unchanged. This
+        # matches the pattern documented for `/summary/` below.
         set $upstream_admin admin;
-        proxy_pass         http://$upstream_admin/admin/;
+        proxy_pass         http://$upstream_admin;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
@@ -194,9 +205,18 @@ server {
         # Variable + resolver: matter is one of the services operators
         # most commonly recreate on its own (LLM key rotation, image
         # bump). The variable form survives that recreate.
+        #
+        # URI handling: matter listens at the root (`/api/...`,
+        # `/health`, ...), not under `/matter/`, so we must strip the
+        # location prefix. Variable `proxy_pass` does not auto-strip,
+        # so we `rewrite ^/matter/(.*) /$1 break;` first, then use a
+        # `proxy_pass` target with NO URI component so the rewritten
+        # request URI (`/api/...`, `/health`) is forwarded as-is. This
+        # is the same pattern documented for `/summary/` below.
         limit_req zone=octo_api burst=20 nodelay;
         set $upstream_matter matter;
-        proxy_pass         http://$upstream_matter:8080/;
+        rewrite ^/matter/(.*) /$1 break;
+        proxy_pass         http://$upstream_matter:8080;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
@@ -289,8 +309,16 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
         # of the SPA containers; a `docker compose up -d --force-recreate
         # web` previously left every `/` (and therefore /chat, /group,
         # /moment SPA routes) returning 502 until nginx was bounced.
+        #
+        # URI handling: web serves at the root, so this is an identity
+        # transform. Variable `proxy_pass` with a URI component (e.g.
+        # `http://$upstream_web/`) would replace the original request
+        # URI with the directive's URI verbatim — every request would
+        # collapse to `/` and the SPA's deep links + static assets
+        # under `/assets/...` would all return `index.html`. Drop the
+        # URI component so nginx forwards the original request URI.
         set $upstream_web web;
-        proxy_pass         http://$upstream_web/;
+        proxy_pass         http://$upstream_web;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
@@ -390,7 +418,7 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #     }
 #     location /admin/ {
 #         set $upstream_admin admin;
-#         proxy_pass         http://$upstream_admin/admin/;
+#         proxy_pass         http://$upstream_admin;
 #         proxy_http_version 1.1;
 #         proxy_set_header   Host              $host;
 #         proxy_set_header   X-Real-IP         $remote_addr;
@@ -401,7 +429,8 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #     location /matter/ {
 #         limit_req zone=octo_api burst=20 nodelay;
 #         set $upstream_matter matter;
-#         proxy_pass         http://$upstream_matter:8080/;
+#         rewrite ^/matter/(.*) /$1 break;
+#         proxy_pass         http://$upstream_matter:8080;
 #         proxy_http_version 1.1;
 #         proxy_set_header   Host              $host;
 #         proxy_set_header   X-Real-IP         $remote_addr;
@@ -448,7 +477,7 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #
 #     location / {
 #         set $upstream_web web;
-#         proxy_pass         http://$upstream_web/;
+#         proxy_pass         http://$upstream_web;
 #         proxy_http_version 1.1;
 #         proxy_set_header   Host              $host;
 #         proxy_set_header   X-Real-IP         $remote_addr;

--- a/setup.sh
+++ b/setup.sh
@@ -155,6 +155,72 @@ if [[ ! -f "${ENV_EXAMPLE}" ]]; then
   fatal "Cannot find ${ENV_EXAMPLE}. Run this script from the repository root."
 fi
 
+# ── Pre-flight: warn on overlapping OCTO deployments ───────────────────────
+# INCIDENT-2026-05-16-001 root cause: docker-compose.yaml pins `name: octo`,
+# so a fresh clone in (e.g.) /tmp shares the SAME named volumes / container
+# namespace as a production stack already running on the host. A routine
+# `docker compose down -v` from the new clone then wipes the production
+# volumes. We rotated all named volumes onto `${COMPOSE_PROJECT_NAME:-octo}-*`
+# in docker-compose.yaml so an explicit `COMPOSE_PROJECT_NAME=octo-<suffix>`
+# fully isolates a second stack — but operators only get that isolation if
+# they remember to set the env var. This check looks for existing OCTO
+# state on the host and (without blocking the run) tells the operator how
+# to isolate before they `up -d` and collide.
+preflight_existing_octo() {
+  command -v docker &>/dev/null || return 0
+  docker info >/dev/null 2>&1 || return 0
+
+  local existing_volumes existing_containers
+  existing_volumes="$(docker volume ls --format '{{.Name}}' 2>/dev/null \
+                       | grep -E '(^|-)octo(-|$)' || true)"
+  existing_containers="$(docker ps -a --filter 'name=octo' --format '{{.Names}}' 2>/dev/null \
+                       | grep -E '(^|-)octo(-|$)' || true)"
+
+  if [[ -z "${existing_volumes}" && -z "${existing_containers}" ]]; then
+    return 0
+  fi
+
+  warn ""
+  warn "⚠  Detected EXISTING OCTO state on this host:"
+  if [[ -n "${existing_volumes}" ]]; then
+    warn "    Docker volumes:"
+    while IFS= read -r v; do warn "      - ${v}"; done <<< "${existing_volumes}"
+  fi
+  if [[ -n "${existing_containers}" ]]; then
+    warn "    Docker containers:"
+    while IFS= read -r c; do warn "      - ${c}"; done <<< "${existing_containers}"
+  fi
+  warn ""
+  warn "Bringing this stack up with the default project name (\"octo\")"
+  warn "will SHARE volumes with the deployment above. A later"
+  warn "\`docker compose down -v\` from EITHER clone will wipe ALL OCTO"
+  warn "data on this host — exactly the failure mode that destroyed"
+  warn "im-test on 2026-05-16."
+  warn ""
+  warn "To isolate this stack:"
+  warn "    export COMPOSE_PROJECT_NAME=octo-\$(your-suffix)"
+  warn "    ./setup.sh ...   # writes docker/.env"
+  warn "    cd docker && docker compose up -d"
+  warn ""
+  warn "The named volumes in docker-compose.yaml interpolate"
+  warn "COMPOSE_PROJECT_NAME so volumes / networks for the two stacks"
+  warn "will stay fully separate."
+  warn ""
+
+  if [[ "${NON_INTERACTIVE}" == "false" ]]; then
+    read -rp "Continue with project name \"${COMPOSE_PROJECT_NAME:-octo}\"? [y/N]: " confirm
+    case "${confirm}" in
+      [yY]|[yY][eE][sS]) info "Continuing — make sure you understand the implications above." ;;
+      *) info "Aborted. Re-run with COMPOSE_PROJECT_NAME=octo-<suffix> exported."; exit 0 ;;
+    esac
+  else
+    warn "(non-interactive mode: not prompting — proceeding with"
+    warn " COMPOSE_PROJECT_NAME=\"${COMPOSE_PROJECT_NAME:-octo}\")"
+  fi
+}
+
+preflight_existing_octo
+
 # ── Guard against overwriting an existing .env ─────────────────────────────
 # Re-running setup.sh regenerates ALL secrets (MySQL root password, MinIO
 # credentials, admin password, etc.). If the stack has already been started,

--- a/setup.sh
+++ b/setup.sh
@@ -171,10 +171,20 @@ preflight_existing_octo() {
   docker info >/dev/null 2>&1 || return 0
 
   local existing_volumes existing_containers
+  # Match BOTH separator variants:
+  #   - underscore (`octo_mysql-data`): Compose v2 default for project-scoped
+  #     named volumes/networks under `name: octo` — this is what every existing
+  #     deployment on `main` has on disk.
+  #   - hyphen (`octo-mysql-data` etc.): used by some older / alternate naming
+  #     paths and by Compose-generated container names (`octo-mysql-1`).
+  # Compose project names always start at the beginning of the volume /
+  # container name, so anchoring on `^octo` plus a `[-_]` or end-of-string
+  # boundary catches the realistic shapes without false-positives on
+  # unrelated images like `octopus-deploy/...`.
   existing_volumes="$(docker volume ls --format '{{.Name}}' 2>/dev/null \
-                       | grep -E '(^|-)octo(-|$)' || true)"
+                       | grep -E '^octo([-_]|$)' || true)"
   existing_containers="$(docker ps -a --filter 'name=octo' --format '{{.Names}}' 2>/dev/null \
-                       | grep -E '(^|-)octo(-|$)' || true)"
+                       | grep -E '^octo([-_]|$)' || true)"
 
   if [[ -z "${existing_volumes}" && -z "${existing_containers}" ]]; then
     return 0


### PR DESCRIPTION
## Summary

Phase 2 of the OOTB deployment hardening. Fixes the 5 blockers exposed
by the 2026-05-16 from-zero E2E test — including the one that wiped
`im-test`'s user data (INCIDENT-2026-05-16-001).

Closes the OOTB Phase 2 work tracked in
https://github.com/Mininglamp-OSS/octo-deployment/issues/26.

## Changes

### A1 (P0) — Named-volume project-name isolation

`docker-compose.yaml` keeps `name: octo` so in-stack DNS names
(`mysql`, `redis`, `octo-server`, …) stay stable, but every named
volume now interpolates `name: ${COMPOSE_PROJECT_NAME:-octo}-<vol>`.

- **Default users**: zero on-disk volume rename — the volumes were
  already implicitly `octo-*` under the project-scoped `name: octo`.
- **Operators running a second stack**:
  ```bash
  export COMPOSE_PROJECT_NAME=octo-fz
  ./setup.sh --non-interactive --domain octo-fz.local --ip 127.0.0.1
  cd docker && docker compose up -d
  ```
  Volumes become `octo-fz-mysql-data`, etc. — fully isolated from the
  default `octo-*` set. A `docker compose down -v` from either clone
  only removes its own state. **That is the fix for the
  INCIDENT-2026-05-16-001 root cause.**

`setup.sh` now runs a pre-flight that lists existing `octo-*` Docker
volumes / containers on the host and tells the operator how to
isolate via `COMPOSE_PROJECT_NAME`. Interactive mode prompts;
non-interactive mode warns and proceeds.

### A2 (P1) — Healthcheck timing + restart resilience

- `wukongim` `healthcheck.start_period`: **20s → 40s**. The 2026-05-16
  from-zero E2E showed `octo-server`'s `depends_on: service_healthy`
  could fire before WuKongIM finished its first-boot init on slower
  hosts (or under concurrent MySQL/MinIO bootstrap load).
- `octo-server` `restart`: **`unless-stopped` → `on-failure:5`**. The
  bounded retry budget self-heals the first-boot dependency race
  without hammering forever on real configuration errors.

### A3 (P2) — Container-name auto-generation

Removed every `container_name: octo-<svc>` line. Compose now derives
the runtime container name from the project, so a second stack with
`COMPOSE_PROJECT_NAME=octo-fz` produces `octo-fz-mysql-1` instead of
colliding on the hardcoded `octo-mysql`. In-stack DNS (used by every
service-to-service URL in this file) keeps using the unchanged
service short names, so nothing inside the stack breaks.

### A4 (P2) — nginx variabilised proxy_pass with embedded Docker resolver

- Added `resolver 127.0.0.11 valid=10s ipv6=off;` at the top of the
  HTTP `server { }` block (and inside the commented HTTPS block).
- Locations that point at services commonly recreated in-place
  (`admin`, `web`, `matter`, `summary-api`) now stage the upstream
  into a `set $upstream_*` variable before `proxy_pass`. nginx
  re-resolves the hostname every 10s instead of caching the
  first-boot IP forever — this stops the 502 wave that previously
  followed every `docker compose up -d --force-recreate <svc>`.
- The four core upstreams that ship with the stack and almost never
  get recreated in isolation (`octo_api` / `octo_ws` /
  `octo_minio_api`, plus the bucket-name MinIO regex) keep their
  `upstream { }` blocks so the keepalive pools they manage stay
  intact.

### A5 (P3) + D — README pre-flight + self-positioning

- Top-level `README.md` now self-identifies as **"The official OOTB
  deployment for OCTO"** and points at `docker/README.md` for the
  single-node prerequisites. Adds a Kubernetes-path prerequisites
  checklist.
- `docker/README.md` leads with a **"Pre-flight: existing OCTO
  deployments on this host"** section covering the
  INCIDENT-2026-05-16-001 scenario, the `COMPOSE_PROJECT_NAME=octo-fz`
  isolation pattern, and a verification recipe (`docker volume ls |
  grep`, `docker ps --filter`) to run before any `down -v`.
- `docker/README.md` adds an explicit **Quick start prerequisites
  checklist** (host requirements, ports, RAM/disk, image-pull
  network).

## Acceptance (on an ephemeral host — NOT `im-test`)

- [ ] First `docker compose up -d` on a clean host reaches all-healthy
      on first try (no second `up -d` retry needed).
- [ ] `COMPOSE_PROJECT_NAME=octo-fz` second stack coexists with the
      default stack with no volume / container collisions; `down -v`
      on one does not touch the other's volumes.
- [ ] `docker compose up -d --force-recreate admin` (or `web` /
      `matter`) does NOT produce a sustained 502 on the corresponding
      `/admin/` / `/` / `/matter/` route — nginx re-resolves within
      ~10s.

## Companion PRs

This PR is the OOTB-side fix. Two sibling PRs land in the same window
to retire the duplicate deployment artefacts and label `octo-matter`'s
in-repo compose as dev-only — so this repository becomes the single
source of truth for OCTO deployment:

- `Mininglamp-OSS/octo-server`: delete `docker/octo/` (the old
  11-service compose) and `docker/tsdd/` (WuKongIM v3.1 test stack);
  point README/QUICKSTART/BUILDING at this repo for OOTB.
- `Mininglamp-OSS/octo-matter`: add a `⚠ DEV ONLY` header to the
  in-repo `docker-compose.yaml`.
