### PR TITLE
fix(setup): --up now blocks until all services healthy (GH#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ cd octo-deployment
 ./setup.sh --verify                         # admin login + presign PUT end-to-end
 ```
 
+Or, on a fresh host, fold the two steps into one with `--up` (GH#32) —
+`setup.sh` writes `docker/.env` AND brings the stack up, blocking
+until every container is `(healthy)` (or printing `compose ps` + a
+`logs <unhealthy-svc>` hint and exiting 1 on timeout). It prints a
+`.` every 5 seconds while waiting so you can see the run is alive:
+
+```bash
+./setup.sh --non-interactive --ip <PUBLIC_IP> --up   # writes .env + starts + waits-for-healthy
+./setup.sh --verify
+```
+
 `setup.sh` prints the admin URL + superAdmin password at the end of
 the run. The password is also persisted to `docker/.env` (mode 600) —
 treat that file as a secret and rotate the password from the admin UI

--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ cd octo-deployment
 
 Or, on a fresh host, fold the two steps into one with `--up` (GH#32) —
 `setup.sh` writes `docker/.env` AND brings the stack up, blocking
-until every container is `(healthy)` (or printing `compose ps` + a
-`logs <unhealthy-svc>` hint and exiting 1 on timeout). It prints a
+until every long-running service reports `(healthy)` and every
+one-shot init job (`preflight`, `minio-init`) exits 0. On timeout or
+startup failure it prints `compose ps`, the specific failing service
+names, and a `logs <svc>` hint for each, then exits 1. It prints a
 `.` every 5 seconds while waiting so you can see the run is alive:
 
 ```bash

--- a/README.zh.md
+++ b/README.zh.md
@@ -54,7 +54,7 @@ cd octo-deployment
 ./setup.sh --verify                         # admin login + presign PUT 端到端检查
 ```
 
-在全新机器上想一条命令搞定，用 `--up`（GH#32）—— `setup.sh` 写完 `docker/.env` 之后自己起栈，**阻塞直到每个容器都 `(healthy)`**（超时则打印 `compose ps` + `logs <unhealthy-svc>` 提示并 exit 1）。等待期间每 5 秒打一个 `.`，方便看到脚本还活着：
+在全新机器上想一条命令搞定，用 `--up`（GH#32）—— `setup.sh` 写完 `docker/.env` 之后自己起栈，**阻塞直到每个长跑服务都 `(healthy)`、每个一次性 init job（`preflight`、`minio-init`）干净退出**。超时或启动失败时打印 `compose ps`、列出具体出问题的服务名、对每个失败服务给一条 `logs <svc>` 排查命令，然后 exit 1。等待期间每 5 秒打一个 `.`，方便看到脚本还活着：
 
 ```bash
 ./setup.sh --non-interactive --ip <PUBLIC_IP> --up   # 写 .env + 起栈 + 等齐 healthy

--- a/README.zh.md
+++ b/README.zh.md
@@ -54,6 +54,13 @@ cd octo-deployment
 ./setup.sh --verify                         # admin login + presign PUT 端到端检查
 ```
 
+在全新机器上想一条命令搞定，用 `--up`（GH#32）—— `setup.sh` 写完 `docker/.env` 之后自己起栈，**阻塞直到每个容器都 `(healthy)`**（超时则打印 `compose ps` + `logs <unhealthy-svc>` 提示并 exit 1）。等待期间每 5 秒打一个 `.`，方便看到脚本还活着：
+
+```bash
+./setup.sh --non-interactive --ip <PUBLIC_IP> --up   # 写 .env + 起栈 + 等齐 healthy
+./setup.sh --verify
+```
+
 `setup.sh` 在最后打印 admin URL + superAdmin 密码。密码同时已写入 `docker/.env`（mode 600）——请把这个文件当成密钥对待，首次登录后从 admin UI 轮换密码（见 `docker/README.zh.md`「首位管理员引导」一节）。客户端只需开**一个** TCP 端口：`28080`（`OCTO_HTTP_PORT`，nginx HTTP 入口）。HTTPS 启用后客户端端口换成 `28443`（`OCTO_HTTPS_PORT`）。其他所有端口（MinIO、MySQL、Redis、WuKongIM monitor、各服务直连 REST）默认 loopback。
 
 卸载 / 重置走交互式：

--- a/docker/README.md
+++ b/docker/README.md
@@ -198,6 +198,21 @@ Or non-interactive:
 ./setup.sh --verify
 ```
 
+Or, on a fresh host where you want a single command to do both, use
+`--up` (added for GH#32) — `setup.sh` writes `.env` AND brings the
+stack up itself, blocking until every container is `(healthy)` (or
+exits 1 with `compose ps` + a `logs <unhealthy-svc>` hint on timeout):
+
+```bash
+./setup.sh --non-interactive --ip 1.2.3.4 --up
+./setup.sh --verify
+```
+
+`--up` uses `docker compose up -d --wait --wait-timeout 120` under
+the hood (with a manual health-poll fallback on Compose < v2.20). It
+prints a `.` every 5 seconds while waiting so the run is visibly
+alive on slow hosts (cold MySQL init can take 60-90s).
+
 To enable the optional LLM summary services, add `--summary`:
 
 ```bash

--- a/docker/README.md
+++ b/docker/README.md
@@ -200,8 +200,11 @@ Or non-interactive:
 
 Or, on a fresh host where you want a single command to do both, use
 `--up` (added for GH#32) — `setup.sh` writes `.env` AND brings the
-stack up itself, blocking until every container is `(healthy)` (or
-exits 1 with `compose ps` + a `logs <unhealthy-svc>` hint on timeout):
+stack up itself, blocking until every long-running service reports
+`(healthy)` and every one-shot init job (`preflight`, `minio-init`)
+exits 0. On timeout or startup failure it prints `compose ps`,
+lists the specific failing service names, and emits a
+`logs <svc>` hint for each before exiting 1:
 
 ```bash
 ./setup.sh --non-interactive --ip 1.2.3.4 --up

--- a/docker/README.zh.md
+++ b/docker/README.zh.md
@@ -113,6 +113,15 @@ cd octo-deployment
 ./setup.sh --verify
 ```
 
+或者，在全新机器上想一条命令搞定 `.env` 生成 + 起栈，用 `--up`（GH#32 引入）——`setup.sh` 会写完 `.env` 之后自己起栈，**阻塞直到每个容器都 `(healthy)`**（或在超时后打印 `compose ps` + `logs <unhealthy-svc>` 提示并 exit 1）：
+
+```bash
+./setup.sh --non-interactive --ip 1.2.3.4 --up
+./setup.sh --verify
+```
+
+`--up` 底层调 `docker compose up -d --wait --wait-timeout 120`（Compose < v2.20 上自动 fallback 到手动 health poll）。等待期间每 5 秒打一个 `.`，方便操作者看到脚本还活着——慢主机上 MySQL 冷启动可能要 60-90 秒。
+
 启用可选的 LLM summary 服务加 `--summary`：
 
 ```bash

--- a/docker/README.zh.md
+++ b/docker/README.zh.md
@@ -113,7 +113,7 @@ cd octo-deployment
 ./setup.sh --verify
 ```
 
-或者，在全新机器上想一条命令搞定 `.env` 生成 + 起栈，用 `--up`（GH#32 引入）——`setup.sh` 会写完 `.env` 之后自己起栈，**阻塞直到每个容器都 `(healthy)`**（或在超时后打印 `compose ps` + `logs <unhealthy-svc>` 提示并 exit 1）：
+或者，在全新机器上想一条命令搞定 `.env` 生成 + 起栈，用 `--up`（GH#32 引入）——`setup.sh` 会写完 `.env` 之后自己起栈，**阻塞直到每个长跑服务都 `(healthy)`、每个一次性 init job（`preflight`、`minio-init`）干净退出**。超时或启动失败时打印 `compose ps`、列出具体出问题的服务名、对每个失败服务给一条 `logs <svc>` 排查命令，然后 exit 1：
 
 ```bash
 ./setup.sh --non-interactive --ip 1.2.3.4 --up

--- a/setup.sh
+++ b/setup.sh
@@ -98,91 +98,129 @@ compose_supports_wait() {
   return 1
 }
 
-# R6 hardening (YUJ-997): shared "fatal state" detector for
-# `compose ps` output. Extracted from `compose_poll_healthy` so that
-# `--verify` step 1 (container health) can reuse the same logic that
-# the manual health poll already runs at `up` time. Previously
-# `--verify` only grep-ed for `(unhealthy)`, so a service that had
-# crash-looped after `up` (`Restarting (1)` / `Exited (1)` / `Dead`)
-# slipped through and `--verify` printed PASS for a half-dead stack.
+# Shared "expected services vs actual states" contract checker. Used by
+# both `compose_poll_healthy()` (Compose < 2.20 fallback) and `--verify`
+# step 1 (container health) so the two paths CANNOT diverge: whatever
+# the fallback poll accepts as "healthy" is exactly what `--verify`
+# accepts post-deploy.
 #
-# Input  : stdin = `{{.Name}} {{.Status}}` lines (one per container)
-#          $1    = (optional) failed-container output sink (declared by
-#                   caller with `local`); when set, the names of
-#                   services in fatal states are written to it for the
-#                   caller's diagnostic output.
-# Output : prints failing lines to the named sink if non-empty.
-# Returns: 0 if no fatal state, 1 if at least one container is in
-#          Exited(non-zero) / Restarting / Dead (one-shot services
-#          preflight / minio-init are exempted — see below).
+# Contract (per docs/dispatch.md item 9: "every long-running service
+# must be healthy"):
 #
-# One-shot services (preflight, minio-init) intentionally finish as
-# `Exited (0)` once they have done their job — those exits are
-# expected, NOT failures. They are excluded from the failure-state
-# match via the service-name filter below (default compose container
-# naming is `<project>-<service>-<replica>`, e.g.
-# `octo-preflight-1` / `octo-minio-init-1`, so we anchor on
-# `-(preflight|minio-init)-`). Note also that `Exited (0)` from a
-# long-running service is *still* a failure here, because none of the
-# non-one-shot services should ever exit voluntarily — that case is
-# caught by the broader `Exited \([1-9]` clause (a service that exits
-# 0 mid-run is a packaging bug, not OOTB; we accept the residual gap
-# in exchange for not false-positive-ing the one-shots).
-check_compose_running_states() {
-  local statuses="$1" failed=""
-  failed="$(printf '%s\n' "${statuses}" \
-              | grep -vE -- '-(preflight|minio-init)-.*Exited \(0\)' \
-              | grep -E 'Exited \([1-9]|Restarting|Dead' || true)"
-  if [[ -n "${failed}" ]]; then
-    printf '%s\n' "${failed}"
+#   long-running service (anything not in the one-shot allowlist):
+#     PASS   →  status starts with `Up ` AND has no `(unhealthy)` and
+#               no `(health: starting)` suffix (i.e. running and either
+#               healthy or with no healthcheck defined).
+#     WAIT   →  `Up …(unhealthy)` or `Up …(health: starting)`
+#               (transient — pollers should keep waiting; `--verify`
+#               treats this as a failure).
+#     FATAL  →  `Created`, `Exited (…)` (ANY code, including 0 —
+#               long-running svcs must never exit), `Restarting (…)`,
+#               `Dead`, `Paused`, `Removing`, or missing container row.
+#
+#   one-shot service (preflight, minio-init):
+#     PASS   →  `Exited (0)` (job ran and finished cleanly).
+#     WAIT   →  still `Up …` / `Created` (job has not finished yet).
+#     FATAL  →  `Exited (n>0)`, `Restarting (…)`, `Dead`, or missing
+#               container row.
+#
+# Inputs:
+#   $1 = tab-separated `{{.Name}}\t{{.Status}}` snapshot of compose ps
+#        --all (one row per container).
+#   $2 = newline-separated list of services from
+#        `${cc} config --services`.
+#
+# stdout: zero or more rows in the form `<REASON>\t<row-or-svc-detail>`
+#         where REASON ∈ {FATAL, WAIT}. Empty stdout means the contract
+#         is fully satisfied.
+# return: 0 iff stdout is empty, 1 otherwise.
+verify_all_services_running_or_healthy() {
+  local statuses="$1" expected="$2"
+  local svc row status out=""
+  while IFS= read -r svc; do
+    [[ -z "${svc}" ]] && continue
+    # `compose ps --all` names a container `<project>-<svc>-<idx>` (or
+    # the legacy `<project>_<svc>_<idx>` form), so anchor on
+    # `[-_]<svc>[-_]<digit>` to avoid matching e.g. `wukongim` against
+    # a `wukongim-extra` clone.
+    row="$(printf '%s\n' "${statuses}" | grep -E -- "[-_]${svc}[-_][0-9]+	" | head -1 || true)"
+    if [[ -z "${row}" ]]; then
+      out="${out}FATAL	${svc}	(no container row in compose ps)
+"
+      continue
+    fi
+    status="${row#*	}"
+    case "${svc}" in
+      preflight|minio-init)
+        case "${status}" in
+          "Exited (0)"*)                 : ;;  # PASS — one-shot finished
+          Exited*|Restarting*|Dead*)     out="${out}FATAL	${row}
+" ;;
+          *)                             out="${out}WAIT	${row}
+" ;;
+        esac
+        ;;
+      *)
+        case "${status}" in
+          Up*"(unhealthy)"*|Up*"(health: starting)"*)
+            out="${out}WAIT	${row}
+"
+            ;;
+          Up*)                           : ;;  # PASS — healthy or no healthcheck
+          *)                             out="${out}FATAL	${row}
+" ;;
+        esac
+        ;;
+    esac
+  done <<< "${expected}"
+  if [[ -n "${out}" ]]; then
+    printf '%s' "${out}"
     return 1
   fi
   return 0
 }
 
-# Poll `docker compose ps` until no container is `(unhealthy)`,
-# `(health: starting)`, or in a hard-fail state (Exited(non-zero) /
-# Restarting / Dead). Used on Compose < 2.20 where `up --wait` is a
-# no-op.
+# Poll `docker compose ps` until the stack satisfies the
+# `verify_all_services_running_or_healthy` contract (every long-running
+# service `Up` and healthy/no-healthcheck, every one-shot `Exited (0)`).
+# Used on Compose < 2.20 where `up --wait` is a no-op.
 #
-# R5 hardening (YUJ-991): the original check only looked for
-# `(unhealthy)` and `(health: starting)`, so a crash-looping service
-# stuck in `Restarting (1)` or a flat-out `Exited (1)` slipped through
-# the gate and the caller printed "All services healthy" while the
-# stack was actually down. Now we also fail-fast on any container in a
-# non-zero Exited / Restarting / Dead state.
+# The poll delegates the full "expected services vs actual states"
+# check to the shared helper so this fallback path and `--verify`
+# step 1 cannot drift apart. Earlier shapes of this function only
+# looked for the presence of `(unhealthy)` / `(health: starting)`
+# substrings — that let `Created` / `Exited (0)` on a long-running
+# service / a missing container row all silently pass, violating the
+# docs/dispatch.md contract ("every long-running service must be
+# healthy").
 #
-# R6 (YUJ-997): the fatal-state detection now lives in
-# `check_compose_running_states()` so `--verify` step 1 can reuse it
-# (Jerry-Xin P1 W1: step 1 grep `(unhealthy)`-only let a crash-looped
-# container slip through `--verify`).
+# Semantics of the helper's report rows here:
+#   FATAL  → return 1 immediately (non-recoverable: Created, Exited,
+#            Restarting, Dead, missing row, etc.).
+#   WAIT   → keep polling — service is transiently `(unhealthy)` or
+#            `(health: starting)`, or a one-shot that has not yet
+#            finished. `(unhealthy)` can flap back to `(healthy)`
+#            once an upstream finishes booting (mysql is the canonical
+#            example), so a single `(unhealthy)` snapshot does NOT end
+#            the wait.
+#   none   → return 0 (contract satisfied).
 compose_poll_healthy() {
-  local cc="$1" timeout="${2:-180}" elapsed=0 statuses="" failed=""
+  local cc="$1" timeout="${2:-180}" elapsed=0 statuses="" expected="" report=""
+  expected="$(cd "${DOCKER_DIR}" && ${cc} config --services 2>/dev/null | sort -u || true)"
+  if [[ -z "${expected}" ]]; then
+    err "compose config --services produced no output — cannot validate stack health."
+    return 1
+  fi
   while (( elapsed < timeout )); do
-    # `--format '{{.Name}} {{.Status}}'` gives us both the container name
-    # (to filter one-shots) and the status string in one shot. Sticking
-    # to a single `compose ps` call per iteration keeps the poll cheap.
-    statuses="$(cd "${DOCKER_DIR}" && ${cc} ps --format '{{.Name}} {{.Status}}' 2>/dev/null || true)"
+    statuses="$(cd "${DOCKER_DIR}" && ${cc} ps --all --format '{{.Name}}	{{.Status}}' 2>/dev/null || true)"
     if [[ -n "${statuses}" ]]; then
-      # Hard-fail only on terminal states (Exited(non-zero) / Restarting / Dead).
-      # `(unhealthy)` is intentionally NOT a hard fail here: per
-      # `docker compose up --wait --wait-timeout` semantics (which this
-      # fallback mirrors for Compose < 2.20), a single `(unhealthy)`
-      # snapshot does not end the wait — the container may flap back to
-      # `(healthy)` once its upstream finishes booting (mysql is the
-      # canonical example). Only a `Restarting` / non-zero `Exited`
-      # state — or running out the timeout — ends the wait with a
-      # failure. YUJ-1019 codex review P1 #2.
-      if ! failed="$(check_compose_running_states "${statuses}")"; then
-        echo "FATAL: service(s) in failed state:" >&2
-        printf '%s\n' "${failed}" | sed 's/^/    /' >&2
-        return 1
-      fi
-      # Healthy iff there is no `(unhealthy)` AND no `(health: starting)`
-      # in the snapshot. If either is present, keep polling until the
-      # timeout expires (do NOT early-return).
-      if ! echo "${statuses}" | grep -qE '\(unhealthy\)|\(health: starting\)'; then
+      if report="$(verify_all_services_running_or_healthy "${statuses}" "${expected}")"; then
         return 0
+      fi
+      if printf '%s\n' "${report}" | grep -q '^FATAL	'; then
+        err "FATAL: service(s) in non-recoverable state:"
+        printf '%s\n' "${report}" | grep '^FATAL	' | sed 's/^FATAL	/    /' >&2
+        return 1
       fi
     fi
     sleep 5
@@ -246,7 +284,7 @@ _compose_dots_stop() {
 # 128+SIGNUM code so the script terminates cleanly instead of silently
 # continuing into the success/diagnostic path. Without this, an operator
 # Ctrl-C during `compose up --wait` would clean the dots and then fall
-# through into the success banner. Codex review P1 #1.
+# through into the success banner.
 #
 # Note: we `exit` rather than `kill -s "${sig}" "$$"` because the latter
 # is unreliable here — bash only delivers the re-raised signal at the
@@ -345,7 +383,6 @@ compose_up_and_wait() {
     # because they gate the rest of the stack. So instead of stripping
     # them by name, we strip the specific benign one-shot status
     # (`Exited (0)`) and let everything else flow into the fail grep.
-    # Codex review P2 #1 (R2 follow-up).
     failing_svcs="$(cd "${DOCKER_DIR}" && ${cc} ps --all --format '{{.Service}}	{{.Status}}' 2>/dev/null \
                       | grep -vE '^(preflight|minio-init)	Exited \(0\)' \
                       | grep -E '	.*(\(unhealthy\)|Restarting|Dead|Exited \([1-9])' \
@@ -358,9 +395,23 @@ compose_up_and_wait() {
         err "    (cd docker && ${cc} logs --tail 200 ${svc})"
       done <<< "${failing_svcs}"
     else
+      # No hard-fail state — the timeout fired while at least one
+      # container was still in `(health: starting)`. Surface the
+      # concrete service names so the operator does not have to
+      # eyeball the ps snapshot above to find them.
+      starting_svcs="$(cd "${DOCKER_DIR}" && ${cc} ps --all --format '{{.Service}}	{{.Status}}' 2>/dev/null \
+                        | grep -E '\(health: starting\)' \
+                        | awk -F'	' '{print $1}' | sort -u || true)"
       err "No service is in a hard-fail state — at least one is still in"
       err "(health: starting) at the ${timeout}s mark. Re-check shortly, or:"
-      err "    (cd docker && ${cc} logs --tail 200 <still-starting-service>)"
+      if [[ -n "${starting_svcs}" ]]; then
+        while IFS= read -r svc; do
+          [[ -z "${svc}" ]] && continue
+          err "    (cd docker && ${cc} logs --tail 200 ${svc})"
+        done <<< "${starting_svcs}"
+      else
+        err "    (cd docker && ${cc} logs --tail 200 <svc>)"
+      fi
       err "Common culprits on a cold boot are mysql / wukongim / minio."
     fi
   fi
@@ -548,69 +599,31 @@ if [[ "${RUN_VERIFY}" == "true" ]]; then
   if ! ( cd "${DOCKER_DIR}" && ${CC} ps --all >/dev/null 2>&1 ); then
     fail "docker compose ps failed — is the stack up?"; ((fails++)) || true
   else
-    # R8 (YUJ-1002 / Jerry-Xin + lml W2): the previous form used
-    # `${CC} ps --status running` (and then `${CC} ps` without
-    # `--all`) for the actual status snapshot. A cleanly stopped
-    # container (`docker compose stop wukongim` → `Exited (0)`) is
-    # NOT in the running set and ALSO not in the default `ps`
-    # output, so step 1 saw an empty list and "passed" while the
-    # service was gone. The fatal-state grep only catches
-    # `Exited \([1-9])` / `Restarting` / `Dead`; an `Exited (0)`
-    # from a long-running service does not match.
-    #
-    # Fix is two-pronged: (a) use `ps --all` so stopped containers
-    # appear in the snapshot, and (b) cross-check the snapshot
-    # against `compose config --services` so a service whose
-    # container disappeared entirely (a `docker rm` or never-
-    # started one-shot turned long-running by image change) still
-    # counts as a fail. The original `(unhealthy)` + fatal-state
-    # checks then run over the broader set so a `Restarting (1)`
-    # in the `--all` view still trips R6's detector.
+    # Delegate the full "expected services vs actual states" contract
+    # check to `verify_all_services_running_or_healthy` — the same
+    # helper that the `compose up --wait` fallback poll uses, so a
+    # snapshot the poll accepted is also the snapshot --verify
+    # accepts. `--all` is required so a cleanly stopped long-running
+    # container (`docker compose stop wukongim` → `Exited (0)`) still
+    # appears in the snapshot; without it, the row vanishes and step
+    # 1 would "pass" while the service was gone.
     statuses="$(cd "${DOCKER_DIR}" && ${CC} ps --all --format '{{.Name}}	{{.Status}}' 2>/dev/null || true)"
     expected_services="$(cd "${DOCKER_DIR}" && ${CC} config --services 2>/dev/null | sort -u || true)"
-    missing_or_stopped=""
-    # Detect: (1) expected services that produced no container row at
-    # all, (2) services whose container is present but in `Exited (0)`
-    # (clean stop of a long-running service — invisible to the fatal
-    # grep below, but still a deployment failure for everything except
-    # the `preflight` / `minio-init` one-shots, which are *meant* to
-    # finish 0).
-    if [[ -n "${expected_services}" ]]; then
-      while IFS= read -r svc; do
-        [[ -z "${svc}" ]] && continue
-        # one-shots are *expected* to be Exited (0) post-run
-        case "${svc}" in
-          preflight|minio-init) continue ;;
-        esac
-        # `compose ps --all` names a container `<project>-<svc>-<idx>`
-        # (or, with the legacy underscore separator, `<project>_<svc>_<idx>`),
-        # so anchor the match on `-<svc>-` / `_<svc>_` to avoid
-        # false-matching `wukongim` against a `wukongim-extra` clone.
-        row="$(printf '%s\n' "${statuses}" | grep -E -- "[-_]${svc}[-_][0-9]+	" || true)"
-        if [[ -z "${row}" ]]; then
-          missing_or_stopped="${missing_or_stopped}${svc}	(no container)
-"
-        elif printf '%s\n' "${row}" | grep -qE 'Exited \(0\)'; then
-          missing_or_stopped="${missing_or_stopped}${row}
-"
-        fi
-      done <<< "${expected_services}"
-    fi
-    failed_states=""
-    if ! failed_states="$(check_compose_running_states "${statuses}")"; then
-      fail "service(s) in fatal state (Exited/Restarting/Dead):"
-      printf '%s\n' "${failed_states}" | sed 's/^/    /'
-      ((fails++)) || true
-    elif [[ -n "${missing_or_stopped}" ]]; then
-      fail "service(s) missing or cleanly stopped (Exited 0 on long-running service):"
-      printf '%s' "${missing_or_stopped}" | sed 's/^/    /'
+    if [[ -z "${expected_services}" ]]; then
+      fail "compose config --services produced no output — cannot validate stack health."
       ((fails++)) || true
     else
-      unhealthy="$(printf '%s\n' "${statuses}" | grep -E '\(unhealthy\)' || true)"
-      if [[ -n "${unhealthy}" ]]; then
-        fail "unhealthy service(s):"; printf '%s\n' "${unhealthy}" | sed 's/^/    /'; ((fails++)) || true
-      else
+      verify_report=""
+      if verify_report="$(verify_all_services_running_or_healthy "${statuses}" "${expected_services}")"; then
         ok
+      else
+        # At `--verify` time the stack is supposed to be steady, so
+        # we treat BOTH `FATAL` and `WAIT` rows as failures (a
+        # service that is still `(health: starting)` minutes after
+        # `up` is not healthy).
+        fail "service(s) failed health contract (expected vs actual):"
+        printf '%s\n' "${verify_report}" | sed 's/^/    /'
+        ((fails++)) || true
       fi
     fi
   fi

--- a/setup.sh
+++ b/setup.sh
@@ -339,13 +339,16 @@ compose_up_and_wait() {
     # Extract concrete failing service names from
     # `ps --format '{{.Service}}\t{{.Status}}'`. We flag anything that
     # is (unhealthy), Restarting, Dead, or Exited(non-zero). One-shot
-    # services (preflight / minio-init) are excluded the same way
-    # `check_compose_running_states` excludes them, so we do not falsely
-    # tell the operator "look at minio-init logs" when minio-init
-    # correctly Exited (0). Codex review P2 #1.
+    # services (preflight / minio-init) are normally expected to be
+    # `Exited (0)` and so are NOT a fail in that state — but if they
+    # crash with `Exited (1)` / `Restarting` / `Dead` they MUST surface,
+    # because they gate the rest of the stack. So instead of stripping
+    # them by name, we strip the specific benign one-shot status
+    # (`Exited (0)`) and let everything else flow into the fail grep.
+    # Codex review P2 #1 (R2 follow-up).
     failing_svcs="$(cd "${DOCKER_DIR}" && ${cc} ps --all --format '{{.Service}}	{{.Status}}' 2>/dev/null \
-                      | grep -vE '^(preflight|minio-init)	' \
-                      | grep -E '	.*((unhealthy)|Restarting|Dead|Exited \([1-9])' \
+                      | grep -vE '^(preflight|minio-init)	Exited \(0\)' \
+                      | grep -E '	.*(\(unhealthy\)|Restarting|Dead|Exited \([1-9])' \
                       | awk -F'	' '{print $1}' | sort -u || true)"
     err ""
     if [[ -n "${failing_svcs}" ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -164,15 +164,24 @@ compose_poll_healthy() {
     # to a single `compose ps` call per iteration keeps the poll cheap.
     statuses="$(cd "${DOCKER_DIR}" && ${cc} ps --format '{{.Name}} {{.Status}}' 2>/dev/null || true)"
     if [[ -n "${statuses}" ]]; then
+      # Hard-fail only on terminal states (Exited(non-zero) / Restarting / Dead).
+      # `(unhealthy)` is intentionally NOT a hard fail here: per
+      # `docker compose up --wait --wait-timeout` semantics (which this
+      # fallback mirrors for Compose < 2.20), a single `(unhealthy)`
+      # snapshot does not end the wait — the container may flap back to
+      # `(healthy)` once its upstream finishes booting (mysql is the
+      # canonical example). Only a `Restarting` / non-zero `Exited`
+      # state — or running out the timeout — ends the wait with a
+      # failure. YUJ-1019 codex review P1 #2.
       if ! failed="$(check_compose_running_states "${statuses}")"; then
         echo "FATAL: service(s) in failed state:" >&2
         printf '%s\n' "${failed}" | sed 's/^/    /' >&2
         return 1
       fi
-      if echo "${statuses}" | grep -q '(unhealthy)'; then
-        return 1
-      fi
-      if ! echo "${statuses}" | grep -q '(health: starting)'; then
+      # Healthy iff there is no `(unhealthy)` AND no `(health: starting)`
+      # in the snapshot. If either is present, keep polling until the
+      # timeout expires (do NOT early-return).
+      if ! echo "${statuses}" | grep -qE '\(unhealthy\)|\(health: starting\)'; then
         return 0
       fi
     fi
@@ -218,6 +227,45 @@ validate_compose_project_name() {
 # short enough to surface a stuck container instead of waiting forever.
 COMPOSE_UP_WAIT_TIMEOUT_DEFAULT=120
 
+# Cleanup helper for `compose_up_and_wait`: idempotently kill the dots
+# subshell, reap it, and clear the EXIT trap. Used both from the normal
+# return path and from the INT/TERM trap, so it must tolerate being
+# called twice. The dots PID is read from a script-global so the INT/TERM
+# handler can see it (a `local` in the function would be invisible to the
+# trap).
+_COMPOSE_DOTS_PID=""
+_compose_dots_stop() {
+  if [[ -n "${_COMPOSE_DOTS_PID}" ]]; then
+    kill "${_COMPOSE_DOTS_PID}" 2>/dev/null || true
+    wait "${_COMPOSE_DOTS_PID}" 2>/dev/null || true
+    _COMPOSE_DOTS_PID=""
+    printf '\n' >&2
+  fi
+}
+# Signal-specific handler: stop the dots, then exit with the canonical
+# 128+SIGNUM code so the script terminates cleanly instead of silently
+# continuing into the success/diagnostic path. Without this, an operator
+# Ctrl-C during `compose up --wait` would clean the dots and then fall
+# through into the success banner. Codex review P1 #1.
+#
+# Note: we `exit` rather than `kill -s "${sig}" "$$"` because the latter
+# is unreliable here — bash only delivers the re-raised signal at the
+# next "safe" point, and by then the trap has already returned and the
+# script may have moved past the `compose_up_and_wait` invocation. A
+# direct `exit 128+SIGNUM` gives operators and CI wrappers a predictable
+# exit status.
+_compose_on_signal() {
+  local sig="$1" code
+  case "${sig}" in
+    INT)  code=130 ;;
+    TERM) code=143 ;;
+    *)    code=1   ;;
+  esac
+  _compose_dots_stop
+  trap - EXIT INT TERM
+  exit "${code}"
+}
+
 # Run `up -d`, preferring `--wait --wait-timeout` on Compose ≥ 2.20 and
 # falling back to a manual health poll on older Compose so users on
 # legacy installs do not see a hard failure. While we wait, a background
@@ -226,14 +274,14 @@ COMPOSE_UP_WAIT_TIMEOUT_DEFAULT=120
 # during which compose itself prints nothing).
 #
 # On failure (timeout, hard error, or one or more containers ending in a
-# fatal state) we dump `compose ps` and a `logs <unhealthy-svc>` hint so
-# the operator has an immediate next step instead of a bare non-zero
-# exit. Returns the exit code of the compose call (or the poll) so
-# callers can fail-fast.
+# fatal state) we dump `compose ps`, list the specific failing service
+# names, and print a `logs <svc>` hint for each so the operator has an
+# immediate next step instead of a bare non-zero exit. Returns the exit
+# code of the compose call (or the poll) so callers can fail-fast.
 compose_up_and_wait() {
   local cc="$1"
   local timeout="${2:-${COMPOSE_UP_WAIT_TIMEOUT_DEFAULT}}"
-  local rc=0 log_file dots_pid
+  local rc=0 log_file ps_snapshot failing_svcs
 
   log_file="$(mktemp 2>/dev/null || echo "/tmp/octo-compose-up.$$")"
 
@@ -241,9 +289,13 @@ compose_up_and_wait() {
   # before compose has even forked. Output to stderr so it stays
   # visible even when stdout is being captured by a CI wrapper.
   ( while :; do sleep 5; printf '.' >&2; done ) &
-  dots_pid=$!
-  # Guarantee the ticker is reaped on any exit path, including Ctrl-C.
-  trap 'kill "'"${dots_pid}"'" 2>/dev/null || true; wait "'"${dots_pid}"'" 2>/dev/null || true' EXIT INT TERM
+  _COMPOSE_DOTS_PID=$!
+  # Guarantee the ticker is reaped on any exit path. EXIT runs the
+  # plain cleanup; INT/TERM re-raise the signal so the script exits
+  # with the canonical 128+SIGNUM instead of silently continuing.
+  trap '_compose_dots_stop' EXIT
+  trap '_compose_on_signal INT'  INT
+  trap '_compose_on_signal TERM' TERM
 
   if compose_supports_wait "${cc}"; then
     set +e
@@ -264,27 +316,50 @@ compose_up_and_wait() {
     fi
   fi
 
-  # Stop the ticker, terminate the dots line, and clear the EXIT trap so
-  # it does not double-fire (or hide a later real error) on the next
+  # Stop the ticker, terminate the dots line, and clear the traps so
+  # they do not double-fire (or hide a later real error) on the next
   # script-level exit.
-  kill "${dots_pid}" 2>/dev/null || true
-  wait "${dots_pid}" 2>/dev/null || true
+  _compose_dots_stop
   trap - EXIT INT TERM
-  printf '\n' >&2
 
   if (( rc != 0 )); then
     err ""
-    err "compose up did not reach healthy within ${timeout}s (rc=${rc})."
+    err "compose up did not reach a healthy state within ${timeout}s (or compose itself failed; rc=${rc})."
     if [[ -s "${log_file}" ]]; then
       err "── Last compose output (tail) ────────────────────────────────"
       tail -n 40 "${log_file}" | sed 's/^/    /' >&2 || true
     fi
     err "── Current service state (docker compose ps) ────────────────"
-    ( cd "${DOCKER_DIR}" && ${cc} ps ) >&2 || true
+    ps_snapshot="$(cd "${DOCKER_DIR}" && ${cc} ps --all 2>/dev/null || true)"
+    if [[ -n "${ps_snapshot}" ]]; then
+      printf '%s\n' "${ps_snapshot}" | sed 's/^/    /' >&2
+    else
+      err "    (docker compose ps produced no output — is the docker daemon reachable?)"
+    fi
+    # Extract concrete failing service names from
+    # `ps --format '{{.Service}}\t{{.Status}}'`. We flag anything that
+    # is (unhealthy), Restarting, Dead, or Exited(non-zero). One-shot
+    # services (preflight / minio-init) are excluded the same way
+    # `check_compose_running_states` excludes them, so we do not falsely
+    # tell the operator "look at minio-init logs" when minio-init
+    # correctly Exited (0). Codex review P2 #1.
+    failing_svcs="$(cd "${DOCKER_DIR}" && ${cc} ps --all --format '{{.Service}}	{{.Status}}' 2>/dev/null \
+                      | grep -vE '^(preflight|minio-init)	' \
+                      | grep -E '	.*((unhealthy)|Restarting|Dead|Exited \([1-9])' \
+                      | awk -F'	' '{print $1}' | sort -u || true)"
     err ""
-    err "Inspect the failing services' logs, e.g.:"
-    err "    (cd docker && ${cc} logs --tail 200 <unhealthy-service>)"
-    err "Common culprits on a cold boot are mysql / wukongim / minio."
+    if [[ -n "${failing_svcs}" ]]; then
+      err "Failing services — inspect each one's logs:"
+      while IFS= read -r svc; do
+        [[ -z "${svc}" ]] && continue
+        err "    (cd docker && ${cc} logs --tail 200 ${svc})"
+      done <<< "${failing_svcs}"
+    else
+      err "No service is in a hard-fail state — at least one is still in"
+      err "(health: starting) at the ${timeout}s mark. Re-check shortly, or:"
+      err "    (cd docker && ${cc} logs --tail 200 <still-starting-service>)"
+      err "Common culprits on a cold boot are mysql / wukongim / minio."
+    fi
   fi
   rm -f "${log_file}" 2>/dev/null || true
   return "${rc}"
@@ -414,11 +489,15 @@ Generation:
   --summary           Enable the optional LLM summary services
                       (COMPOSE_PROFILES=summary).
   --up                After writing .env, run `docker compose up -d --wait
-                      --wait-timeout 120` and block until every service is
-                      healthy (or print `compose ps` + a `logs <svc>` hint
-                      and exit 1 on timeout). A '.' prints every 5 seconds
-                      while waiting so the run is visibly alive on slow
-                      hosts (cold MySQL init can take 60-90s).
+                      --wait-timeout 120` and block until every long-
+                      running service is healthy AND every one-shot init
+                      job (preflight / minio-init) exited 0. On timeout
+                      or startup failure: print `compose ps`, list the
+                      specific failing service names, and emit one
+                      `logs <svc>` hint for each before exit 1. A '.'
+                      prints every 5 seconds while waiting so the run is
+                      visibly alive on slow hosts (cold MySQL init can
+                      take 60-90s).
 
 Smoke test / tear-down (work against an already-existing docker/.env):
   --verify            Probe nginx / octo-server / matter / object-store

--- a/setup.sh
+++ b/setup.sh
@@ -162,7 +162,16 @@ verify_all_services_running_or_healthy() {
         ;;
       *)
         case "${status}" in
-          Up*"(unhealthy)"*|Up*"(health: starting)"*)
+          Up*"(unhealthy)"*|Up*"(health: starting)"*|Created*)
+            # `Created` on a long-running svc is the cold-boot race
+            # window: `compose up -d` ordered it after a depends_on
+            # gate (e.g. preflight exit 0, mysql health) and Compose
+            # has not yet `Start`-ed it. From `compose_poll_healthy`
+            # this is WAIT (poll again — `Created` will flip to `Up`
+            # once the gate clears); from `--verify` (stack already
+            # steady) WAIT is treated as a failure by the caller,
+            # which is what we want — a `Created` row at that point
+            # means the gate never cleared.
             out="${out}WAIT	${row}
 "
             ;;
@@ -195,14 +204,19 @@ verify_all_services_running_or_healthy() {
 # healthy").
 #
 # Semantics of the helper's report rows here:
-#   FATAL  → return 1 immediately (non-recoverable: Created, Exited,
-#            Restarting, Dead, missing row, etc.).
-#   WAIT   → keep polling — service is transiently `(unhealthy)` or
-#            `(health: starting)`, or a one-shot that has not yet
-#            finished. `(unhealthy)` can flap back to `(healthy)`
-#            once an upstream finishes booting (mysql is the canonical
-#            example), so a single `(unhealthy)` snapshot does NOT end
-#            the wait.
+#   FATAL  → return 1 immediately (non-recoverable: Exited on a
+#            long-running svc, Restarting, Dead, missing row,
+#            one-shot `Exited (n>0)`, etc.).
+#   WAIT   → keep polling — service is transiently `(unhealthy)`,
+#            `(health: starting)`, or `Created` (long-running svc
+#            still in the cold-boot race window — Compose ordered
+#            it after a depends_on gate and has not `Start`-ed it
+#            yet); or a one-shot that has not yet finished.
+#            `(unhealthy)` can flap back to `(healthy)` once an
+#            upstream finishes booting (mysql is the canonical
+#            example), so a single `(unhealthy)` snapshot does NOT
+#            end the wait. `Created` likewise flips to `Up` once
+#            the gate clears.
 #   none   → return 0 (contract satisfied).
 compose_poll_healthy() {
   local cc="$1" timeout="${2:-180}" elapsed=0 statuses="" expected="" report=""

--- a/setup.sh
+++ b/setup.sh
@@ -210,21 +210,84 @@ validate_compose_project_name() {
   return 0
 }
 
-# Run `up -d`, preferring `--wait` on Compose ≥ 2.20 and falling back to a
-# manual health poll on older Compose so users on legacy installs do not
-# see a hard failure. Returns the exit code of the compose call (or the
-# poll) so callers can fail-fast.
+# Default wait timeout (seconds) for `compose up -d --wait` and the
+# manual-poll fallback. Aligned at 120s after PR#30 public-IP E2E
+# (YUJ-1019 / GH#32) exposed that the previous 60s ceiling tripped on a
+# cold MySQL boot on small GCP instances. 120s comfortably covers the
+# first-time pull-and-init path on a freshly built host while still being
+# short enough to surface a stuck container instead of waiting forever.
+COMPOSE_UP_WAIT_TIMEOUT_DEFAULT=120
+
+# Run `up -d`, preferring `--wait --wait-timeout` on Compose ≥ 2.20 and
+# falling back to a manual health poll on older Compose so users on
+# legacy installs do not see a hard failure. While we wait, a background
+# subshell prints a `.` every 5 seconds so the operator can SEE the
+# script is still alive on slow hosts (cold MySQL init can take 60-90s
+# during which compose itself prints nothing).
+#
+# On failure (timeout, hard error, or one or more containers ending in a
+# fatal state) we dump `compose ps` and a `logs <unhealthy-svc>` hint so
+# the operator has an immediate next step instead of a bare non-zero
+# exit. Returns the exit code of the compose call (or the poll) so
+# callers can fail-fast.
 compose_up_and_wait() {
   local cc="$1"
+  local timeout="${2:-${COMPOSE_UP_WAIT_TIMEOUT_DEFAULT}}"
+  local rc=0 log_file dots_pid
+
+  log_file="$(mktemp 2>/dev/null || echo "/tmp/octo-compose-up.$$")"
+
+  # Start the dots ticker. Sleep first so we do not print a leading dot
+  # before compose has even forked. Output to stderr so it stays
+  # visible even when stdout is being captured by a CI wrapper.
+  ( while :; do sleep 5; printf '.' >&2; done ) &
+  dots_pid=$!
+  # Guarantee the ticker is reaped on any exit path, including Ctrl-C.
+  trap 'kill "'"${dots_pid}"'" 2>/dev/null || true; wait "'"${dots_pid}"'" 2>/dev/null || true' EXIT INT TERM
+
   if compose_supports_wait "${cc}"; then
-    ( cd "${DOCKER_DIR}" && ${cc} up -d --wait )
-    return $?
+    set +e
+    ( cd "${DOCKER_DIR}" && ${cc} up -d --wait --wait-timeout "${timeout}" ) > "${log_file}" 2>&1
+    rc=$?
+    set -e
+  else
+    warn "Detected Compose < v2.20 — \`up --wait\` is unavailable, falling back to manual health poll."
+    set +e
+    ( cd "${DOCKER_DIR}" && ${cc} up -d ) > "${log_file}" 2>&1
+    rc=$?
+    set -e
+    if (( rc == 0 )); then
+      set +e
+      compose_poll_healthy "${cc}" "${timeout}"
+      rc=$?
+      set -e
+    fi
   fi
-  warn "Detected Compose < v2.20 — \`up --wait\` is unavailable, falling back to manual health poll."
-  if ! ( cd "${DOCKER_DIR}" && ${cc} up -d ); then
-    return 1
+
+  # Stop the ticker, terminate the dots line, and clear the EXIT trap so
+  # it does not double-fire (or hide a later real error) on the next
+  # script-level exit.
+  kill "${dots_pid}" 2>/dev/null || true
+  wait "${dots_pid}" 2>/dev/null || true
+  trap - EXIT INT TERM
+  printf '\n' >&2
+
+  if (( rc != 0 )); then
+    err ""
+    err "compose up did not reach healthy within ${timeout}s (rc=${rc})."
+    if [[ -s "${log_file}" ]]; then
+      err "── Last compose output (tail) ────────────────────────────────"
+      tail -n 40 "${log_file}" | sed 's/^/    /' >&2 || true
+    fi
+    err "── Current service state (docker compose ps) ────────────────"
+    ( cd "${DOCKER_DIR}" && ${cc} ps ) >&2 || true
+    err ""
+    err "Inspect the failing services' logs, e.g.:"
+    err "    (cd docker && ${cc} logs --tail 200 <unhealthy-service>)"
+    err "Common culprits on a cold boot are mysql / wukongim / minio."
   fi
-  compose_poll_healthy "${cc}" 180
+  rm -f "${log_file}" 2>/dev/null || true
+  return "${rc}"
 }
 
 # Read a value from docker/.env (defaults if missing). Used by --verify
@@ -350,8 +413,12 @@ Generation:
                       See docker/certs/README.md for the full procedure.
   --summary           Enable the optional LLM summary services
                       (COMPOSE_PROFILES=summary).
-  --up                After writing .env, run `docker compose up -d --wait`
-                      and print healthy/unhealthy status for every service.
+  --up                After writing .env, run `docker compose up -d --wait
+                      --wait-timeout 120` and block until every service is
+                      healthy (or print `compose ps` + a `logs <svc>` hint
+                      and exit 1 on timeout). A '.' prints every 5 seconds
+                      while waiting so the run is visibly alive on slow
+                      hosts (cold MySQL init can take 60-90s).
 
 Smoke test / tear-down (work against an already-existing docker/.env):
   --verify            Probe nginx / octo-server / matter / object-store
@@ -1337,18 +1404,18 @@ if [[ "${RUN_UP}" == "true" ]]; then
   # process sees it even if the calling shell never did.
   export COMPOSE_PROJECT_NAME="${PROJECT_NAME_VALUE}"
   echo ""
-  info "Starting stack (project: ${PROJECT_NAME_VALUE}) — first boot can take 60-120s…"
-  if compose_up_and_wait "${CC}"; then
+  info "Starting stack (project: ${PROJECT_NAME_VALUE}) — waiting up to ${COMPOSE_UP_WAIT_TIMEOUT_DEFAULT}s for all services to become healthy."
+  info "A '.' will print every 5s while we wait so you know the script is still alive."
+  if compose_up_and_wait "${CC}" "${COMPOSE_UP_WAIT_TIMEOUT_DEFAULT}"; then
     info "All services reached healthy."
   else
     # FAIL-FAST: a compose-up failure means the stack is NOT running.
     # Previously this was just a warning and the success banner below
     # printed anyway, which (a) misled the operator and (b) let CI /
     # automation see exit 0 when nothing was actually up.
-    err "${CC} up failed — stack is NOT running."
-    err "Run:"
-    err "    cd docker && ${CC} ps"
-    err "    cd docker && ${CC} logs --tail 100"
+    # `compose_up_and_wait` already printed `ps` + a `logs <svc>` hint
+    # (YUJ-1019 / GH#32) above this line, so we only need the
+    # rerun-pointer here.
     err "Fix the root cause and rerun ./setup.sh --up (or ./setup.sh --verify"
     err "once the stack is healthy)."
     err "docker/.env has been written — re-running setup.sh is NOT required."

--- a/setup.sh
+++ b/setup.sh
@@ -131,7 +131,7 @@ compose_supports_wait() {
 check_compose_running_states() {
   local statuses="$1" failed=""
   failed="$(printf '%s\n' "${statuses}" \
-              | grep -vE -- '-(preflight|minio-init)-' \
+              | grep -vE -- '-(preflight|minio-init)-.*Exited \(0\)' \
               | grep -E 'Exited \([1-9]|Restarting|Dead' || true)"
   if [[ -n "${failed}" ]]; then
     printf '%s\n' "${failed}"


### PR DESCRIPTION
## Summary

Fixes [GH#32](https://github.com/Mininglamp-OSS/octo-deployment/issues/32) (YUJ-1019).

PR#30 public-IP E2E exposed: `setup.sh --up` invoked plain `docker compose up -d` (no `--wait`), so on a freshly built host the script returned immediately while MySQL was still booting. The follow-up `octo-server` health probe then retried 5 times and `setup.sh` exited 1 — operators had to manually rerun `docker compose up -d --wait` to get a healthy stack. PR#30 dispatch.md item #9 already called for `--wait` + progress dots; this lands what R1-R10 left on the table.

## Changes

### `setup.sh`
- `compose_up_and_wait` now runs `docker compose up -d --wait --wait-timeout 120` on Compose ≥ 2.20 (with the existing manual health-poll fallback on older Compose), both bounded by a single `COMPOSE_UP_WAIT_TIMEOUT_DEFAULT=120` constant.
- A background ticker prints a `.` every 5s to stderr while we wait, so the run is visibly alive on slow hosts where cold MySQL init can take 60-90s and compose itself prints nothing.
- On timeout / hard failure the helper now dumps the captured compose log tail, runs `docker compose ps`, and prints a `logs <unhealthy-service>` hint so operators have an immediate next step instead of a bare exit 1.
- Outer `--up` block trimmed (no longer prints duplicate `ps`/`logs` guidance) and reworded to mention the 120s budget and the dots.
- `--up` help text rewritten to document the new behavior.

### Docs (`README.md` / `README.zh.md` / `docker/README.md` / `docker/README.zh.md`)
- Added a `--up` shortcut block under the Docker Compose quick-start, documenting wait-until-healthy semantics, the 120s timeout, and the progress-dot affordance.
- Existing manual `(cd docker && docker compose up -d --wait)` paths are kept unchanged.

## R4 follow-up — lml R3 blocker (one-shot crash visibility in fallback poll)

Commit `6f48407` lands lml R3's precise one-line diff against `check_compose_running_states()`:

```diff
- grep -vE -- '-(preflight|minio-init)-'
+ grep -vE -- '-(preflight|minio-init)-.*Exited \(0\)'
```

Previously the Compose < 2.20 health-poll fallback stripped every `preflight` / `minio-init` line by name before scanning for `Exited (non-zero) / Restarting / Dead`, so a one-shot init that failed (`Exited (1)`, `Exited (137)`, `Restarting (1)`, ...) was invisible to the gate, violating the new docs contract ("every one-shot init job must exit 0"). The matching R2 fix already shipped on the `failing_svcs` hint path (`^(preflight|minio-init)\tExited \(0\)`); this PR now applies the same shape to the fatal-state filter so both paths agree.

### R4 validation
- `bash -n setup.sh` — clean.
- 6 synthetic `check_compose_running_states` cases replayed (`preflight Exited (0)` + `minio-init Exited (0)` correctly suppressed; `preflight Exited (1)`, `minio-init Restarting (1)`, `minio-init Exited (137)`, long-running `matter Exited (137)`, long-running `octo-server Restarting (1)` all surface).
- Diff is byte-for-byte the one lml posted in R3.

Jerry R3's wider suggestion (`ps --all` + diff vs `compose config --services`) is acknowledged as a more thorough hardening and tracked for a follow-up issue — per lml's R3 agreement it is **out of scope** for this PR.

## Local validation

- `bash -n setup.sh` — syntax OK.
- `shellcheck setup.sh` — no new findings (5 pre-existing info-level hits, all SC2015/SC2016 carryover).
- `(cd docker && docker compose config -q)` — config OK.
- `./setup.sh --help` renders the rewritten `--up` description correctly.
- Unit-test of the dots + timeout logic on a stubbed `compose`: success path prints `.` every 5s then returns 0; failure path returns non-zero immediately and dumps the captured stderr.

## E2E (pending — needs GCP machine)

Per the dispatch:

- Build a NEW GCP instance (`octo-ootb-dispatch-v11`, **do not** reuse `octo-ootb-dispatch-v10`).
- `setup.sh --non-interactive --ip <IP> --up` should succeed in a single shot, all containers `(healthy)`.
- `docker stop mysql` then `setup.sh --up --force` should time out (not hang) and print `compose ps` + the `logs <svc>` hint.

GCP access is not available from this sandbox — screenshots of `compose ps` (all healthy) and `setup.sh` single-shot success will be attached to this PR before merge, per the anti-review-storm protocol.

## Anti-review-storm checklist

- One-shot patch — no incremental drip.
- README + README.zh + `docker/README` + `docker/README.zh` all updated in this PR.
- `--up` help text + outer block + helper all consistent on the 120s budget and the dots affordance.
- R4 is a single-line grep change, no extra scope (Jerry's broader hardening deferred per lml).

---

## R5 update (head `a4c07e8`) — Jerry R4 P0×2 + 1 nit, one-shot close

### Extracted helper

`verify_all_services_running_or_healthy(statuses, expected_services)` — shared "expected services vs actual states" contract checker (setup.sh:137).

Contract per docs/dispatch.md item 9 ("every long-running service must be healthy"):

| service kind | PASS | WAIT | FATAL |
|---|---|---|---|
| long-running | `Up` (healthy or no healthcheck) | `(unhealthy)` / `(health: starting)` | `Created`, `Exited (any code incl. 0)`, `Restarting`, `Dead`, `Paused`, `Removing`, missing row |
| one-shot (`preflight`, `minio-init`) | `Exited (0)` | `Up …` / `Created` | `Exited (n>0)`, `Restarting`, `Dead`, missing row |

stdout = `<REASON>\t<row-detail>` rows (FATAL or WAIT), one per failing service; empty stdout ⇔ contract satisfied.

### Both paths now call the helper

```
$ grep -n 'verify_all_services_running_or_healthy' setup.sh
137:verify_all_services_running_or_healthy() {
184:# `verify_all_services_running_or_healthy` contract (every long-running
217:      if report="$(verify_all_services_running_or_healthy "${statuses}" "${expected}")"; then
603:    # check to `verify_all_services_running_or_healthy` — the same
617:      if verify_report="$(verify_all_services_running_or_healthy "${statuses}" "${expected_services}")"; then
```

- Line 217 → `compose_poll_healthy()` fallback (Compose < 2.20). Returns 0 on PASS, 1 immediately on any FATAL row, keeps polling while only WAIT rows are outstanding.
- Line 617 → `--verify` step 1 (container health). Both FATAL and WAIT rows reported as failures (stack should be steady by `--verify` time).

The old `check_compose_running_states()` is gone (was used in exactly those two sites). The duplicate inline Exited(0)/missing-row scan in `--verify` is gone too.

### Stub repro — Jerry's exact case

```
=== STUB REPRO: compose_poll_healthy with statuses='octo-mysql-1 Created' + 'octo-octo-server-1 Created' ===
FATAL: service(s) in non-recoverable state:
    octo-mysql-1	Created
    octo-octo-server-1	Created
RESULT: returned 1  ← correct (Created on long-running service → FATAL)
```

On `6f48407d` this returned 0 (contract violation). On `a4c07e8` it returns 1, with the failing rows emitted to stderr.

12-case contract test (happy path, Created on long svc, Exited(0) on long svc, missing row, (health: starting) → WAIT, (unhealthy) → WAIT, one-shot still running, one-shot Exited(1), Up-no-healthcheck, Restarting, legacy underscore container names, anchor regression wukongim vs wukongim-extra) — all pass.

### Reviewer-provenance markers stripped

```
$ grep -nE 'codex|Codex' setup.sh
(no output)
```

The three call-outs Jerry flagged (`:175` `YUJ-1019 codex review P1 #2`, `:249` `Codex review P1 #1`, `:348` `Codex review P2 #1 (R2 follow-up)`) are gone; comments now describe *why*, not *who asked*.

### Timeout diagnostic — concrete still-starting service names

`<still-starting-service>` placeholder removed. The timeout branch in `compose_up_and_wait` now parses `(health: starting)` rows out of `${cc} ps --all --format '{{.Service}}\t{{.Status}}'` and emits one `(cd docker && ${cc} logs --tail 200 <svc>)` line per concrete service.


---

## R6 (head `5b113b9`) — `Created` on long-svc is WAIT, not FATAL (Jerry + lml R5 consensus, one-line)

R5 helper PASS/WAIT/FATAL design was right, but the long-running-svc branch put `Created` into FATAL. That broke cold-boot: `compose up -d` starts containers asynchronously down the `depends_on` graph, and during the gate window (e.g. preflight `Up`, mysql `Up (health: starting)`, **octo-server `Created`** waiting for preflight to exit 0) `compose_poll_healthy()` saw `Created` → returned 1 → spurious failure.

### Fix — one case-arm change (lml-钦点 Option C)

```diff
--- a/setup.sh
+++ b/setup.sh
@@ verify_all_services_running_or_healthy() {
       *)
         case "${status}" in
-          Up*"(unhealthy)"*|Up*"(health: starting)"*)
+          Up*"(unhealthy)"*|Up*"(health: starting)"*|Created*)
             out="${out}WAIT	${row}
 "
             ;;
           Up*)                           : ;;  # PASS — healthy or no healthcheck
           *)                             out="${out}FATAL	${row}
 " ;;
         esac
```

Doc comment above `compose_poll_healthy()` updated to match (FATAL no longer lists `Created`; WAIT now does, with the cold-boot-race rationale).

### Why this is safe for both call sites (no `--strict` flag needed)

| Caller | sees `Created` long-svc row | semantics |
| --- | --- | --- |
| `compose_poll_healthy` (line 217) | helper rc=1, FATAL count=0, WAIT count≥1 | does **not** early-fail (only `^FATAL\t` triggers `return 1`); sleeps 5s and re-polls — exactly what we want during cold-boot. |
| `--verify` step 1 (line 626) | helper rc=1, WAIT row present | existing caller logic already treats **both FATAL and WAIT as failures** because `--verify` runs against a stack that is supposed to be steady; a `Created` row at that point means the gate never cleared. Fails correctly. |

### Stub repro

Driver: `bash /tmp/r6_stub.sh` (sourced `verify_all_services_running_or_healthy` directly from `setup.sh:137-191`). Expected behavior column = the contract lml + Jerry agreed on.

```
[C1: cold-boot race (Jerry's case)] rc=1 FATAL=0 WAIT=3
   WAIT	octo-preflight-1	Up 5 seconds
   WAIT	octo-mysql-1	Up 4 seconds (health: starting)
   WAIT	octo-octo-server-1	Created                                ✓ PASS
   → compose_poll_healthy: no ^FATAL row → keeps polling (not a false failure).

[C2: octo-server Created only (verify-as-failure)] rc=1 FATAL=0 WAIT=1
   WAIT	octo-octo-server-1	Created                                ✓ PASS
   → --verify caller (FATAL OR WAIT = failure) fails correctly.

[C3: happy path] rc=0 FATAL=0 WAIT=0                                  ✓ PASS

[C4: real FATAL — long-svc Exited(137)] rc=1 FATAL=1 WAIT=0
   FATAL	octo-octo-server-1	Exited (137)                          ✓ PASS
   → compose_poll_healthy early-fails immediately (Exited on long svc still FATAL).

[C5: one-shot still running → WAIT, not FATAL] rc=1 FATAL=0 WAIT=2
   WAIT	octo-preflight-1	Up 2 seconds
   WAIT	octo-octo-server-1	Created                                ✓ PASS

[C6: one-shot Exited(1) → FATAL] rc=1 FATAL=1 WAIT=0
   FATAL	octo-preflight-1	Exited (1)                              ✓ PASS

[C7: missing container row → FATAL] rc=1 FATAL=1 WAIT=0
   FATAL	octo-server	(no container row in compose ps)             ✓ PASS
```

On `a4c07e8` C1 returned a FATAL row for octo-server → `compose_poll_healthy` would `return 1` immediately (the regression Jerry + lml independently flagged). On `5b113b9` it returns WAIT → poll continues. All other contract cases (C3–C7) unchanged.

### Sanity grep

```
$ grep -nE 'Created\*' setup.sh
165:          Up*"(unhealthy)"*|Up*"(health: starting)"*|Created*)
```

One hit, in the case-arm, exactly as specified.

```
$ bash -n setup.sh && echo ok
ok
$ shellcheck setup.sh   # no new findings — same 5 pre-existing SC2015 / 2 SC2016 info-level lines as R5
```

### Scope discipline

One case-arm change + a doc-comment update reflecting the new classification. Nothing else touched. No `--strict` mode, no second helper, no caller changes. Ready for lml + Jerry to flip APPROVED — no R7.
