### PR TITLE
fix(ootb): default presign URL host to OCTO_EXTERNAL_IP (GH#41)

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -256,7 +256,19 @@ services:
       # `:29000`), override MINIO_SERVER_URL and TS_MINIO_DOWNLOADURL
       # in .env. See docker/README.md "Network surface" for the
       # rationale and trade-offs.
-      MINIO_SERVER_URL: ${MINIO_SERVER_URL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}}
+      # GH#41 (YUJ-1060): default prefers OCTO_EXTERNAL_IP over
+      # OCTO_DOMAIN. OOTB public-IP deployments leave OCTO_DOMAIN at
+      # the `octo.local` placeholder (no DNS), and a presigned PUT
+      # signed against that host fails browser DNS — every image /
+      # file message silently breaks. setup.sh always populates
+      # OCTO_EXTERNAL_IP (from --ip or auto-detect), so preferring
+      # it here makes the default browser-reachable without operator
+      # intervention. Operators with a real DNS name set OCTO_DOMAIN
+      # AND override MINIO_SERVER_URL explicitly in .env. MUST track
+      # TS_MINIO_DOWNLOADURL below — MinIO validates SigV4 against
+      # the host octo-server signed for; a mismatch returns 403
+      # SignatureDoesNotMatch on every PUT.
+      MINIO_SERVER_URL: ${MINIO_SERVER_URL:-http://${OCTO_EXTERNAL_IP:-${OCTO_DOMAIN:-octo.local}}:${OCTO_HTTP_PORT:-28080}}
       # MINIO_BROWSER_REDIRECT_URL is the canonical URL MinIO redirects
       # the console to after auth. The previous default pointed at the
       # nginx /minio-console/ route, but that route is no longer exposed
@@ -659,7 +671,19 @@ services:
       # --- terminating TLS at a different hostname), set
       # --- TS_MINIO_DOWNLOADURL in .env to the public URL of YOUR
       # --- nginx — still host:port only, no path.
-      TS_MINIO_DOWNLOADURL: "${TS_MINIO_DOWNLOADURL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}}"
+      # --- GH#41 (YUJ-1060): default prefers OCTO_EXTERNAL_IP over
+      # --- OCTO_DOMAIN so that OOTB public-IP deployments produce a
+      # --- browser-resolvable presign host without operator action.
+      # --- Without this, OCTO_DOMAIN stays at the placeholder
+      # --- `octo.local`, octo-server signs presigned PUT URLs against
+      # --- `http://octo.local:28080/...`, and the browser hits DNS
+      # --- fail → every image / file message silently breaks.
+      # --- setup.sh always populates OCTO_EXTERNAL_IP (from --ip or
+      # --- auto-detect); operators with a real DNS name set
+      # --- OCTO_DOMAIN AND override TS_MINIO_DOWNLOADURL explicitly
+      # --- in .env. MUST track MINIO_SERVER_URL above — the two MUST
+      # --- resolve to the SAME host:port or SigV4 fails on every PUT.
+      TS_MINIO_DOWNLOADURL: "${TS_MINIO_DOWNLOADURL:-http://${OCTO_EXTERNAL_IP:-${OCTO_DOMAIN:-octo.local}}:${OCTO_HTTP_PORT:-28080}}"
       # --- octo-server's own external URL (the value it returns to
       # --- clients in places that need an absolute URL — e.g. login
       # --- redirects, OIDC callback hints, public asset links). The


### PR DESCRIPTION
## Summary

Closes #41.

OOTB public-IP deployments leave `OCTO_DOMAIN` at its placeholder `octo.local` (operators have no DNS pointed at the VM). The existing compose defaults therefore made octo-server sign presigned PUT URLs against `http://octo.local:28080/...`. The browser DNS-fails on that host and **every image / file message silently breaks at the upload step** — caught end-to-end on Coda E2E v12 (35.229.161.253).

`setup.sh` always populates `OCTO_EXTERNAL_IP` (from `--ip` or auto-detect), so preferring it in the default fallback makes presign URLs browser-reachable without any operator action.

## Change

Two env vars, in lockstep:

| line | var | role |
|------|-----|------|
| 259 | `MINIO_SERVER_URL` | MinIO's own absolute-URL host |
| 674 | `TS_MINIO_DOWNLOADURL` | the host octo-server signs presign URLs for |

Both now default to:

```
http://${OCTO_EXTERNAL_IP:-${OCTO_DOMAIN:-octo.local}}:${OCTO_HTTP_PORT:-28080}
```

The two MUST resolve to the same `host:port` or SigV4 rejects every PUT with `403 SignatureDoesNotMatch`, hence the joint change. Explicit `.env` overrides (`MINIO_SERVER_URL=…` / `TS_MINIO_DOWNLOADURL=…`) keep precedence, so operators with a real DNS name still work as documented.

## Root cause analysis (grep evidence)

octo-server is **correct** — `modules/file/service_minio.go:264` `publicEndpoint()` resolver reads `cfg.Minio.DownloadURL` (from `TS_MINIO_DOWNLOADURL`), and `modules/file/service_minio.go:370` `PresignedPutURL()` signs against that public endpoint. No `os.Getenv("OCTO_DOMAIN")` in any URL-building Go code.

The bug is purely in this compose default:

```
grep -nE 'OCTO_DOMAIN|OCTO_EXTERNAL_IP|TS_MINIO_DOWNLOADURL|MINIO_SERVER_URL' docker/docker-compose.yaml
259: MINIO_SERVER_URL:     ${MINIO_SERVER_URL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}}
662: TS_MINIO_DOWNLOADURL: "${TS_MINIO_DOWNLOADURL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}}"
```

## Scope

Deliberately limited to the presign path. Audit found two more defaults with the same `OCTO_DOMAIN`-first pattern that affect *other* URL-building paths:

| line | var | path | tracking |
|------|-----|------|----------|
| 475 | `WK_EXTERNAL_WSADDR` | wukongim WebSocket addr | separate issue |
| 682 | `TS_EXTERNAL_BASEURL` | OIDC callback / asset link | separate issue |

They are NOT in the presign signature chain, so kept out of this PR to keep the hunk minimal and reviewable.

## Verification

Rendered `docker compose config` under three scenarios — all behave as expected:

```text
1. OCTO_EXTERNAL_IP=35.229.161.253, OCTO_DOMAIN unset (defaults to octo.local)
   → MINIO_SERVER_URL=http://35.229.161.253:28080  ✅
   → TS_MINIO_DOWNLOADURL=http://35.229.161.253:28080  ✅

2. only OCTO_DOMAIN=mycompany.example.com set (real DNS)
   → MINIO_SERVER_URL=http://mycompany.example.com:28080  ✅
   → TS_MINIO_DOWNLOADURL=http://mycompany.example.com:28080  ✅

3. neither set
   → MINIO_SERVER_URL=http://octo.local:28080  ✅ (matches prior default)
   → TS_MINIO_DOWNLOADURL=http://octo.local:28080  ✅
```

`docker compose -f docker/docker-compose.yaml config --quiet` exits 0.

## E2E suggested (per linked issue)

```bash
# Fresh GCP instance (not reusing v12)
sudo bash ../setup.sh --non-interactive --ip <new-IP> --up
sleep 30  # wait for healthy

TOKEN=$(curl -sS -X POST http://<new-IP>:28080/api/v1/manager/login \
  -H 'Content-Type: application/json' \
  -d '{"username":"superAdmin","password":"<OCTO_ADMIN_PWD>"}' | jq -r '.data.token // .token')

curl -sS -H "token: $TOKEN" \
  "http://<new-IP>:28080/api/v1/file/upload/credentials?type=common&filename=x.txt&fileSize=1" \
  | jq .uploadUrl
# Expect: "http://<new-IP>:28080/common/…"  (NOT "http://octo.local:28080/…")
```

Refs: YUJ-1060
