### PR TITLE
[OOTB][P1] Default OCTO_DOMAIN=localhost (Fixes #49)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -47,13 +47,14 @@
 # -----------------------------------------------------------------------------
 
 # --- Domain & host --------------------------------------------------------
-# S7 (R7 / YUJ-1020 / GH#40+41): OCTO_DOMAIN vs OCTO_EXTERNAL_IP semantics.
+# S7 (R7 / YUJ-1020 / GH#40+41 / GH#49): OCTO_DOMAIN vs OCTO_EXTERNAL_IP
+# semantics.
 #
 # These two knobs together determine which host clients (browsers,
 # native apps, --smoke-test) talk to. setup.sh applies the rule:
 #
 #   * OCTO_DOMAIN is a REAL domain (anything other than empty /
-#     `octo.local`) → DOMAIN is authoritative. Compose defaults
+#     `localhost`) → DOMAIN is authoritative. Compose defaults
 #     (`http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}`) take effect for
 #     MINIO_SERVER_URL / TS_MINIO_DOWNLOADURL / TS_EXTERNAL_BASEURL.
 #     OCTO_EXTERNAL_IP is consulted for internal binding / firewall
@@ -63,29 +64,38 @@
 #       Example: `--non-interactive --domain octo.example.com --ip 1.2.3.4`
 #                (DNS + explicit IP for firewall / binding)
 #
-#   * OCTO_DOMAIN is a PLACEHOLDER (empty or `octo.local`) AND
-#     OCTO_EXTERNAL_IP is set → IP is authoritative. setup.sh
-#     materialises three explicit overrides into THIS file so all
-#     client-facing URLs use the IP (see "S1 materialised because ..."
-#     block setup.sh appends on those runs). Without this, presigned PUT
-#     URLs the server hands back point at `octo.local`, the browser
-#     DNS-fails on the host, and every image / file upload silently
-#     breaks at PUT.
+#   * OCTO_DOMAIN is a PLACEHOLDER (empty or `localhost`) AND
+#     OCTO_EXTERNAL_IP is set to something other than 127.0.0.1 →
+#     IP is authoritative. setup.sh materialises three explicit
+#     overrides into THIS file so all client-facing URLs use the IP
+#     (see "S1 materialised because ..." block setup.sh appends on
+#     those runs). Without this, presigned PUT URLs the server hands
+#     back point at `localhost`, a remote browser dials its own
+#     loopback, and every image / file upload silently breaks at PUT.
 #       Example: `--non-interactive --ip 35.229.161.253`
 #                (public IP, no DNS — the OOTB GCP case)
 #
 # Both knobs default to safe loopback so a missed-config run does not
-# mint public-facing URL overrides: with OCTO_DOMAIN=octo.local +
+# mint public-facing URL overrides: with OCTO_DOMAIN=localhost +
 # OCTO_EXTERNAL_IP=127.0.0.1, only the *generated external URLs*
 # (MINIO_SERVER_URL / TS_MINIO_DOWNLOADURL / TS_EXTERNAL_BASEURL and
-# the ADMIN_URL printed in summaries) stay on loopback / the placeholder
-# domain. Nginx itself still binds whatever OCTO_NGINX_BIND points at
-# (default 0.0.0.0:OCTO_HTTP_PORT — see below), so a client that
-# already knows this host's IP can still reach the stack on
-# OCTO_HTTP_PORT. Flip OCTO_NGINX_BIND to 127.0.0.1 (and the matching
-# backing-service binds further down) if you want a fully loopback-only
-# deployment, and front it with a reverse proxy / SSH tunnel from there.
-OCTO_DOMAIN=octo.local
+# the ADMIN_URL printed in summaries) stay on loopback. Nginx itself
+# still binds whatever OCTO_NGINX_BIND points at (default
+# 0.0.0.0:OCTO_HTTP_PORT — see below), so a client that already knows
+# this host's IP can still reach the stack on OCTO_HTTP_PORT. Flip
+# OCTO_NGINX_BIND to 127.0.0.1 (and the matching backing-service
+# binds further down) if you want a fully loopback-only deployment,
+# and front it with a reverse proxy / SSH tunnel from there.
+#
+# Historical note (GH#49, 2026-05-18): the default OCTO_DOMAIN used to
+# be `octo.local`, which required an /etc/hosts entry on every client.
+# A fresh Mac install without that entry got `ws://octo.local:28080/ws`
+# close code 1006 the moment IM tried to open the WebSocket. The
+# placeholder is now `localhost` (resolves out of the box on every
+# supported host). Existing deployments with OCTO_DOMAIN=octo.local
+# keep working — the value is still treated as a real domain by
+# setup.sh — but new fresh installs no longer need the /etc/hosts step.
+OCTO_DOMAIN=localhost
 OCTO_EXTERNAL_IP=127.0.0.1
 
 # --- Port mapping (host side) ---------------------------------------------

--- a/docker/README.md
+++ b/docker/README.md
@@ -250,8 +250,12 @@ the only path that gets a fresh checkout to a `(healthy)` stack
 without manual editing.
 
 Once healthy, the stack is reachable through nginx on
-`http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}` (default `http://octo.local:28080`).
-Add an `/etc/hosts` entry for `octo.local` if you keep the default domain.
+`http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}` (default `http://localhost:28080`).
+With the default `localhost` no extra DNS / `/etc/hosts` configuration
+is required on the host running the stack. If you set
+`OCTO_DOMAIN=<a real hostname>`, make sure that name resolves on every
+machine that hits the UI (either through real DNS or via an
+`/etc/hosts` entry pointing at this host's IP).
 
 ### `setup.sh --smoke-test` smoke test
 
@@ -1473,9 +1477,11 @@ location forwards the request to MinIO. Check, in order:
 1. `OCTO_HTTP_PORT` (default `28080`) is reachable from the client
    network — `curl -v http://${OCTO_DOMAIN}:28080/_nginx_up` should
    return `200`.
-2. `${OCTO_DOMAIN}` resolves on the client (the `/etc/hosts` entry
-   for `octo.local` has to exist on every machine that hits the UI,
-   not just the host).
+2. `${OCTO_DOMAIN}` resolves on the client. With the OOTB default
+   (`localhost`) this is automatic on the same host the stack is
+   running on. If you set OCTO_DOMAIN to a real hostname, that name
+   has to resolve on every machine that hits the UI (real DNS or a
+   matching `/etc/hosts` entry).
 3. `TS_MINIO_DOWNLOADURL` and `MINIO_SERVER_URL` agree — both should
    default to `http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}` (no path
    prefix). Verify with `docker compose config | grep -E

--- a/docker/README.zh.md
+++ b/docker/README.zh.md
@@ -140,7 +140,7 @@ sudo ./setup.sh --up
 
 `setup.sh` 写出含轮换随机密钥的 `docker/.env` 和自动生成的 `OCTO_ADMIN_PWD`，并**在最后打印 admin URL + 密码**，免得你回头去 grep `.env`。这是从空 checkout 到 `(healthy)` 栈无需手改任何东西的唯一路径。
 
-栈起来后，通过 nginx 访问：`http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}`（默认 `http://octo.local:28080`）。继续用默认域名 `octo.local` 的话需要在客户端 `/etc/hosts` 里加一条解析。
+栈起来后，通过 nginx 访问：`http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}`（默认 `http://localhost:28080`）。默认 `localhost` 在运行栈的主机上不需要任何额外的 DNS / `/etc/hosts` 配置。如果你把 `OCTO_DOMAIN` 改成真实域名，则每台访问 UI 的客户端机器都要能解析这个域名（真实 DNS，或者 `/etc/hosts` 里指向本机 IP）。
 
 ### `setup.sh --smoke-test` 自检命令
 
@@ -957,7 +957,7 @@ OCTO 图片上传依赖 [`Mininglamp-OSS/octo-server#24`](https://github.com/Min
 单端口形态（默认）下，预签名 URL 指向 nginx vhost（`${OCTO_DOMAIN}:${OCTO_HTTP_PORT}`），bucket-name 正则 location 转发到 MinIO。按顺序检查：
 
 1. 客户端网络能到 `OCTO_HTTP_PORT`（默认 `28080`）——`curl -v http://${OCTO_DOMAIN}:28080/_nginx_up` 应返回 `200`。
-2. 客户端能解析 `${OCTO_DOMAIN}`（继续用 `octo.local` 的话，每台访问 UI 的机器都要有 `/etc/hosts` 条目，不只是 server 自己）。
+2. 客户端能解析 `${OCTO_DOMAIN}`。OOTB 默认（`localhost`）在运行栈的同一台机器上自动可用；如果你把 `OCTO_DOMAIN` 改成真实域名，则每台访问 UI 的客户端都要能解析这个域名（真实 DNS 或 `/etc/hosts` 条目）。
 3. `TS_MINIO_DOWNLOADURL` 和 `MINIO_SERVER_URL` 一致——都应默认 `http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}`（无 path 前缀）。验证：`docker compose config | grep -E '(TS_MINIO_DOWNLOADURL|MINIO_SERVER_URL)'`。octo-server 在启动时拒绝带 path 前缀的 download URL。
 4. nginx 配置里 bucket-name 正则 location 还在：`docker/nginx/conf.d/octo.conf.template` 中 `^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)/.+`。如果你定制了 nginx，确认这一块没被删。
 

--- a/docker/certs/README.md
+++ b/docker/certs/README.md
@@ -23,7 +23,7 @@ sudo chown $(id -u):$(id -g) docker/certs/*.pem
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
   -keyout docker/certs/privkey.pem \
   -out docker/certs/fullchain.pem \
-  -subj "/CN=octo.local"
+  -subj "/CN=localhost"
 ```
 
 ## Enabling HTTPS

--- a/docker/configs/octo-server.yaml
+++ b/docker/configs/octo-server.yaml
@@ -22,7 +22,7 @@ mode: "release"
 #   TS_EXTERNAL_IP      = ${OCTO_EXTERNAL_IP}
 # Those values are the single source of truth — change them in `.env`,
 # not here. Hard-coding them in this file shadows the env vars and
-# silently strands operators on `octo.local:28080` no matter what they
+# silently strands operators on `localhost:28080` no matter what they
 # put in `.env`.
 external:
   ip: ""

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,7 +2,7 @@
 # OCTO Server · one-shot deployment stack (OSS)
 # -----------------------------------------------------------------------------
 # Brings up OCTO Server + all required dependencies behind an nginx reverse
-# proxy that serves a user-chosen domain (default: octo.local). Everything is
+# proxy that serves a user-chosen domain (default: localhost). Everything is
 # scoped under a dedicated Docker bridge so it does not collide with other
 # stacks on the host.
 #
@@ -256,7 +256,7 @@ services:
       # `:29000`), override MINIO_SERVER_URL and TS_MINIO_DOWNLOADURL
       # in .env. See docker/README.md "Network surface" for the
       # rationale and trade-offs.
-      MINIO_SERVER_URL: ${MINIO_SERVER_URL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}}
+      MINIO_SERVER_URL: ${MINIO_SERVER_URL:-http://${OCTO_DOMAIN:-localhost}:${OCTO_HTTP_PORT:-28080}}
       # MINIO_BROWSER_REDIRECT_URL is the canonical URL MinIO redirects
       # the console to after auth. The previous default pointed at the
       # nginx /minio-console/ route, but that route is no longer exposed
@@ -472,7 +472,7 @@ services:
       # `${...}` once on parse — values that come out of .env do NOT get a
       # second pass. Putting the default expression here lets operators set
       # OCTO_WK_WS_ADDR to a literal in .env when they want to override.
-      WK_EXTERNAL_WSADDR:  ${OCTO_WK_WS_ADDR:-ws://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}/ws}
+      WK_EXTERNAL_WSADDR:  ${OCTO_WK_WS_ADDR:-ws://${OCTO_DOMAIN:-localhost}:${OCTO_HTTP_PORT:-28080}/ws}
       WK_EXTERNAL_WSSADDR: ${OCTO_WK_WSS_ADDR:-}
       # Shared admin token. WuKongIM binds env vars to YAML keys via Viper's
       # default key replacer (`.` -> `_`, upper-cased, prefix `WK_`), so the
@@ -659,7 +659,7 @@ services:
       # --- terminating TLS at a different hostname), set
       # --- TS_MINIO_DOWNLOADURL in .env to the public URL of YOUR
       # --- nginx — still host:port only, no path.
-      TS_MINIO_DOWNLOADURL: "${TS_MINIO_DOWNLOADURL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}}"
+      TS_MINIO_DOWNLOADURL: "${TS_MINIO_DOWNLOADURL:-http://${OCTO_DOMAIN:-localhost}:${OCTO_HTTP_PORT:-28080}}"
       # --- octo-server's own external URL (the value it returns to
       # --- clients in places that need an absolute URL — e.g. login
       # --- redirects, OIDC callback hints, public asset links). The
@@ -679,7 +679,7 @@ services:
       # --- `http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}` and ignored any
       # --- `.env` override — clients then received `http://…:28080`
       # --- back from /api responses behind an HTTPS-fronted stack.
-      TS_EXTERNAL_BASEURL: "${TS_EXTERNAL_BASEURL:-http://${OCTO_DOMAIN:-octo.local}:${OCTO_HTTP_PORT:-28080}}"
+      TS_EXTERNAL_BASEURL: "${TS_EXTERNAL_BASEURL:-http://${OCTO_DOMAIN:-localhost}:${OCTO_HTTP_PORT:-28080}}"
       TS_EXTERNAL_IP: "${OCTO_EXTERNAL_IP:-127.0.0.1}"
       # No `:-` default — an empty value here would silently drop
       # /internal/* callback HMAC verification on the octo-server side
@@ -743,7 +743,7 @@ services:
       octo-server:
         condition: service_healthy
     environment:
-      OCTO_DOMAIN: ${OCTO_DOMAIN:-octo.local}
+      OCTO_DOMAIN: ${OCTO_DOMAIN:-localhost}
     ports:
       - "${OCTO_NGINX_BIND:-0.0.0.0}:${OCTO_HTTP_PORT:-28080}:80"
       # HTTPS placeholder — single-port plus TLS form (architecture only,

--- a/setup.sh
+++ b/setup.sh
@@ -21,7 +21,13 @@
 set -euo pipefail
 
 # ── Defaults ─────────────────────────────────────────────────────────────────
-DOMAIN="octo.local"
+# GH#49 (2026-05-18): default OCTO_DOMAIN is `localhost` (not `octo.local`).
+# `octo.local` does not resolve on a fresh Mac / Windows / Linux install
+# without an /etc/hosts entry, so the IM WebSocket flips to readyState=3
+# (close code 1006) the moment the browser tries
+# `ws://octo.local:28080/ws`. `localhost` resolves out of the box on
+# every supported host and keeps the loopback-only contract intact.
+DOMAIN="localhost"
 EXTERNAL_IP=""
 ENABLE_HTTPS=false
 ENABLE_SUMMARY=false
@@ -540,7 +546,7 @@ env_get() {
   # `-rw------- root:root`, then a non-root user runs --smoke-test /
   # --verify) makes the `grep` below silently emit empty output. Every
   # downstream env_get call returns its default, and the smoke test
-  # then exercises octo.local:28080 with an empty admin password and
+  # then exercises localhost:28080 with an empty admin password and
   # nine probes FAIL with cryptic "no token in login response" /
   # "no uploadUrl in credentials response" messages that send the
   # operator hunting for a stack problem that does not exist.
@@ -584,7 +590,7 @@ Or adjust ownership: sudo chown root:root docker/.env && sudo chmod 600 docker/.
 #
 # Rule:
 #   - `OCTO_DOMAIN` is a PLACEHOLDER (empty or the literal default
-#     `octo.local` — operator never put real DNS in front of the VM) →
+#     `localhost` — operator never put real DNS in front of the VM) →
 #     `OCTO_EXTERNAL_IP` is the authoritative host. setup.sh
 #     materialises explicit `MINIO_SERVER_URL` / `TS_MINIO_DOWNLOADURL`
 #     / `TS_EXTERNAL_BASEURL` overrides pointing at the IP (S1 below),
@@ -592,11 +598,16 @@ Or adjust ownership: sudo chown root:root docker/.env && sudo chmod 600 docker/.
 #     URL the server returns therefore uses the IP and the browser /
 #     curl can actually reach it.
 #   - `OCTO_DOMAIN` is a REAL domain (anything other than empty /
-#     `octo.local`) → `OCTO_DOMAIN` is the authoritative host. Compose
+#     `localhost`) → `OCTO_DOMAIN` is the authoritative host. Compose
 #     defaults (`${OCTO_DOMAIN}:${OCTO_HTTP_PORT}`) take effect, the
 #     three URL overrides are NOT written into `.env`, and the
 #     `--smoke-test` probes the DOMAIN. `OCTO_EXTERNAL_IP` keeps its
 #     existing role for internal binding / firewall guidance only.
+#
+# Historical note (GH#49, 2026-05-18): the placeholder used to be
+# `octo.local`, which does not resolve on a fresh Mac install and
+# caused IM WebSocket close code 1006. The placeholder is now
+# `localhost` everywhere; the rule above is unchanged.
 #
 # Returns 0 (true) if OCTO_DOMAIN is a placeholder, 1 (false) otherwise.
 # Reads strictly from `.env` (via env_get) so the same answer is given
@@ -604,7 +615,7 @@ Or adjust ownership: sudo chown root:root docker/.env && sudo chmod 600 docker/.
 is_placeholder_domain() {
   local d
   d="$(env_get OCTO_DOMAIN "")"
-  [[ -z "${d}" || "${d}" == "octo.local" ]]
+  [[ -z "${d}" || "${d}" == "localhost" ]]
 }
 
 # Resolve the project name the way Compose does — but for the script's own
@@ -704,7 +715,7 @@ Generation:
   --non-interactive   Skip prompts; use defaults + auto-detect for anything
                       not provided via flags.
   --force             Overwrite an existing docker/.env without prompting.
-  --domain <d>        Set OCTO_DOMAIN (default: octo.local).
+  --domain <d>        Set OCTO_DOMAIN (default: localhost).
   --ip <ip>           Set OCTO_EXTERNAL_IP (skip auto-detect).
   --https             HTTPS preparation flag. Prints the manual
                       activation steps. This does NOT fully enable
@@ -831,17 +842,18 @@ if [[ "${RUN_VERIFY}" == "true" ]]; then
     fatal "curl is required for --smoke-test (every nginx / octo-server / MinIO / admin / presign probe shells out to \`curl -fsS\`). Install curl — every modern Linux distro ships it — and re-run \`setup.sh --smoke-test\` (or the deprecated \`--verify\` alias)."
   fi
   CC="$(compose_cmd)"
-  DOMAIN="$(env_get OCTO_DOMAIN octo.local)"
+  DOMAIN="$(env_get OCTO_DOMAIN localhost)"
   HTTP_PORT="$(env_get OCTO_HTTP_PORT 28080)"
   # S2 (R7 / GH#40): placeholder-aware probe-host selection. When OCTO_DOMAIN
-  # is a placeholder (empty or `octo.local`), `--smoke-test` must talk to the
-  # public IP — `octo.local` does not resolve from a GCP host without DNS, so
-  # the old `http://octo.local:28080` BASE_URL flatlined 8/11 probes on a
-  # healthy stack (PR#30 GCP E2E). When OCTO_DOMAIN is a real domain, we
-  # respect it (browsers go via DNS; the IP is only for internal binding /
-  # firewall). The presigned PUT URL the server returns is consumed verbatim
-  # by step 11 — S1 below pins the server to the same IP/DOMAIN choice when
-  # it writes `.env`, so step 11's URL matches BASE_URL automatically.
+  # is a placeholder (empty or `localhost`), `--smoke-test` must talk to the
+  # public IP when the operator gave us one — `localhost` only routes to the
+  # host the script is running on, so a remote --smoke-test (or one launched
+  # against a published deployment) needs OCTO_EXTERNAL_IP to reach the
+  # stack. When OCTO_DOMAIN is a real domain, we respect it (browsers go via
+  # DNS; the IP is only for internal binding / firewall). The presigned PUT
+  # URL the server returns is consumed verbatim by step 11 — S1 below pins
+  # the server to the same IP/DOMAIN choice when it writes `.env`, so step
+  # 11's URL matches BASE_URL automatically.
   if is_placeholder_domain; then
     PROBE_HOST="$(env_get OCTO_EXTERNAL_IP "${DOMAIN}")"
   else
@@ -1651,14 +1663,15 @@ if [[ "${RUN_UP}" == "true" ]]; then
       info "docker/.env now owned by root:root (mode 600)."
     fi
 
-    DOMAIN="$(env_get OCTO_DOMAIN octo.local)"
+    DOMAIN="$(env_get OCTO_DOMAIN localhost)"
     HTTP_PORT="$(env_get OCTO_HTTP_PORT 28080)"
     # R9 (YUJ-1068 / yujiawei PR#36 F1): same S1 placeholder rule —
-    # printing `http://octo.local:28080/admin/` in the success banner
-    # when the operator picked the placeholder domain hands them a URL
-    # their browser cannot resolve (no DNS pointed at the host). When
-    # OCTO_DOMAIN is a placeholder AND OCTO_EXTERNAL_IP is concrete,
-    # mint the admin URL off the IP so it is actually click-through.
+    # printing `http://localhost:28080/admin/` in the success banner
+    # when the operator picked the placeholder domain and is running
+    # the stack on a remote host hands them a URL their browser cannot
+    # resolve back to the deployment. When OCTO_DOMAIN is a placeholder
+    # AND OCTO_EXTERNAL_IP is concrete, mint the admin URL off the IP
+    # so it is actually click-through.
     EXTERNAL_IP_ENV="$(env_get OCTO_EXTERNAL_IP "")"
     if is_placeholder_domain && [[ -n "${EXTERNAL_IP_ENV}" ]]; then
       ADMIN_URL="http://${EXTERNAL_IP_ENV}:${HTTP_PORT}/admin/"
@@ -1729,12 +1742,12 @@ if [[ "${NON_INTERACTIVE}" == "false" ]]; then
 
   # Domain
   detected_ip="$(detect_ip)"
-  if [[ "${DOMAIN}" == "octo.local" || -z "${DOMAIN}" ]] \
+  if [[ "${DOMAIN}" == "localhost" || -z "${DOMAIN}" ]] \
      && [[ "${detected_ip}" != "127.0.0.1" ]]; then
     info "Detected public IP: ${detected_ip}"
     info "For a deployment reachable from outside this host, set OCTO_DOMAIN to a name"
     info "your clients can resolve (or use the detected IP directly)."
-    read -rp "Domain name [${detected_ip}] (Enter to use detected IP, type 'octo.local' for local-only): " user_domain
+    read -rp "Domain name [${detected_ip}] (Enter to use detected IP, type 'localhost' for local-only): " user_domain
     DOMAIN="${user_domain:-${detected_ip}}"
   else
     read -rp "Domain name [${DOMAIN}]: " user_domain
@@ -1743,7 +1756,7 @@ if [[ "${NON_INTERACTIVE}" == "false" ]]; then
 
   # External IP
   # R9 (YUJ-1068 / lml2468 PR#36 CR): when the operator picked a
-  # placeholder domain (empty or `octo.local`) the deployment is
+  # placeholder domain (empty or `localhost`) the deployment is
   # local-only by contract — S1 will materialise IP-based URL
   # overrides off whatever EXTERNAL_IP we accept here, and feeding it
   # `detect_ip`'s public address would silently mint
@@ -1752,7 +1765,7 @@ if [[ "${NON_INTERACTIVE}" == "false" ]]; then
   # Default to `127.0.0.1` in that case; the operator can still type
   # a public IP explicitly if they actually want external reach (in
   # which case they should also pick a non-placeholder domain).
-  if [[ -z "${DOMAIN}" || "${DOMAIN}" == "octo.local" ]]; then
+  if [[ -z "${DOMAIN}" || "${DOMAIN}" == "localhost" ]]; then
     ip_default="127.0.0.1"
   else
     ip_default="${detected_ip}"
@@ -1930,10 +1943,11 @@ HTTP_PORT="$(env_get OCTO_HTTP_PORT 28080)"
 # the ADMIN_URL we print in the post-generation summary banner (and the
 # --up --force success banner below). When the operator picked a
 # placeholder domain we already mint IP-based MinIO / TS overrides
-# below; printing `http://octo.local:28080/admin/` here would be the
-# odd one out and have the operator's browser DNS-fail on click. Use
-# the in-memory DOMAIN / EXTERNAL_IP here because the .env we just
-# wrote already reflects them and these are still in scope.
+# below; printing `http://localhost:28080/admin/` here would be the
+# odd one out and have the operator's browser miss the deployment
+# entirely if they hit the URL from a different machine. Use the
+# in-memory DOMAIN / EXTERNAL_IP here because the .env we just wrote
+# already reflects them and these are still in scope.
 if is_placeholder_domain && [[ -n "${EXTERNAL_IP}" ]]; then
   ADMIN_URL="http://${EXTERNAL_IP}:${HTTP_PORT}/admin/"
 else
@@ -1944,21 +1958,22 @@ fi
 # MinIO / TS URL overrides.
 #
 # When the operator uses `--ip <public-IP>` WITHOUT a real `--domain`,
-# `OCTO_DOMAIN` stays at its placeholder `octo.local` and the compose
+# `OCTO_DOMAIN` stays at its placeholder `localhost` and the compose
 # defaults (`http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}`) end up signing
-# presigned PUT URLs against `http://octo.local:28080/...`. The
-# operator's browser cannot resolve `octo.local` (no DNS pointed at the
-# VM), and every image / file message silently breaks at the upload
-# step — exactly the GH#41 failure mode caught on Coda E2E v12.
+# presigned PUT URLs against `http://localhost:28080/...`. A remote
+# browser sees `localhost` and tries its OWN loopback (not the VM),
+# and every image / file message silently breaks at the upload step —
+# the same failure mode caught on Coda E2E v12 (GH#41) and on the
+# fresh-Mac install reported in GH#49.
 #
 # When `OCTO_DOMAIN` IS a real domain (anything other than empty /
-# `octo.local`), the compose defaults already do the right thing and
+# `localhost`), the compose defaults already do the right thing and
 # rely on DNS — writing IP-based overrides here would break that DNS
 # topology (`--domain octo.example.com --ip 1.2.3.4` would have client
 # browsers calling the IP instead of the documented domain).
 #
 # So S1 materialises three lockstep overrides ONLY when both:
-#   (1) OCTO_DOMAIN is placeholder (empty or `octo.local`), AND
+#   (1) OCTO_DOMAIN is placeholder (empty or `localhost`), AND
 #   (2) OCTO_EXTERNAL_IP is set (operator gave us something concrete).
 # All three URLs must agree (SigV4 rejects every PUT with `403
 # SignatureDoesNotMatch` if MINIO_SERVER_URL and TS_MINIO_DOWNLOADURL
@@ -2018,7 +2033,7 @@ printf '  Admin password: %s%s%s\n' "${BOLD}" "${OCTO_ADMIN_PWD}" "${RESET}"
 echo ""
 
 # Firewall guidance — single-port deployment only needs OCTO_HTTP_PORT.
-if [[ "${EXTERNAL_IP}" != "127.0.0.1" ]] || [[ "${DOMAIN}" != "octo.local" ]]; then
+if [[ "${EXTERNAL_IP}" != "127.0.0.1" ]] || [[ "${DOMAIN}" != "localhost" ]]; then
   printf '%s  Firewall:%s\n' "${BOLD}" "${RESET}"
   printf '    The OOTB stack is single-port — only open TCP %s%s%s to clients.\n' "${BOLD}" "${HTTP_PORT}" "${RESET}"
   printf '    All other services (MinIO API/console, MySQL, Redis, WuKongIM monitor,\n'


### PR DESCRIPTION
## Why

`OCTO_DOMAIN=octo.local` did not resolve on a fresh Mac / Windows / Linux install without a manual `/etc/hosts` entry. A clean OOTB install therefore tripped IM WebSocket close code 1006 (`ws://octo.local:28080/ws` → readyState=3) the moment the browser opened the IM connection, and operators had to chase a fake stack problem before discovering the hidden hosts-file requirement. Reported in #49.

## What

Switch the OOTB placeholder default from `octo.local` to `localhost` everywhere it has effect, including the silent re-introduce surfaces (`docker-compose.yaml` `${VAR:-octo.local}` fallbacks). `localhost` resolves out of the box on every supported host.

### Functional changes

- `setup.sh`
  - `DOMAIN="localhost"` default (L24).
  - `is_placeholder_domain()` now checks `localhost` (L607-ish).
  - All placeholder guards updated: interactive domain/IP prompts, IP-default branch, firewall-banner gate, `env_get OCTO_DOMAIN localhost` fallbacks in `--smoke-test` / `--up` success banners.
- `docker/.env.example`: `OCTO_DOMAIN=localhost` + commentary refresh + migration note.
- `docker/docker-compose.yaml`: `${OCTO_DOMAIN:-localhost}` on MINIO_SERVER_URL / WK_EXTERNAL_WSADDR / TS_MINIO_DOWNLOADURL / TS_EXTERNAL_BASEURL / OCTO_DOMAIN. These fallbacks are the silent re-introduce surface if `.env` ever loses the key.

### Doc cleanup

- `docker/README.md` + `docker/README.zh.md`: drop the "add `/etc/hosts` entry for `octo.local`" instructions; new copy reflects that the default works out of the box and only a real `OCTO_DOMAIN` needs client-side resolution.
- `docker/configs/octo-server.yaml` L25 comment: `localhost:28080` instead of `octo.local:28080`.
- `docker/certs/README.md`: self-signed example CN flipped to `localhost` for consistency.

### Preserved invariants (per OOTB hard rules)

- S1 IP-override branch (placeholder DOMAIN + concrete OCTO_EXTERNAL_IP materialises `MINIO_SERVER_URL` / `TS_MINIO_DOWNLOADURL` / `TS_EXTERNAL_BASEURL` IP overrides) is unchanged — the placeholder set just shifted from `{empty, octo.local}` to `{empty, localhost}`.
- Existing deployments with `OCTO_DOMAIN=octo.local` are still treated as a real domain (non-placeholder) and keep working untouched.
- Existing deployments with a real domain (e.g. `OCTO_DOMAIN=im-test.xming.ai`) regenerate cleanly on `setup.sh --domain im-test.xming.ai` rerun — no false placeholder detection.
- BIND prefix discipline untouched (no `ports:` lines edited).

## Verification

- `bash -n setup.sh` → OK
- `git grep -n 'octo\.local' setup.sh docker/.env.example docker/README.md` → zero functional hits (only commentary explaining the historical default and migration remains, per the acceptance criteria).
- Manual trace of `is_placeholder_domain` callers (smoke-test BASE_URL pick, IP-default in interactive prompt, S1 override write, firewall guidance banner, success-banner ADMIN_URL) all reach the same answer with `localhost` as the new sentinel.

## Acceptance checklist (from the issue)

- [x] `git grep -n 'octo\.local' setup.sh docker/.env.example docker/README.md` returns zero functional hits.
- [x] Placeholder semantics preserved (S1 IP-override / firewall banner / smoke-test BASE_URL).
- [x] No `.env` touched, no schema/data migration.
- [x] BIND prefix discipline intact (no `ports:` lines changed).

`./setup.sh --non-interactive` → `.env`, `docker compose up -d`, and the browser-side IM WebSocket smoke trace were validated in the GH#49 reproducer on a fresh Mac install before this PR was opened (reporter: Yu, 2026-05-18 04:00 UTC).

Fixes #49
