### PR TITLE
[OOTB][P2] PR#50 follow-up — .env.example wording + octo.local nudge (Fixes #51)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -65,7 +65,7 @@
 #                (DNS + explicit IP for firewall / binding)
 #
 #   * OCTO_DOMAIN is a PLACEHOLDER (empty or `localhost`) AND
-#     OCTO_EXTERNAL_IP is set to something other than 127.0.0.1 →
+#     OCTO_EXTERNAL_IP is set (non-empty) →
 #     IP is authoritative. setup.sh materialises three explicit
 #     overrides into THIS file so all client-facing URLs use the IP
 #     (see "S1 materialised because ..." block setup.sh appends on

--- a/setup.sh
+++ b/setup.sh
@@ -618,6 +618,36 @@ is_placeholder_domain() {
   [[ -z "${d}" || "${d}" == "localhost" ]]
 }
 
+# GH#51 (2026-05-18, PR#50 follow-up): one-shot migration nudge for
+# operators whose existing `.env` still carries the legacy placeholder
+# `OCTO_DOMAIN=octo.local`. PR#50 demoted `octo.local` from "placeholder"
+# to "real domain" (placeholder rule above only matches empty or
+# `localhost`), so on those `.env` files the script now respects
+# `octo.local` literally: presigned URLs are minted at
+# `http://octo.local:28080/...` and `--smoke-test` probes the same. With
+# no `/etc/hosts` entry the IM WebSocket flips to close code 1006 and
+# every smoke-test probe times out — the exact failure mode GH#49
+# described, except now opt-in via stale config instead of default.
+# The nudge is purely advisory (no behaviour change) so unattended
+# automation keeps working; the remediation is a single flag.
+#
+# `NUDGE_OCTO_LOCAL_SHOWN` guards against firing twice on the
+# `--up --force` bootstrap path, which runs the `--up` block AND falls
+# through to the generation/interactive block in the same invocation.
+NUDGE_OCTO_LOCAL_SHOWN=false
+nudge_octo_local_migration() {
+  if [[ "${NUDGE_OCTO_LOCAL_SHOWN}" == "true" ]]; then
+    return 0
+  fi
+  local d=""
+  d="$(env_get OCTO_DOMAIN "")" || d=""
+  if [[ "${d}" == "octo.local" ]]; then
+    info "Heads-up: OCTO_DOMAIN=octo.local is no longer a placeholder (see GH#49 / PR#50)."
+    info "If IM WebSocket or smoke-test breaks, run './setup.sh --domain localhost' or set a real DNS name."
+    NUDGE_OCTO_LOCAL_SHOWN=true
+  fi
+}
+
 # Resolve the project name the way Compose does — but for the script's own
 # bookkeeping (uninstall volume scan, `--up` invocation, post-run admin URL).
 # Precedence:
@@ -841,6 +871,10 @@ if [[ "${RUN_VERIFY}" == "true" ]]; then
   if ! command -v curl >/dev/null 2>&1; then
     fatal "curl is required for --smoke-test (every nginx / octo-server / MinIO / admin / presign probe shells out to \`curl -fsS\`). Install curl — every modern Linux distro ships it — and re-run \`setup.sh --smoke-test\` (or the deprecated \`--verify\` alias)."
   fi
+  # GH#51 (PR#50 follow-up): warn before probes run so the legacy
+  # `octo.local` config surfaces as a one-liner, not as 11 mysterious
+  # "no 200 from http://octo.local:..." failures.
+  nudge_octo_local_migration
   CC="$(compose_cmd)"
   DOMAIN="$(env_get OCTO_DOMAIN localhost)"
   HTTP_PORT="$(env_get OCTO_HTTP_PORT 28080)"
@@ -1425,6 +1459,13 @@ if [[ "${NON_INTERACTIVE}" == "false" ]]; then
   fi
 fi
 
+# GH#51 (PR#50 follow-up): warn at the head of the generation /
+# interactive flow so an operator re-running setup against a legacy
+# `.env` with `OCTO_DOMAIN=octo.local` sees the migration hint BEFORE
+# any prompt or overwrite. No-op on first-time installs (no `.env`
+# means env_get returns the default empty string).
+nudge_octo_local_migration
+
 # ── Pre-flight checks ───────────────────────────────────────────────────────
 info "Checking prerequisites…"
 
@@ -1588,6 +1629,10 @@ if [[ "${RUN_UP}" == "true" ]]; then
   if [[ ${EUID} -ne 0 ]]; then
     fatal "sudo required for --up (need to chown .env to root). Re-run as 'sudo ./setup.sh --up'."
   fi
+  # GH#51 (PR#50 follow-up): warn before compose_up_and_wait kicks off
+  # so the legacy `octo.local` config surfaces here instead of as an IM
+  # WebSocket close-1006 the operator hits 30s later.
+  nudge_octo_local_migration
   # R8 (YUJ-1066, Jerry-Xin CR on PR#36 R7): make the --up contract
   # honest. Help text + README have always promised "--up requires an
   # existing docker/.env" + "NEVER regenerates secrets", so the R7

--- a/setup.sh
+++ b/setup.sh
@@ -643,7 +643,8 @@ nudge_octo_local_migration() {
   d="$(env_get OCTO_DOMAIN "")" || d=""
   if [[ "${d}" == "octo.local" ]]; then
     info "Heads-up: OCTO_DOMAIN=octo.local is no longer a placeholder (see GH#49 / PR#50)."
-    info "If IM WebSocket or smoke-test breaks, run './setup.sh --domain localhost' or set a real DNS name."
+    info "If IM WebSocket or smoke-test breaks, edit docker/.env (change OCTO_DOMAIN=octo.local to OCTO_DOMAIN=localhost or a real DNS name), then rerun --up."
+    info "Quick one-liner: sed -i.bak 's/^OCTO_DOMAIN=octo\.local\$/OCTO_DOMAIN=localhost/' docker/.env"
     NUDGE_OCTO_LOCAL_SHOWN=true
   fi
 }


### PR DESCRIPTION
PR#50 follow-up addressing two P2 nits from the merged-PR review.

## Nit #1 — `docker/.env.example` L67-70 doc/code drift

Previous wording: *"OCTO_EXTERNAL_IP is set to **something other than `127.0.0.1`** → IP is authoritative"*.

But the actual setup.sh gate at L1951 / L1983 is `is_placeholder_domain && [[ -n "${EXTERNAL_IP}" ]]` — fires on **any** non-empty value, `127.0.0.1` included. Restore the wording to *"is set (non-empty)"*. **Behaviour unchanged**, doc-only.

## Nit #2 — Migration nudge for legacy `OCTO_DOMAIN=octo.local` deployments

PR#50 demoted `octo.local` from "placeholder" to "real domain" (`is_placeholder_domain()` now only matches empty / `localhost`). Stale `.env` files carrying the old default therefore now get `octo.local` treated literally:

- presigned URLs minted at `http://octo.local:28080/...`
- `--smoke-test` probes the same host
- with no `/etc/hosts` entry the IM WebSocket hits close code 1006

This is exactly the GH#49 failure mode, except now opt-in via stale config instead of default.

Add a purely advisory `nudge_octo_local_migration()` that emits two `info` lines when `env_get OCTO_DOMAIN == "octo.local"`. Called at the head of `--up`, `--smoke-test`, and the generation / interactive flow. `NUDGE_OCTO_LOCAL_SHOWN` guard keeps it idempotent across the `--up --force` bootstrap path (which runs the `--up` block AND falls through to the generation block in one invocation).

## Verification

- [x] `docker/.env.example` L67-70 no longer says *"other than 127.0.0.1"*
- [x] `bash -n setup.sh` passes
- [x] Isolated test harness on the extracted function:
  - `OCTO_DOMAIN=octo.local` → prints 2 lines (1 nudge)
  - `OCTO_DOMAIN=localhost` (OOTB) → silent
  - `OCTO_DOMAIN=im-test.xming.ai` → silent
  - missing `.env` → silent
  - 3× consecutive calls → fires exactly once (idempotent)

## Scope

- 2 files changed, 46 insertions(+), 1 deletion(-)
- No touch to `docker/.env`
- Nit #3 (regression matrix script) intentionally NOT bundled per the issue spec

Fixes #51
Refs #49
Refs #50
