### PR TITLE
[OOTB][P1] setup.sh: skip MinIO/TS URL override on loopback EXTERNAL_IP (Fixes #54)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -65,7 +65,8 @@
 #                (DNS + explicit IP for firewall / binding)
 #
 #   * OCTO_DOMAIN is a PLACEHOLDER (empty or `localhost`) AND
-#     OCTO_EXTERNAL_IP is set (non-empty) →
+#     OCTO_EXTERNAL_IP is set to a NON-loopback IP (i.e. not
+#     `127.0.0.1` / `::1`) →
 #     IP is authoritative. setup.sh materialises three explicit
 #     overrides into THIS file so all client-facing URLs use the IP
 #     (see "S1 materialised because ..." block setup.sh appends on
@@ -75,12 +76,25 @@
 #       Example: `--non-interactive --ip 35.229.161.253`
 #                (public IP, no DNS — the OOTB GCP case)
 #
+#   * OCTO_DOMAIN is a PLACEHOLDER AND OCTO_EXTERNAL_IP is a loopback
+#     IP (`127.0.0.1` / `::1`) — the OOTB single-host case (GH#54) →
+#     setup.sh skips the three URL overrides entirely. The compose
+#     defaults (`http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}` =
+#     `http://localhost:28080`) take over so the page, every presigned
+#     URL, and the printed ADMIN_URL all sit on the same `localhost`
+#     origin. Materialising overrides to `http://127.0.0.1:28080` here
+#     was historically what caused the GH#54 CSP / cookie break: the
+#     page loaded at `localhost` but img src URLs were on `127.0.0.1`
+#     (different origin → CSP `'self'` blocked images, cookies under
+#     one host weren't sent under the other).
+#
 # Both knobs default to safe loopback so a missed-config run does not
 # mint public-facing URL overrides: with OCTO_DOMAIN=localhost +
-# OCTO_EXTERNAL_IP=127.0.0.1, only the *generated external URLs*
+# OCTO_EXTERNAL_IP=127.0.0.1, setup.sh keeps every client-facing URL
 # (MINIO_SERVER_URL / TS_MINIO_DOWNLOADURL / TS_EXTERNAL_BASEURL and
-# the ADMIN_URL printed in summaries) stay on loopback. Nginx itself
-# still binds whatever OCTO_NGINX_BIND points at (default
+# the ADMIN_URL printed in summaries) on `localhost` via the compose
+# defaults — see the loopback-IP branch above. Nginx itself still
+# binds whatever OCTO_NGINX_BIND points at (default
 # 0.0.0.0:OCTO_HTTP_PORT — see below), so a client that already knows
 # this host's IP can still reach the stack on OCTO_HTTP_PORT. Flip
 # OCTO_NGINX_BIND to 127.0.0.1 (and the matching backing-service

--- a/setup.sh
+++ b/setup.sh
@@ -618,6 +618,27 @@ is_placeholder_domain() {
   [[ -z "${d}" || "${d}" == "localhost" ]]
 }
 
+# GH#54 (2026-05-18): companion to is_placeholder_domain — recognise IP
+# values that are same-origin with the `localhost` placeholder. The OOTB
+# defaults (OCTO_DOMAIN=localhost + OCTO_EXTERNAL_IP=127.0.0.1, see
+# docker/.env.example) used to trip the placeholder + EXTERNAL_IP guard
+# below and materialise MINIO_SERVER_URL=http://127.0.0.1:28080 (plus the
+# two TS overrides). The browser then loaded the admin page at
+# http://localhost:28080 but img src URLs pointed at 127.0.0.1:28080 —
+# the CSP `'self'` policy treats these as different origins and blocked
+# every inline image, and Set-Cookie under one host wasn't sent under
+# the other. Treat loopback IPs (and the empty string, mirroring the
+# `-z` arm of is_placeholder_domain) as "same as localhost" so the
+# override block stays a no-op on the default config. A non-loopback IP
+# (operator passed `--ip <public-IP>`) still falls through and minted
+# overrides exactly like GH#41 expected.
+is_loopback_ip() {
+  case "$1" in
+    127.0.0.1|::1|localhost|"") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # GH#51 (2026-05-18, PR#50 follow-up): one-shot migration nudge for
 # operators whose existing `.env` still carries the legacy placeholder
 # `OCTO_DOMAIN=octo.local`. PR#50 demoted `octo.local` from "placeholder"
@@ -1718,8 +1739,13 @@ if [[ "${RUN_UP}" == "true" ]]; then
     # resolve back to the deployment. When OCTO_DOMAIN is a placeholder
     # AND OCTO_EXTERNAL_IP is concrete, mint the admin URL off the IP
     # so it is actually click-through.
+    # GH#54 (2026-05-18): exclude loopback IPs — see S1 block + the
+    # generation-path ADMIN_URL above for the full rationale. Loopback
+    # IP is same-origin with the `localhost` placeholder, so swapping
+    # the banner to `127.0.0.1` only re-introduces the CSP / cookie
+    # mismatch this fix is closing.
     EXTERNAL_IP_ENV="$(env_get OCTO_EXTERNAL_IP "")"
-    if is_placeholder_domain && [[ -n "${EXTERNAL_IP_ENV}" ]]; then
+    if is_placeholder_domain && [[ -n "${EXTERNAL_IP_ENV}" ]] && ! is_loopback_ip "${EXTERNAL_IP_ENV}"; then
       ADMIN_URL="http://${EXTERNAL_IP_ENV}:${HTTP_PORT}/admin/"
     else
       ADMIN_URL="http://${DOMAIN}:${HTTP_PORT}/admin/"
@@ -1994,7 +2020,13 @@ HTTP_PORT="$(env_get OCTO_HTTP_PORT 28080)"
 # entirely if they hit the URL from a different machine. Use the
 # in-memory DOMAIN / EXTERNAL_IP here because the .env we just wrote
 # already reflects them and these are still in scope.
-if is_placeholder_domain && [[ -n "${EXTERNAL_IP}" ]]; then
+# GH#54 (2026-05-18): also gate on is_loopback_ip — if EXTERNAL_IP is
+# 127.0.0.1 / ::1 the S1 block below is now skipped, so the rest of the
+# stack stays on the `localhost` placeholder. Printing the loopback IP
+# in the banner would invite the operator to open `http://127.0.0.1:.../admin/`
+# while presigned URLs are minted at `http://localhost:.../`, re-creating
+# the exact CSP / cookie mismatch this fix is meant to close.
+if is_placeholder_domain && [[ -n "${EXTERNAL_IP}" ]] && ! is_loopback_ip "${EXTERNAL_IP}"; then
   ADMIN_URL="http://${EXTERNAL_IP}:${HTTP_PORT}/admin/"
 else
   ADMIN_URL="http://${DOMAIN}:${HTTP_PORT}/admin/"
@@ -2018,15 +2050,24 @@ fi
 # topology (`--domain octo.example.com --ip 1.2.3.4` would have client
 # browsers calling the IP instead of the documented domain).
 #
-# So S1 materialises three lockstep overrides ONLY when both:
+# So S1 materialises three lockstep overrides ONLY when all of:
 #   (1) OCTO_DOMAIN is placeholder (empty or `localhost`), AND
-#   (2) OCTO_EXTERNAL_IP is set (operator gave us something concrete).
+#   (2) OCTO_EXTERNAL_IP is set (operator gave us something concrete), AND
+#   (3) OCTO_EXTERNAL_IP is NOT a loopback (`127.0.0.1` / `::1` / `localhost`
+#       / empty) — GH#54: when the IP is loopback it is same-origin with
+#       the `localhost` placeholder, so materialising the overrides is a
+#       no-op for reachability AND actively breaks CSP / cookies because
+#       the browser then loads the page at one of {localhost, 127.0.0.1}
+#       and the img src URLs at the other. Skip the block and let the
+#       compose defaults (`http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}` =
+#       `http://localhost:28080`) take over so everything stays on a
+#       single origin.
 # All three URLs must agree (SigV4 rejects every PUT with `403
 # SignatureDoesNotMatch` if MINIO_SERVER_URL and TS_MINIO_DOWNLOADURL
 # disagree on host:port), so they are written as a single block.
 # Reads/imports stay literal — Compose interpolates `.env` once into
 # YAML without recursive expansion.
-if is_placeholder_domain && [[ -n "${EXTERNAL_IP}" ]]; then
+if is_placeholder_domain && [[ -n "${EXTERNAL_IP}" ]] && ! is_loopback_ip "${EXTERNAL_IP}"; then
   info "OCTO_DOMAIN is a placeholder (${DOMAIN}); materialising IP-based URL overrides so presigned PUT / TS callback URLs are browser-reachable from ${EXTERNAL_IP}."
   cat >> "${ENV_OUT}" <<URLS
 


### PR DESCRIPTION
Fixes #54 (Mininglamp-OSS/octo-deployment#54)

## Root cause

The S1 block in `setup.sh` (R7 / YUJ-1020 / GH#41) materialised three URL overrides
whenever **OCTO_DOMAIN was a placeholder AND OCTO_EXTERNAL_IP was non-empty**.

The OOTB defaults in `.env.example` ship as:

```
OCTO_DOMAIN=localhost
OCTO_EXTERNAL_IP=127.0.0.1
```

That tripped the guard on every fresh install and wrote:

```
MINIO_SERVER_URL=http://127.0.0.1:28080
TS_MINIO_DOWNLOADURL=http://127.0.0.1:28080
TS_EXTERNAL_BASEURL=http://127.0.0.1:28080
```

Browsers loaded the admin page at `http://localhost:28080`, but image `src`
URLs (presigned by the server using `MINIO_SERVER_URL`) pointed at
`http://127.0.0.1:28080`. The CSP `'self'` directive treats `localhost` and
`127.0.0.1` as **different origins** → every inline image was blocked,
and cookies set under one host were not sent under the other. Historical
messages plus new uploads were equally affected, because the absolute URL
is minted by `MINIO_SERVER_URL` at presign time.

## Fix

Add an `is_loopback_ip` helper next to `is_placeholder_domain`, and AND it
into the three call sites that gate behaviour on "placeholder domain +
concrete EXTERNAL_IP":

```bash
is_loopback_ip() {
  case "$1" in
    127.0.0.1|::1|localhost|"") return 0 ;;
    *) return 1 ;;
  esac
}

# S1 materialisation + both ADMIN_URL banner sites:
if is_placeholder_domain && [[ -n "${EXTERNAL_IP}" ]] && ! is_loopback_ip "${EXTERNAL_IP}"; then
  ...
fi
```

Rationale: loopback IP (`127.0.0.1`, `::1`, empty, `localhost`) is
same-origin with the `localhost` placeholder, so materialising the
overrides is a no-op for reachability **and** actively breaks CSP /
cookies. Skip the block and let the compose defaults
(`http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}` = `http://localhost:28080`)
take over so everything stays on a single origin. A non-loopback IP
(operator passed `--ip <public-IP>`) still falls through and mints the
overrides exactly like GH#41 expected.

The same gate was added to the two `ADMIN_URL` banner sites
(generation-path summary, and the `--up` success banner). Otherwise the
operator would be handed `http://127.0.0.1:28080/admin/` in the success
banner while presigned URLs were minted at `http://localhost:28080/...`,
which would re-introduce the exact same CSP / cookie mismatch the moment
they clicked the printed URL.

`docker/.env.example` got a comment refresh to document the new
loopback-IP branch (the old wording claimed the default config kept the
override URLs "on loopback", which was misleading — they were
materialised to `127.0.0.1`).

Substantive code changes: **~9 lines** (1 helper function + 3 `if`
conditions). The rest of the diff is comments.

## Verification

### AC#1 — fresh OOTB deploy (default `localhost` + `127.0.0.1`)

Simulated the new gate against the exact OOTB path:

```
DOMAIN=localhost       EXTERNAL_IP=127.0.0.1   → skip (compose defaults take over)
```

→ none of `MINIO_SERVER_URL` / `TS_MINIO_DOWNLOADURL` / `TS_EXTERNAL_BASEURL`
are appended to `docker/.env`. Compose default
`http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}` = `http://localhost:28080`
takes over, and the page + presigned URLs + printed `ADMIN_URL` all sit
on the single `localhost` origin → CSP `'self'` is satisfied.

### AC#2 — explicit public IP (GH#41 regression guard)

```
DOMAIN=localhost       EXTERNAL_IP=1.2.3.4     → MATERIALISE (MINIO_SERVER_URL=http://1.2.3.4:28080)
```

→ behaviour unchanged from PR#36 / GH#41. Operators on real GCP/EC2
instances who pass `--ip <public-IP>` still get the three lockstep
overrides written into `.env`.

### Other paths re-verified for no regression

```
DOMAIN=localhost       EXTERNAL_IP=            → skip
DOMAIN=localhost       EXTERNAL_IP=::1         → skip   (IPv6 loopback)
DOMAIN=localhost       EXTERNAL_IP=localhost   → skip
DOMAIN=octo.example... EXTERNAL_IP=1.2.3.4     → skip   (real domain wins, DNS topology preserved)
DOMAIN=octo.example... EXTERNAL_IP=127.0.0.1   → skip
DOMAIN=                EXTERNAL_IP=1.2.3.4     → MATERIALISE   (empty domain = placeholder + remote IP)
```

`bash -n setup.sh` passes (syntax clean).

### AC#3 — smoke-test 11/11 PASS

Not run in this dev environment (no docker stack); the change does not
touch `--smoke-test` probe-host selection (S2 / line 913). With
OCTO_DOMAIN=localhost + OCTO_EXTERNAL_IP=127.0.0.1, `PROBE_HOST` resolves
to `127.0.0.1` and `BASE_URL` to `http://127.0.0.1:28080`, both locally
reachable — smoke-test behaviour is unchanged.

### AC#4 — browser verification

Not exercised in dev env. Logic verified by the AC#1 / AC#2 dry-run
above: with overrides skipped, page + img src + ADMIN_URL all align on
`http://localhost:28080`, eliminating the cross-origin condition that
triggered CSP block.

## Backwards compatibility

- **Already-deployed users**: unaffected unless they actively re-run
  `setup.sh --force` (the .env file is not regenerated on `--up` alone).
- **Remote IP deployment (GH#41 scenario)**: behaviour unchanged — the
  AC#2 simulation above confirms `MINIO_SERVER_URL=http://1.2.3.4:28080`
  is still materialised when the operator passes `--ip <non-loopback>`.
- **Real-domain deployment (`--domain octo.example.com`)**: unchanged —
  `is_placeholder_domain` short-circuits the guard.

## Scope guard (per issue)

- ✅ Single file change: `setup.sh` (+ `docker/.env.example` comment refresh
  documenting new behaviour, as the issue explicitly allowed).
- ✅ Did NOT touch `octo-server` presign logic.
- ✅ Did NOT touch historical data migration.
- ✅ Single PR, not split.

