### PR TITLE
[OOTB][P2] setup.sh UX two-fer (GH#56): ANSI escape on macOS + Domain prompt default

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -186,9 +186,10 @@ sudo ./setup.sh --smoke-test                # admin login + presign PUT end-to-e
 
 `setup.sh` auto-detects the public IP via `ifconfig.me`. If you run
 on a host that has one (cloud VM, bare-metal with public IPv4), the
-prompt suggests the detected IP as your `OCTO_DOMAIN` default —
-override with a real DNS name when you have one, or accept the IP
-for an IP-only deployment.
+prompt prints the detected IP for reference but **defaults to
+`localhost`** (Enter → local-only on this host). Type the detected
+IP, or a real DNS name your clients can resolve, only when you want
+the stack reachable from outside this host.
 
 Or non-interactive:
 

--- a/docker/README.zh.md
+++ b/docker/README.zh.md
@@ -103,7 +103,7 @@ sudo ./setup.sh --up                        # 起栈
 sudo ./setup.sh --smoke-test                # admin login + presign PUT 端到端检查（旧名 --verify 仍可用，已 deprecated）
 ```
 
-`setup.sh` 通过 `ifconfig.me` 自动探测公网 IP。如果主机有公网 IP（云 VM、有公网 IPv4 的裸金属），交互向导会把探测到的 IP 作为 `OCTO_DOMAIN` 的默认建议——有真正的 DNS 名时填进去，没有就直接用 IP 跑「纯 IP」部署。
+`setup.sh` 通过 `ifconfig.me` 自动探测公网 IP。如果主机有公网 IP（云 VM、有公网 IPv4 的裸金属），交互向导会**打印**探测到的 IP 供参考，但 `OCTO_DOMAIN` 的**默认值是 `localhost`**（回车 = 仅在本机访问）。只有当你确实要让栈对外可达时，才在 prompt 里手动输入探测到的 IP，或者输入一个客户端能解析的真实 DNS 名。
 
 非交互：
 

--- a/setup.sh
+++ b/setup.sh
@@ -58,8 +58,15 @@ ENV_OUT="${SCRIPT_DIR}/docker/.env"
 DOCKER_DIR="${SCRIPT_DIR}/docker"
 
 # ── Colours / helpers ────────────────────────────────────────────────────────
+# GH#56 bug 1: use $'…' ANSI-C quoting so the variables hold actual ESC
+# bytes. Single-quoted '\033…' is just a literal backslash-0-3-3 string;
+# when fed to `printf '%s'` (no escape interpretation in arguments) it
+# round-trips verbatim and the terminal prints `\033[0;32m[setup]…`
+# instead of a green `[setup]`. This bit macOS users first (bash/zsh
+# default `/bin/echo` POSIX behaviour amplifies it) but the same literal
+# leaked on Linux too — $'…' makes printf '%s' work as intended on both.
 if [[ -t 1 ]]; then
-  GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; BOLD='\033[1m'; CYAN='\033[0;36m'; RESET='\033[0m'
+  GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'; RED=$'\033[0;31m'; BOLD=$'\033[1m'; CYAN=$'\033[0;36m'; RESET=$'\033[0m'
 else
   GREEN=''; YELLOW=''; RED=''; BOLD=''; CYAN=''; RESET=''
 fi
@@ -1817,10 +1824,17 @@ if [[ "${NON_INTERACTIVE}" == "false" ]]; then
   if [[ "${DOMAIN}" == "localhost" || -z "${DOMAIN}" ]] \
      && [[ "${detected_ip}" != "127.0.0.1" ]]; then
     info "Detected public IP: ${detected_ip}"
-    info "For a deployment reachable from outside this host, set OCTO_DOMAIN to a name"
-    info "your clients can resolve (or use the detected IP directly)."
-    read -rp "Domain name [${detected_ip}] (Enter to use detected IP, type 'localhost' for local-only): " user_domain
-    DOMAIN="${user_domain:-${detected_ip}}"
+    info "For a deployment reachable from outside this host, type the detected IP"
+    info "(or a real DNS name your clients can resolve)."
+    # GH#56 bug 2: default to `localhost` even when a public IP is
+    # detected. Mac / laptop users — by far the most common OOTB
+    # audience — hit Enter expecting a local-only stack; the previous
+    # default silently pinned OCTO_DOMAIN to a public IP and broke
+    # browser access through `http://localhost:28080`. External-reach
+    # operators are the minority; they can explicitly type the IP
+    # (printed above) or a hostname.
+    read -rp "Domain name [localhost] (Enter for local-only on this host, type '${detected_ip}' or a custom domain for external access): " user_domain
+    DOMAIN="${user_domain:-localhost}"
   else
     read -rp "Domain name [${DOMAIN}]: " user_domain
     DOMAIN="${user_domain:-${DOMAIN}}"


### PR DESCRIPTION
Fixes #56 (Mininglamp-OSS/octo-deployment#56)

## Bug 1: ANSI escape on macOS

`GREEN/YELLOW/RED/BOLD/CYAN/RESET` were single-quoted (`'\033[0;32m'`), making them literal 6-char strings. The `info()/warn()/err()` helpers feed them to `printf '%s'` — and `%s` doesn't interpret escapes in argument values — so terminals printed the raw chars `\033[0;32m[setup]\033[0m` instead of a green tag. macOS Terminal (zsh / bash + POSIX `/bin/echo`) surfaced it first; Linux had the same leak but went mostly unnoticed.

Fix: ANSI-C `$'…'` quoting so the variables hold actual ESC bytes.

```diff
-  GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; BOLD='\033[1m'; CYAN='\033[0;36m'; RESET='\033[0m'
+  GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'; RED=$'\033[0;31m'; BOLD=$'\033[1m'; CYAN=$'\033[0;36m'; RESET=$'\033[0m'
```

## Bug 2: Domain prompt default

When a public IP was detected, the prompt offered it as the default — Mac/laptop users hitting Enter unexpectedly got `OCTO_DOMAIN=<public-ip>`. Swap: default is now `localhost`; the detected IP is still printed for reference and the user can type it (or a DNS name) to opt in to external reach.

| Scenario | Before | After |
| --- | --- | --- |
| Detected public IP, user hits Enter | `OCTO_DOMAIN=<public-ip>` | `OCTO_DOMAIN=localhost` |
| User types `38.64.57.135` | `OCTO_DOMAIN=38.64.57.135` | `OCTO_DOMAIN=38.64.57.135` |
| `--domain example.com` flag | `OCTO_DOMAIN=example.com` | `OCTO_DOMAIN=example.com` |
| `--non-interactive` (no flag) | `OCTO_DOMAIN=localhost` | `OCTO_DOMAIN=localhost` |

External-IP prompt already defaults to `127.0.0.1` when the domain is a placeholder (R9 / YUJ-1068), so an Enter-Enter run yields `OCTO_DOMAIN=localhost` + `OCTO_EXTERNAL_IP=127.0.0.1` automatically.

```diff
-    info "For a deployment reachable from outside this host, set OCTO_DOMAIN to a name"
-    info "your clients can resolve (or use the detected IP directly)."
-    read -rp "Domain name [${detected_ip}] (Enter to use detected IP, type 'localhost' for local-only): " user_domain
-    DOMAIN="${user_domain:-${detected_ip}}"
+    info "For a deployment reachable from outside this host, type the detected IP"
+    info "(or a real DNS name your clients can resolve)."
+    read -rp "Domain name [localhost] (Enter for local-only on this host, type '${detected_ip}' or a custom domain for external access): " user_domain
+    DOMAIN="${user_domain:-localhost}"
```

## Verification

- `bash -n setup.sh`: **PASS**
- Probe `printf '%s' "$GREEN"` with `$'…'` colour vars under `script` → real ESC (`^[`) bytes, no literal `\033`
- Same probe with original `'…'` colour vars → reproduces the literal `\033[0;32m[setup]…` leak (confirms root cause)
- `--domain example.com` CLI flag: unchanged
- `--non-interactive` default: still `localhost`
- Docs synced: `docker/README.md` + `docker/README.zh.md` paragraph about detected-IP prompt rewritten to match new default

## Boundary

- Only `setup.sh` + `docker/README.md` + `docker/README.zh.md` touched
- No change to S1 / loopback / GH#41 path logic
- No change to CLI flag behaviour
- Single PR closing both bugs (~24 lines net)