### PR TITLE
feat(helm): add Helm chart for full OCTO stack deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,10 @@ kustomize/overlays/**
 docker/certs/*.pem
 docker/certs/*.key
 docker/certs/*.crt
+
+# Helm — packaged chart tarballs and personal values (real credentials)
+helm/*.tgz
+helm/values.personal.yaml
+
+# macOS
+.DS_Store

--- a/helm/octo/.helmignore
+++ b/helm/octo/.helmignore
@@ -1,0 +1,5 @@
+.DS_Store
+*.swp
+*.swo
+*.bak
+values.personal.yaml

--- a/helm/octo/Chart.yaml
+++ b/helm/octo/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: octo
+description: OCTO Server — self-hosted enterprise messaging platform (IM + AI)
+type: application
+version: 0.2.1
+appVersion: "latest"
+keywords:
+  - octo
+  - messaging
+  - im
+  - wukongim
+home: https://github.com/Mininglamp-OSS/octo-deployment
+sources:
+  - https://github.com/Mininglamp-OSS/octo-deployment
+maintainers:
+  - name: Mininglamp OSS
+    url: https://github.com/Mininglamp-OSS

--- a/helm/octo/README.md
+++ b/helm/octo/README.md
@@ -70,7 +70,8 @@ helm install octo oci://ghcr.io/mininglamp-oss/octo --version 0.2.1 \
   --set secrets.summaryReaderPassword="$(openssl rand -hex 16)" \
   --set secrets.octoMasterKey="$(openssl rand -hex 16)" \
   --set secrets.notifyInternalToken="$(openssl rand -hex 32)" \
-  --set secrets.wukongimManagerToken="$(openssl rand -hex 32)"
+  --set secrets.wukongimManagerToken="$(openssl rand -hex 32)" \
+  --set secrets.adminPwd="$(openssl rand -hex 16)"
 ```
 
 > **Important:** Save the randomly generated secret values — they are required for future upgrades.  

--- a/helm/octo/README.md
+++ b/helm/octo/README.md
@@ -1,0 +1,254 @@
+# OCTO Helm Chart
+
+Deploy the full OCTO stack on Kubernetes — MySQL, Redis, MinIO, WuKongIM, Nginx, and all application services — with a single `helm install`.
+
+## Prerequisites
+
+| Tool | Version |
+|------|---------|
+| Kubernetes | 1.24+ |
+| Helm | 3.10+ |
+| kubectl | matching cluster version |
+| A default StorageClass | (or set `*.storage.storageClass`) |
+
+---
+
+## Quick Start
+
+### 1. Create a values file
+
+Create `my-values.yaml` with your configuration:
+
+```yaml
+# my-values.yaml
+domain: "octo.example.com"
+externalBaseURL: "https://octo.example.com"
+
+ingress:
+  enabled: true
+  className: nginx
+  host: "octo.example.com"
+  tls:
+    enabled: true
+    secretName: octo-tls   # kubectl create secret tls octo-tls --cert=tls.crt --key=tls.key
+
+llm:
+  apiURL: "https://api.openai.com/v1"
+  model: "gpt-4o"
+
+secrets:
+  llmApiKey: "sk-..."
+
+server:
+  config:
+    register:
+      disabled: false      # allow self-registration
+      emailOn: true
+    support:
+      email: "noreply@example.com"
+      emailSmtp: "smtp.gmail.com:465"
+      emailPwd: "your-app-password"
+```
+
+To see all available options:
+
+```bash
+helm show values oci://ghcr.io/mininglamp-oss/octo --version 0.2.1
+```
+
+### 2. Install
+
+```bash
+helm install octo oci://ghcr.io/mininglamp-oss/octo --version 0.2.1 \
+  --namespace octo --create-namespace \
+  -f my-values.yaml \
+  --set secrets.mysqlRootPassword="$(openssl rand -hex 16)" \
+  --set secrets.minioRootPassword="$(openssl rand -hex 16)" \
+  --set secrets.minioAppPassword="$(openssl rand -hex 24)" \
+  --set secrets.matterDbPassword="$(openssl rand -hex 16)" \
+  --set secrets.summaryDbPassword="$(openssl rand -hex 16)" \
+  --set secrets.summaryReaderPassword="$(openssl rand -hex 16)" \
+  --set secrets.octoMasterKey="$(openssl rand -hex 16)" \
+  --set secrets.notifyInternalToken="$(openssl rand -hex 32)" \
+  --set secrets.wukongimManagerToken="$(openssl rand -hex 32)"
+```
+
+> **Important:** Save the randomly generated secret values — they are required for future upgrades.  
+> Store them in a secrets manager or a local encrypted file.
+
+### 3. Wait for all pods to be ready
+
+```bash
+kubectl get pods -n octo -w
+```
+
+All 11 pods should reach `1/1 Running` within 2–3 minutes.
+
+### 4. Expose the service
+
+By default `nginx.service.type` is `ClusterIP`. Expose it via your preferred method:
+
+**Ingress** (recommended, configured in `my-values.yaml` above):  
+Point your DNS to the Ingress controller's external IP and access `https://octo.example.com`.
+
+**LoadBalancer** (cloud providers):  
+Add to `my-values.yaml`:
+```yaml
+nginx:
+  service:
+    type: LoadBalancer
+```
+
+**Port-forward** (local testing):
+```bash
+kubectl port-forward -n octo svc/octo-nginx 8080:80
+# open http://localhost:8080
+```
+
+---
+
+## Upgrade
+
+```bash
+helm upgrade octo oci://ghcr.io/mininglamp-oss/octo --version 0.2.1 \
+  --namespace octo \
+  --reuse-values \
+  -f my-values.yaml
+```
+
+`--reuse-values` preserves the secrets set during install. Only pass `-f` for values that change.
+
+---
+
+## HTTPS / TLS
+
+The embedded Nginx handles all routing internally over plain HTTP. TLS termination should happen at the edge — either a cloud load balancer or a Kubernetes Ingress controller.
+
+If your load balancer or ingress controller terminates TLS, set:
+
+```yaml
+externalBaseURL: "https://octo.example.com"
+```
+
+The WebSocket address (`wss://`) and MinIO presigned URL scheme are derived automatically from `externalBaseURL` — no additional config needed.
+
+---
+
+## Key Configuration Reference
+
+### Top-level
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `domain` | Public hostname | `octo.local` |
+| `externalBaseURL` | Full public URL (scheme + host) | `http://<domain>:80` |
+| `timezone` | Container timezone | `UTC` |
+
+### Secrets
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `secrets.mysqlRootPassword` | MySQL root password | `""` |
+| `secrets.minioRootPassword` | MinIO root password (≥ 8 chars) | `""` |
+| `secrets.minioAppPassword` | MinIO app-scoped IAM password | `""` |
+| `secrets.matterDbPassword` | MySQL password for matter service | `""` |
+| `secrets.summaryDbPassword` | MySQL password for summary service | `""` |
+| `secrets.summaryReaderPassword` | MySQL read-only password for summary | `""` |
+| `secrets.octoMasterKey` | OCTO master key (exactly 32 hex chars) | `""` |
+| `secrets.notifyInternalToken` | Inter-service HMAC token | `""` |
+| `secrets.wukongimManagerToken` | WuKongIM admin token | `""` |
+| `secrets.adminPwd` | Initial superAdmin password | `superAdmin` |
+| `secrets.llmApiKey` | LLM API key for AI features | `""` |
+
+### LLM (AI features)
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `llm.apiURL` | LLM API base URL | `https://api.example.com/v1` |
+| `llm.model` | Model name | `claude-sonnet-4-6` |
+
+### octo-server runtime
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `server.config.register.disabled` | Disable self-registration | `true` |
+| `server.config.register.emailOn` | Enable email registration | `false` |
+| `server.config.support.email` | Sender address for outbound email | `""` |
+| `server.config.support.emailSmtp` | SMTP server (`host:port`) | `""` |
+| `server.config.support.emailPwd` | SMTP password | `""` |
+| `server.config.logger.level` | Log level (0=off … 4=debug) | `2` |
+
+### Storage
+
+Each stateful component has a `storage.size` and `storage.storageClass` field:
+
+```yaml
+mysql:
+  storage:
+    size: 20Gi
+    storageClass: ""   # uses cluster default
+
+redis:
+  storage:
+    size: 10Gi
+
+minio:
+  storage:
+    size: 50Gi
+
+wukongim:
+  storage:
+    size: 10Gi
+```
+
+### Ingress
+
+```yaml
+ingress:
+  enabled: false
+  className: ""          # e.g. nginx, traefik, qcloud
+  host: ""               # defaults to .Values.domain
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "1000m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+  tls:
+    enabled: false
+    secretName: ""       # existing TLS secret name
+```
+
+---
+
+## Uninstall
+
+```bash
+helm uninstall octo -n octo
+kubectl delete pvc --all -n octo   # remove persistent data
+kubectl delete namespace octo
+```
+
+> **Warning:** Deleting PVCs permanently removes all data (MySQL, MinIO, Redis, WuKongIM). Back up before uninstalling.
+
+---
+
+## Architecture
+
+```
+                    ┌─────────────────────────────────────┐
+  Browser / App ──▶ │  Kubernetes Ingress / LoadBalancer  │
+                    └──────────────┬──────────────────────┘
+                                   │ :80
+                    ┌──────────────▼──────────────────────┐
+                    │           octo-nginx                 │
+                    │  (routing, rate-limit, WS upgrade)   │
+                    └──┬──────┬──────┬──────┬─────────────┘
+                       │      │      │      │
+                   /api/  /ws  /minio/ /admin/ /matter/ /summary/
+                       │      │      │      │
+              octo-server  wukongim  minio  octo-admin
+              octo-web              │      octo-matter
+                                    │      summary-api
+                              mysql / redis summary-worker
+```
+
+All routing complexity (WebSocket upgrades, URL rewrites, presigned-URL passthrough) is handled by the embedded Nginx. The Kubernetes Ingress only needs a single catch-all rule pointing at the `octo-nginx` Service.

--- a/helm/octo/README.zh.md
+++ b/helm/octo/README.zh.md
@@ -1,0 +1,263 @@
+# OCTO Helm Chart
+
+通过一条 `helm install` 命令，在 Kubernetes 上部署完整的 OCTO 服务栈——MySQL、Redis、MinIO、WuKongIM、Nginx 以及所有应用服务。
+
+## 前置条件
+
+| 工具 | 版本要求 |
+|------|---------|
+| Kubernetes | 1.24+ |
+| Helm | 3.10+ |
+| kubectl | 与集群版本匹配 |
+| 默认 StorageClass | （或手动指定 `*.storage.storageClass`） |
+
+---
+
+## 快速开始
+
+### 1. 创建配置文件
+
+新建 `my-values.yaml`，填入你的配置：
+
+```yaml
+# my-values.yaml
+domain: "octo.example.com"
+externalBaseURL: "https://octo.example.com"
+
+ingress:
+  enabled: true
+  className: nginx
+  host: "octo.example.com"
+  tls:
+    enabled: true
+    secretName: octo-tls   # kubectl create secret tls octo-tls --cert=tls.crt --key=tls.key
+
+llm:
+  apiURL: "https://api.openai.com/v1"
+  model: "gpt-4o"
+
+secrets:
+  llmApiKey: "sk-..."
+
+server:
+  config:
+    register:
+      disabled: false      # 允许用户自主注册
+      emailOn: true
+    support:
+      email: "noreply@example.com"
+      emailSmtp: "smtp.gmail.com:465"
+      emailPwd: "your-app-password"
+```
+
+查看所有可用配置项：
+
+```bash
+helm show values oci://ghcr.io/mininglamp-oss/octo --version 0.2.1
+```
+
+### 2. 安装
+
+```bash
+helm install octo oci://ghcr.io/mininglamp-oss/octo --version 0.2.1 \
+  --namespace octo --create-namespace \
+  -f my-values.yaml \
+  --set secrets.mysqlRootPassword="$(openssl rand -hex 16)" \
+  --set secrets.minioRootPassword="$(openssl rand -hex 16)" \
+  --set secrets.minioAppPassword="$(openssl rand -hex 24)" \
+  --set secrets.matterDbPassword="$(openssl rand -hex 16)" \
+  --set secrets.summaryDbPassword="$(openssl rand -hex 16)" \
+  --set secrets.summaryReaderPassword="$(openssl rand -hex 16)" \
+  --set secrets.octoMasterKey="$(openssl rand -hex 16)" \
+  --set secrets.notifyInternalToken="$(openssl rand -hex 32)" \
+  --set secrets.wukongimManagerToken="$(openssl rand -hex 32)"
+```
+
+> **重要：** 请妥善保存安装时随机生成的密钥值，升级时需要用到。  
+> 建议存入密钥管理工具或本地加密文件。
+
+### 3. 等待所有 Pod 就绪
+
+```bash
+kubectl get pods -n octo -w
+```
+
+全部 11 个 Pod 应在 2–3 分钟内达到 `1/1 Running` 状态。
+
+### 4. 暴露服务
+
+默认 `nginx.service.type` 为 `ClusterIP`，根据实际环境选择暴露方式：
+
+**Ingress**（推荐，已在上方 `my-values.yaml` 中配置）：  
+将域名 DNS 指向 Ingress 控制器的外部 IP，访问 `https://octo.example.com` 即可。
+
+**LoadBalancer**（云环境）：  
+在 `my-values.yaml` 中添加：
+```yaml
+nginx:
+  service:
+    type: LoadBalancer
+```
+
+**端口转发**（本地测试）：
+```bash
+kubectl port-forward -n octo svc/octo-nginx 8080:80
+# 浏览器访问 http://localhost:8080
+```
+
+---
+
+## 升级
+
+```bash
+helm upgrade octo oci://ghcr.io/mininglamp-oss/octo --version 0.2.1 \
+  --namespace octo \
+  --reuse-values \
+  -f my-values.yaml
+```
+
+`--reuse-values` 会保留安装时设置的密钥，`-f` 只需传入有变更的配置。
+
+---
+
+## HTTPS / TLS
+
+内置 Nginx 在集群内部以纯 HTTP 处理所有路由，TLS 终止应在边缘完成——云负载均衡器或 Kubernetes Ingress 控制器均可。
+
+如果负载均衡器或 Ingress 已做 TLS 终止，只需设置：
+
+```yaml
+externalBaseURL: "https://octo.example.com"
+```
+
+WebSocket 地址（`wss://`）和 MinIO 预签名 URL 的协议会自动从 `externalBaseURL` 推导，无需额外配置。
+
+---
+
+## 核心配置参数
+
+### 顶层参数
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `domain` | 公网访问域名 | `octo.local` |
+| `externalBaseURL` | 完整公网地址（含协议和域名） | `http://<domain>:80` |
+| `timezone` | 容器时区 | `UTC` |
+
+### 密钥
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `secrets.mysqlRootPassword` | MySQL root 密码 | `""` |
+| `secrets.minioRootPassword` | MinIO root 密码（≥ 8 位） | `""` |
+| `secrets.minioAppPassword` | MinIO 应用级 IAM 密码 | `""` |
+| `secrets.matterDbPassword` | matter 服务的 MySQL 密码 | `""` |
+| `secrets.summaryDbPassword` | summary 服务的 MySQL 密码 | `""` |
+| `secrets.summaryReaderPassword` | summary 服务的 MySQL 只读密码 | `""` |
+| `secrets.octoMasterKey` | OCTO 主密钥（恰好 32 位十六进制） | `""` |
+| `secrets.notifyInternalToken` | 服务间 HMAC 令牌 | `""` |
+| `secrets.wukongimManagerToken` | WuKongIM 管理员令牌 | `""` |
+| `secrets.adminPwd` | 初始超级管理员密码 | `superAdmin` |
+| `secrets.llmApiKey` | AI 功能 LLM API Key | `""` |
+
+### LLM（AI 功能）
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `llm.apiURL` | LLM API 地址 | `https://api.example.com/v1` |
+| `llm.model` | 模型名称 | `claude-sonnet-4-6` |
+
+### octo-server 运行时配置
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `server.config.register.disabled` | 禁止用户自主注册 | `true` |
+| `server.config.register.emailOn` | 启用邮箱注册 | `false` |
+| `server.config.support.email` | 发件人地址 | `""` |
+| `server.config.support.emailSmtp` | SMTP 服务器（`host:port`） | `""` |
+| `server.config.support.emailPwd` | SMTP 密码 | `""` |
+| `server.config.logger.level` | 日志级别（0=关闭 … 4=调试） | `2` |
+
+常用 SMTP 配置示例：
+
+| 邮件服务 | SMTP 地址 | 说明 |
+|---------|-----------|------|
+| Gmail | `smtp.gmail.com:465` | 使用应用专用密码 |
+| QQ 邮箱 | `smtp.qq.com:465` | 使用授权码 |
+| 163 邮箱 | `smtp.163.com:465` | 使用授权码 |
+| Outlook | `smtp.office365.com:587` | 使用账号密码 |
+
+### 存储配置
+
+每个有状态组件均支持 `storage.size` 和 `storage.storageClass`：
+
+```yaml
+mysql:
+  storage:
+    size: 20Gi
+    storageClass: ""   # 留空使用集群默认 StorageClass
+
+redis:
+  storage:
+    size: 10Gi
+
+minio:
+  storage:
+    size: 50Gi
+
+wukongim:
+  storage:
+    size: 10Gi
+```
+
+### Ingress 配置
+
+```yaml
+ingress:
+  enabled: false
+  className: ""          # 如 nginx、traefik、qcloud
+  host: ""               # 默认使用 .Values.domain
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "1000m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+  tls:
+    enabled: false
+    secretName: ""       # 已存在的 TLS Secret 名称
+```
+
+---
+
+## 卸载
+
+```bash
+helm uninstall octo -n octo
+kubectl delete pvc --all -n octo   # 删除持久化数据
+kubectl delete namespace octo
+```
+
+> **警告：** 删除 PVC 会永久清除所有数据（MySQL、MinIO、Redis、WuKongIM），卸载前请做好备份。
+
+---
+
+## 架构说明
+
+```
+                    ┌─────────────────────────────────────┐
+  浏览器 / 客户端 ──▶ │  Kubernetes Ingress / LoadBalancer  │
+                    └──────────────┬──────────────────────┘
+                                   │ :80
+                    ┌──────────────▼──────────────────────┐
+                    │           octo-nginx                 │
+                    │  （路由分发、限速、WebSocket 升级）     │
+                    └──┬──────┬──────┬──────┬─────────────┘
+                       │      │      │      │
+                   /api/  /ws  /minio/ /admin/ /matter/ /summary/
+                       │      │      │      │
+              octo-server  wukongim  minio  octo-admin
+              octo-web              │      octo-matter
+                                    │      summary-api
+                              mysql / redis summary-worker
+```
+
+所有路由复杂性（WebSocket 升级、URL 改写、预签名 URL 透传）均由内置 Nginx 处理。Kubernetes Ingress 只需一条兜底规则，将流量指向 `octo-nginx` Service 即可。

--- a/helm/octo/README.zh.md
+++ b/helm/octo/README.zh.md
@@ -70,7 +70,8 @@ helm install octo oci://ghcr.io/mininglamp-oss/octo --version 0.2.1 \
   --set secrets.summaryReaderPassword="$(openssl rand -hex 16)" \
   --set secrets.octoMasterKey="$(openssl rand -hex 16)" \
   --set secrets.notifyInternalToken="$(openssl rand -hex 32)" \
-  --set secrets.wukongimManagerToken="$(openssl rand -hex 32)"
+  --set secrets.wukongimManagerToken="$(openssl rand -hex 32)" \
+  --set secrets.adminPwd="$(openssl rand -hex 16)"
 ```
 
 > **重要：** 请妥善保存安装时随机生成的密钥值，升级时需要用到。  

--- a/helm/octo/templates/NOTES.txt
+++ b/helm/octo/templates/NOTES.txt
@@ -1,0 +1,38 @@
+OCTO Server has been deployed.
+
+External URL: {{ include "octo.externalBaseURL" . }}
+
+Service endpoints (internal cluster):
+  API:     http://{{ include "octo.server.fullname" . }}:8090
+  Web:     http://{{ include "octo.web.fullname" . }}
+  Admin:   http://{{ include "octo.admin.fullname" . }}
+  Matter:  http://{{ include "octo.matter.fullname" . }}:8080
+{{- if .Values.summary.enabled }}
+  Summary: http://{{ include "octo.summaryApi.fullname" . }}:8080
+{{- end }}
+
+Get the public nginx address:
+{{- if eq .Values.nginx.service.type "LoadBalancer" }}
+  kubectl get svc {{ include "octo.nginx.fullname" . }} -n {{ .Release.Namespace }} \
+    -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+{{- else if eq .Values.nginx.service.type "NodePort" }}
+  NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}')
+  NODE_PORT=$(kubectl get svc {{ include "octo.nginx.fullname" . }} -n {{ .Release.Namespace }} \
+    -o jsonpath='{.spec.ports[0].nodePort}')
+  echo "http://$NODE_IP:$NODE_PORT"
+{{- end }}
+
+Wait for all pods to be ready:
+  kubectl rollout status deployment/{{ include "octo.server.fullname" . }} -n {{ .Release.Namespace }}
+
+Quick health check:
+  kubectl exec -n {{ .Release.Namespace }} \
+    deploy/{{ include "octo.server.fullname" . }} -- \
+    wget -q -O- http://localhost:8090/v1/ping
+
+MinIO console (SSH tunnel to pod):
+  kubectl port-forward -n {{ .Release.Namespace }} \
+    svc/{{ include "octo.minio.fullname" . }} 9001:9001
+
+NOTE: If secrets.adminPwd was set, the initial superAdmin account is
+available at {{ include "octo.externalBaseURL" . }}/admin/

--- a/helm/octo/templates/_helpers.tpl
+++ b/helm/octo/templates/_helpers.tpl
@@ -1,0 +1,251 @@
+{{/*
+Build a full image reference, optionally prefixed with global.imageRegistry.
+Usage: include "octo.image" (dict "repo" .Values.foo.image.repository "tag" .Values.foo.image.tag "ctx" .)
+*/}}
+{{- define "octo.image" -}}
+{{- $reg := .ctx.Values.global.imageRegistry | default "" -}}
+{{- if $reg -}}
+{{- printf "%s/%s:%s" ($reg | trimSuffix "/") .repo .tag -}}
+{{- else -}}
+{{- printf "%s:%s" .repo .tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+imagePullSecrets block. Renders nothing when the list is empty.
+Indent the output to match the surrounding pod spec (typically nindent 6).
+*/}}
+{{- define "octo.imagePullSecrets" -}}
+{{- with .Values.global.imagePullSecrets -}}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "octo.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+Truncate at 63 chars because some Kubernetes name fields are limited to this.
+*/}}
+{{- define "octo.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart label value.
+*/}}
+{{- define "octo.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels applied to every resource.
+*/}}
+{{- define "octo.labels" -}}
+helm.sh/chart: {{ include "octo.chart" . }}
+{{ include "octo.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels (immutable after initial deploy).
+*/}}
+{{- define "octo.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "octo.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* ── Component fully-qualified names ─────────────────────────────────────── */}}
+
+{{- define "octo.mysql.fullname" -}}
+{{- printf "%s-mysql" (include "octo.fullname" .) }}
+{{- end }}
+
+{{- define "octo.redis.fullname" -}}
+{{- printf "%s-redis" (include "octo.fullname" .) }}
+{{- end }}
+
+{{- define "octo.minio.fullname" -}}
+{{- printf "%s-minio" (include "octo.fullname" .) }}
+{{- end }}
+
+{{- define "octo.wukongim.fullname" -}}
+{{- printf "%s-wukongim" (include "octo.fullname" .) }}
+{{- end }}
+
+{{- define "octo.server.fullname" -}}
+{{- printf "%s-server" (include "octo.fullname" .) }}
+{{- end }}
+
+{{- define "octo.web.fullname" -}}
+{{- printf "%s-web" (include "octo.fullname" .) }}
+{{- end }}
+
+{{- define "octo.admin.fullname" -}}
+{{- printf "%s-admin" (include "octo.fullname" .) }}
+{{- end }}
+
+{{- define "octo.matter.fullname" -}}
+{{- printf "%s-matter" (include "octo.fullname" .) }}
+{{- end }}
+
+{{- define "octo.summaryApi.fullname" -}}
+{{- printf "%s-summary-api" (include "octo.fullname" .) }}
+{{- end }}
+
+{{- define "octo.summaryWorker.fullname" -}}
+{{- printf "%s-summary-worker" (include "octo.fullname" .) }}
+{{- end }}
+
+{{- define "octo.nginx.fullname" -}}
+{{- printf "%s-nginx" (include "octo.fullname" .) }}
+{{- end }}
+
+{{- define "octo.secretName" -}}
+{{- printf "%s-secrets" (include "octo.fullname" .) }}
+{{- end }}
+
+{{/* ── Connection helpers ────────────────────────────────────────────────────── */}}
+
+{{/*
+MySQL hostname (bundled or external).
+*/}}
+{{- define "octo.mysql.host" -}}
+{{- if .Values.mysql.enabled }}
+{{- include "octo.mysql.fullname" . }}
+{{- else }}
+{{- required "externalMySQL.host is required when mysql.enabled=false" .Values.externalMySQL.host }}
+{{- end }}
+{{- end }}
+
+{{/*
+MySQL port.
+*/}}
+{{- define "octo.mysql.port" -}}
+{{- if .Values.mysql.enabled }}
+{{- .Values.mysql.service.port | default 3306 }}
+{{- else }}
+{{- .Values.externalMySQL.port | default 3306 }}
+{{- end }}
+{{- end }}
+
+{{/*
+MySQL database name.
+*/}}
+{{- define "octo.mysql.database" -}}
+{{- if .Values.mysql.enabled }}
+{{- .Values.mysql.auth.database | default "octo" }}
+{{- else }}
+{{- .Values.externalMySQL.database | default "octo" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Redis addr (host:port).
+*/}}
+{{- define "octo.redis.addr" -}}
+{{- if .Values.redis.enabled }}
+{{- printf "%s:%v" (include "octo.redis.fullname" .) (.Values.redis.service.port | default 6379) }}
+{{- else }}
+{{- required "externalRedis.addr is required when redis.enabled=false" .Values.externalRedis.addr }}
+{{- end }}
+{{- end }}
+
+{{/*
+MinIO internal endpoint (host:port) used by server-side calls.
+*/}}
+{{- define "octo.minio.endpoint" -}}
+{{- if .Values.minio.enabled }}
+{{- printf "%s:%v" (include "octo.minio.fullname" .) (.Values.minio.service.apiPort | default 9000) }}
+{{- else }}
+{{- required "externalMinio.endpoint is required when minio.enabled=false" .Values.externalMinio.endpoint }}
+{{- end }}
+{{- end }}
+
+{{/*
+MinIO internal URL (http://host:port).
+*/}}
+{{- define "octo.minio.url" -}}
+{{- printf "http://%s" (include "octo.minio.endpoint" .) }}
+{{- end }}
+
+{{/*
+MinIO app user (IAM).
+*/}}
+{{- define "octo.minio.appUser" -}}
+{{- if .Values.minio.enabled }}
+{{- .Values.minio.auth.appUser | default "octo-app" }}
+{{- else }}
+{{- .Values.externalMinio.appUser | default "octo-app" }}
+{{- end }}
+{{- end }}
+
+{{/*
+WuKongIM API URL.
+*/}}
+{{- define "octo.wukongim.apiURL" -}}
+{{- if .Values.wukongim.enabled }}
+{{- printf "http://%s:%v" (include "octo.wukongim.fullname" .) (.Values.wukongim.service.apiPort | default 5001) }}
+{{- else }}
+{{- required "externalWukongim.apiURL is required when wukongim.enabled=false" .Values.externalWukongim.apiURL }}
+{{- end }}
+{{- end }}
+
+{{/*
+nginx HTTP port (the public port exposed by the nginx Service).
+*/}}
+{{- define "octo.nginx.port" -}}
+{{- .Values.nginx.service.port | default 80 }}
+{{- end }}
+
+{{/*
+External base URL (used for presigned URLs and OIDC callbacks).
+*/}}
+{{- define "octo.externalBaseURL" -}}
+{{- if .Values.externalBaseURL }}
+{{- .Values.externalBaseURL }}
+{{- else }}
+{{- printf "http://%s:%v" .Values.domain (include "octo.nginx.port" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+MinIO public S3 server URL (MINIO_SERVER_URL + TS_MINIO_DOWNLOADURL).
+*/}}
+{{- define "octo.minio.serverURL" -}}
+{{- if .Values.minio.serverURL }}
+{{- .Values.minio.serverURL }}
+{{- else }}
+{{- include "octo.externalBaseURL" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+WuKongIM external WebSocket address.
+*/}}
+{{- define "octo.wukongim.wsAddr" -}}
+{{- if .Values.wukongim.wsAddr }}
+{{- .Values.wukongim.wsAddr }}
+{{- else }}
+{{- $base := include "octo.externalBaseURL" . }}
+{{- $base | replace "https://" "wss://" | replace "http://" "ws://" }}/ws
+{{- end }}
+{{- end }}

--- a/helm/octo/templates/configmap-misc.yaml
+++ b/helm/octo/templates/configmap-misc.yaml
@@ -1,0 +1,131 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "octo.fullname" . }}-misc
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+data:
+  minio-octo-app-policy.json: |
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "OctoAppBucketReadWrite",
+          "Effect": "Allow",
+          "Action": [
+            "s3:GetBucketLocation",
+            "s3:ListBucket",
+            "s3:ListBucketMultipartUploads"
+          ],
+          "Resource": [
+            "arn:aws:s3:::file",
+            "arn:aws:s3:::chat",
+            "arn:aws:s3:::moment",
+            "arn:aws:s3:::sticker",
+            "arn:aws:s3:::report",
+            "arn:aws:s3:::chatbg",
+            "arn:aws:s3:::common",
+            "arn:aws:s3:::download",
+            "arn:aws:s3:::group",
+            "arn:aws:s3:::avatar"
+          ]
+        },
+        {
+          "Sid": "OctoAppObjectReadWrite",
+          "Effect": "Allow",
+          "Action": [
+            "s3:GetObject",
+            "s3:PutObject",
+            "s3:DeleteObject",
+            "s3:AbortMultipartUpload",
+            "s3:ListMultipartUploadParts"
+          ],
+          "Resource": [
+            "arn:aws:s3:::file/*",
+            "arn:aws:s3:::chat/*",
+            "arn:aws:s3:::moment/*",
+            "arn:aws:s3:::sticker/*",
+            "arn:aws:s3:::report/*",
+            "arn:aws:s3:::chatbg/*",
+            "arn:aws:s3:::common/*",
+            "arn:aws:s3:::download/*",
+            "arn:aws:s3:::group/*",
+            "arn:aws:s3:::avatar/*"
+          ]
+        }
+      ]
+    }
+
+  init-extra-dbs.sh: |
+    #!/bin/bash
+    # Runs inside MySQL's docker-entrypoint-initdb.d on first volume init.
+    # Creates extra schemas and service-account users for octo-matter + smart-summary.
+    set -euo pipefail
+
+    : "${OCTO_MATTER_DB_PASSWORD:=matter}"
+    : "${OCTO_SUMMARY_DB_PASSWORD:=summary}"
+    : "${OCTO_SUMMARY_READER_PASSWORD:=summary_reader}"
+    : "${MYSQL_DATABASE:=octo}"
+
+    validate_password() {
+      local name="$1" value="$2"
+      if [ -z "$value" ]; then
+        echo "[init-extra-dbs] FATAL: $name is empty" >&2; exit 1
+      fi
+      case "$value" in
+        *[!A-Za-z0-9._-]*)
+          echo "[init-extra-dbs] FATAL: $name contains characters outside [A-Za-z0-9._-]" >&2; exit 1 ;;
+      esac
+      local lc; lc=$(printf %s "$value" | tr 'A-Z' 'a-z')
+      case "$lc" in
+        change_me_*|chg_me*)
+          echo "[init-extra-dbs] FATAL: $name is still a CHANGE_ME placeholder." >&2; exit 1 ;;
+      esac
+    }
+
+    reject_literal_default() {
+      local name="$1" value="$2" default="$3"
+      if [ "$value" = "$default" ]; then
+        echo "[init-extra-dbs] FATAL: $name is still the literal default ('$default')." >&2; exit 1
+      fi
+    }
+
+    validate_identifier() {
+      local name="$1" value="$2"
+      if [ -z "$value" ]; then
+        echo "[init-extra-dbs] FATAL: $name is empty" >&2; exit 1
+      fi
+      case "$value" in
+        *[!A-Za-z0-9_]*)
+          echo "[init-extra-dbs] FATAL: $name contains characters outside [A-Za-z0-9_]" >&2; exit 1 ;;
+      esac
+    }
+
+    validate_password  OCTO_MATTER_DB_PASSWORD       "$OCTO_MATTER_DB_PASSWORD"
+    validate_password  OCTO_SUMMARY_DB_PASSWORD      "$OCTO_SUMMARY_DB_PASSWORD"
+    validate_password  OCTO_SUMMARY_READER_PASSWORD  "$OCTO_SUMMARY_READER_PASSWORD"
+    reject_literal_default OCTO_MATTER_DB_PASSWORD       "$OCTO_MATTER_DB_PASSWORD"      "matter"
+    reject_literal_default OCTO_SUMMARY_DB_PASSWORD      "$OCTO_SUMMARY_DB_PASSWORD"     "summary"
+    reject_literal_default OCTO_SUMMARY_READER_PASSWORD  "$OCTO_SUMMARY_READER_PASSWORD" "summary_reader"
+    validate_password  MYSQL_ROOT_PASSWORD            "$MYSQL_ROOT_PASSWORD"
+    validate_identifier MYSQL_DATABASE               "$MYSQL_DATABASE"
+
+    MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -u root <<SQL
+    CREATE DATABASE IF NOT EXISTS octo_matter  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+    CREATE DATABASE IF NOT EXISTS octo_summary CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+    CREATE USER IF NOT EXISTS 'matter'@'%'  IDENTIFIED BY '${OCTO_MATTER_DB_PASSWORD}';
+    ALTER USER IF EXISTS      'matter'@'%'  IDENTIFIED BY '${OCTO_MATTER_DB_PASSWORD}';
+    CREATE USER IF NOT EXISTS 'summary'@'%' IDENTIFIED BY '${OCTO_SUMMARY_DB_PASSWORD}';
+    ALTER USER IF EXISTS      'summary'@'%' IDENTIFIED BY '${OCTO_SUMMARY_DB_PASSWORD}';
+
+    CREATE USER IF NOT EXISTS 'summary_reader'@'%' IDENTIFIED BY '${OCTO_SUMMARY_READER_PASSWORD}';
+    ALTER USER IF EXISTS      'summary_reader'@'%' IDENTIFIED BY '${OCTO_SUMMARY_READER_PASSWORD}';
+
+    GRANT ALL PRIVILEGES ON octo_matter.*       TO 'matter'@'%';
+    GRANT ALL PRIVILEGES ON octo_summary.*      TO 'summary'@'%';
+    GRANT SELECT         ON \`${MYSQL_DATABASE}\`.* TO 'summary_reader'@'%';
+    FLUSH PRIVILEGES;
+    SQL
+
+    echo "[init-extra-dbs] created octo_matter + octo_summary + service users"

--- a/helm/octo/templates/configmap-nginx.yaml
+++ b/helm/octo/templates/configmap-nginx.yaml
@@ -1,0 +1,199 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "octo.fullname" . }}-nginx-config
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+data:
+  nginx.conf: |
+    user  nginx;
+    worker_processes  auto;
+    error_log  /var/log/nginx/error.log notice;
+    pid        /var/run/nginx.pid;
+
+    events {
+        worker_connections  1024;
+    }
+
+    http {
+        include       /etc/nginx/mime.types;
+        default_type  application/octet-stream;
+
+        server_tokens off;
+
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+        access_log  /var/log/nginx/access.log  main;
+
+        sendfile        on;
+        keepalive_timeout  65;
+
+        limit_req_zone $binary_remote_addr zone=octo_api:10m  rate=30r/s;
+        limit_req_zone $binary_remote_addr zone=octo_auth:10m rate=10r/s;
+
+        gzip  on;
+        gzip_min_length  1k;
+        gzip_vary        on;
+        gzip_proxied     any;
+        gzip_comp_level  2;
+        gzip_buffers     16 8k;
+        gzip_http_version 1.1;
+        gzip_types text/plain text/css application/json application/javascript
+                   text/xml application/xml application/xml+rss text/javascript
+                   application/wasm image/svg+xml font/woff2;
+
+        include /etc/nginx/conf.d/*.conf;
+    }
+
+  octo.conf: |
+    upstream octo_api {
+        server {{ include "octo.server.fullname" . }}:8090;
+        keepalive 16;
+    }
+
+    upstream octo_ws {
+        server {{ include "octo.wukongim.fullname" . }}:{{ .Values.wukongim.service.wsPort | default 5200 }};
+        keepalive 8;
+    }
+
+    upstream octo_minio_api {
+        server {{ include "octo.minio.fullname" . }}:{{ .Values.minio.service.apiPort | default 9000 }};
+        keepalive 8;
+    }
+
+    server {
+        listen       80 default_server;
+        listen       [::]:80 default_server;
+        server_name  {{ .Values.domain }} localhost _;
+
+        client_max_body_size    1000m;
+        client_body_buffer_size 8m;
+
+        add_header X-Frame-Options          "SAMEORIGIN" always;
+        add_header X-Content-Type-Options   "nosniff" always;
+        add_header Referrer-Policy          "strict-origin-when-cross-origin" always;
+
+        location = /_nginx_up {
+            access_log off;
+            default_type text/plain;
+            return 200 "ok\n";
+        }
+
+        location /api/ {
+            limit_req zone=octo_api burst=60 nodelay;
+            proxy_pass         http://octo_api/;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_set_header   Connection        "";
+            proxy_read_timeout 600s;
+        }
+
+        location ^~ /v1/ {
+            limit_req zone=octo_auth burst=20 nodelay;
+            proxy_pass         http://octo_api/v1/;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_set_header   Connection        "";
+            proxy_read_timeout 600s;
+        }
+
+        location /ws {
+            proxy_pass          http://octo_ws;
+            proxy_http_version  1.1;
+            proxy_set_header    Upgrade           $http_upgrade;
+            proxy_set_header    Connection        "upgrade";
+            proxy_set_header    Host              $host;
+            proxy_set_header    X-Real-IP         $remote_addr;
+            proxy_set_header    X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header    X-Forwarded-Proto $scheme;
+            proxy_read_timeout  3600s;
+            proxy_send_timeout  3600s;
+        }
+
+        location /minio/ {
+            proxy_pass         http://octo_minio_api;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $http_host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_set_header   Connection        "";
+            proxy_read_timeout 600s;
+            proxy_request_buffering off;
+            proxy_buffering off;
+        }
+
+        location = /admin {
+            return 301 /admin/;
+        }
+        location /admin/ {
+            proxy_pass         http://{{ include "octo.admin.fullname" . }}/admin/;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+        }
+
+        location /matter/ {
+            limit_req zone=octo_api burst=20 nodelay;
+            rewrite ^/matter/(.*) /$1 break;
+            proxy_pass         http://{{ include "octo.matter.fullname" . }}:8080;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+        }
+
+        {{- if .Values.summary.enabled }}
+        location /summary/ {
+            limit_req zone=octo_api burst=20 nodelay;
+            rewrite ^/summary/(.*) /$1 break;
+            proxy_pass         http://{{ include "octo.summaryApi.fullname" . }}:8080;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+        }
+        {{- end }}
+
+        location = /_octo_up {
+            default_type text/html;
+            return 200 "OCTO Server is up. Visit /admin/ for the admin console.";
+        }
+
+        location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)/.+ {
+            proxy_pass         http://octo_minio_api;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $http_host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_set_header   Connection        "";
+            proxy_request_buffering off;
+            proxy_buffering off;
+            proxy_read_timeout 600s;
+        }
+
+        location / {
+            proxy_pass         http://{{ include "octo.web.fullname" . }};
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+        }
+    }
+
+  default.conf: |
+    # Empty — suppresses nginx built-in default server.

--- a/helm/octo/templates/configmap-octo-server.yaml
+++ b/helm/octo/templates/configmap-octo-server.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "octo.fullname" . }}-octo-server-config
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+data:
+  tsdd.yaml: |
+    {{- $cfg      := .Values.server.config     | default dict }}
+    {{- $logger   := $cfg.logger               | default dict }}
+    {{- $register := $cfg.register             | default dict }}
+    {{- $support  := $cfg.support              | default dict }}
+    mode: {{ $cfg.mode | default "release" | quote }}
+
+    external:
+      ip: ""
+      baseURL: ""
+      {{- if $cfg.webLoginURL }}
+      webLoginURL: {{ $cfg.webLoginURL | quote }}
+      {{- end }}
+
+    smsCode: {{ $cfg.smsCode | default "" | quote }}
+    adminPwd: ""
+
+    db:
+      mysqlAddr: ""
+      redisAddr: ""
+      redisPass: ""
+
+    wukongIM:
+      apiURL: "{{ include "octo.wukongim.apiURL" . }}"
+      managerToken: ""
+
+    fileService: {{ $cfg.fileService | default "minio" | quote }}
+    minio:
+      url: "{{ include "octo.minio.url" . }}"
+      downloadURL: ""
+      accessKeyID: ""
+      secretAccessKey: ""
+
+    logger:
+      level: {{ $logger.level | default 2 }}
+      dir: {{ $logger.dir | default "./logs" | quote }}
+      lineNum: {{ hasKey $logger "lineNum" | ternary (index $logger "lineNum") false }}
+
+    register:
+      off: {{ hasKey $register "disabled" | ternary (index $register "disabled") true }}
+      onlyChina: {{ hasKey $register "onlyChina" | ternary (index $register "onlyChina") false }}
+      emailOn: {{ hasKey $register "emailOn" | ternary (index $register "emailOn") false }}
+
+    {{- if or $support.email $support.emailSmtp $support.emailPwd }}
+    support:
+      {{- if $support.email }}
+      email: {{ $support.email | quote }}
+      {{- end }}
+      {{- if $support.emailSmtp }}
+      emailSmtp: {{ $support.emailSmtp | quote }}
+      {{- end }}
+      {{- if $support.emailPwd }}
+      emailPwd: {{ $support.emailPwd | quote }}
+      {{- end }}
+    {{- end }}

--- a/helm/octo/templates/configmap-wukongim.yaml
+++ b/helm/octo/templates/configmap-wukongim.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "octo.fullname" . }}-wukongim-config
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+data:
+  wk.yaml: |
+    mode: "{{ .Values.wukongim.mode | default "release" }}"
+
+    tokenAuthOn: true
+
+    external:
+      ip: "{{ .Values.wukongim.externalIP | default "" }}"
+      tcpAddr: "{{ .Values.wukongim.tcpAddr | default "" }}"
+      wsAddr: "{{ include "octo.wukongim.wsAddr" . }}"
+      wssAddr: "{{ .Values.wukongim.wssAddr | default "" }}"
+
+    monitor:
+      on: true
+      addr: "0.0.0.0:5300"
+
+    webhook:
+      grpcAddr: "{{ include "octo.server.fullname" . }}:6979"
+
+    conversation:
+      on: true

--- a/helm/octo/templates/deployment-frontend.yaml
+++ b/helm/octo/templates/deployment-frontend.yaml
@@ -1,0 +1,147 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octo.web.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    {{- include "octo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "octo.web.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  replicas: {{ .Values.web.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      initContainers:
+        - name: wait-for-server
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command: ['sh', '-c', 'until wget -q -O- http://{{ include "octo.server.fullname" . }}:8090/v1/ping >/dev/null 2>&1; do echo waiting for octo-server; sleep 5; done']
+      containers:
+        - name: octo-web
+          image: {{ include "octo.image" (dict "repo" .Values.web.image.repository "tag" .Values.web.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+          env:
+            - name: API_URL
+              value: "http://{{ include "octo.server.fullname" . }}:8090"
+            {{- if .Values.summary.enabled }}
+            - name: SUMMARY_API_URL
+              value: "http://{{ include "octo.summaryApi.fullname" . }}:8080"
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.web.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octo.admin.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admin
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    {{- include "octo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: admin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "octo.admin.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admin
+spec:
+  replicas: {{ .Values.admin.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: admin
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: admin
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      initContainers:
+        - name: wait-for-server
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command: ['sh', '-c', 'until wget -q -O- http://{{ include "octo.server.fullname" . }}:8090/v1/ping >/dev/null 2>&1; do echo waiting for octo-server; sleep 5; done']
+      containers:
+        - name: octo-admin
+          image: {{ include "octo.image" (dict "repo" .Values.admin.image.repository "tag" .Values.admin.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.admin.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+          env:
+            - name: API_BACKEND
+              value: "{{ include "octo.server.fullname" . }}:8090"
+          readinessProbe:
+            httpGet:
+              path: /admin/
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /admin/
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.admin.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/helm/octo/templates/deployment-nginx.yaml
+++ b/helm/octo/templates/deployment-nginx.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.nginx.service.type | default "LoadBalancer" }}
+  type: {{ .Values.nginx.service.type | default "ClusterIP" }}
   ports:
     - name: http
       port: {{ .Values.nginx.service.port | default 80 }}

--- a/helm/octo/templates/deployment-nginx.yaml
+++ b/helm/octo/templates/deployment-nginx.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octo.nginx.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nginx
+  {{- with .Values.nginx.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.nginx.service.type | default "LoadBalancer" }}
+  ports:
+    - name: http
+      port: {{ .Values.nginx.service.port | default 80 }}
+      targetPort: http
+      {{- if and (eq (.Values.nginx.service.type | default "") "NodePort") .Values.nginx.service.nodePort }}
+      nodePort: {{ .Values.nginx.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "octo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: nginx
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "octo.nginx.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: nginx
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: nginx
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-nginx.yaml") . | sha256sum }}
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: nginx
+          image: {{ include "octo.image" (dict "repo" .Values.nginx.image.repository "tag" .Values.nginx.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /_nginx_up
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /_nginx_up
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/octo.conf
+              subPath: octo.conf
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+          {{- with .Values.nginx.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: {{ include "octo.fullname" . }}-nginx-config

--- a/helm/octo/templates/deployment-octo-matter.yaml
+++ b/helm/octo/templates/deployment-octo-matter.yaml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octo.matter.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: matter
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  selector:
+    {{- include "octo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: matter
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "octo.matter.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: matter
+spec:
+  replicas: {{ .Values.matter.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: matter
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: matter
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      initContainers:
+        - name: wait-for-mysql
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command: ['sh', '-c', 'until nc -z {{ include "octo.mysql.host" . }} {{ include "octo.mysql.port" . }}; do echo waiting for mysql; sleep 2; done']
+      containers:
+        - name: octo-matter
+          image: {{ include "octo.image" (dict "repo" .Values.matter.image.repository "tag" .Values.matter.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.matter.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: APP_ENV
+              value: {{ .Values.matter.appEnv | default "prod" | quote }}
+            - name: OCTO_MATTER_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_MATTER_DB_PASSWORD
+            - name: MYSQL_DSN
+              value: "matter:$(OCTO_MATTER_DB_PASSWORD)@tcp({{ include "octo.mysql.host" . }}:{{ include "octo.mysql.port" . }})/octo_matter?charset=utf8mb4&parseTime=true"
+            - name: DMWORKIM_URL
+              value: "http://{{ include "octo.server.fullname" . }}:8090"
+            - name: WUKONGIM_URL
+              value: {{ include "octo.wukongim.apiURL" . | quote }}
+            - name: SERVER_PORT
+              value: "8080"
+            - name: NOTIFY_INTERNAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_NOTIFY_INTERNAL_TOKEN
+            - name: LLM_API_URL
+              value: {{ .Values.llm.apiURL | default "https://api.example.com/v1" | quote }}
+            - name: LLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: LLM_API_KEY
+            - name: LLM_MODEL
+              value: {{ .Values.llm.model | default "claude-sonnet-4-6" | quote }}
+            - name: LLM_TIMEOUT
+              value: "30"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: logs
+              mountPath: /home/logs
+          {{- with .Values.matter.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: logs
+          emptyDir: {}

--- a/helm/octo/templates/deployment-octo-matter.yaml
+++ b/helm/octo/templates/deployment-octo-matter.yaml
@@ -30,6 +30,8 @@ spec:
       app.kubernetes.io/component: matter
   template:
     metadata:
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "octo.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: matter

--- a/helm/octo/templates/deployment-octo-server.yaml
+++ b/helm/octo/templates/deployment-octo-server.yaml
@@ -1,0 +1,182 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octo.server.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8090
+      targetPort: http
+    - name: grpc
+      port: 6979
+      targetPort: grpc
+  selector:
+    {{- include "octo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "octo.server.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  replicas: {{ .Values.server.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: server
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      initContainers:
+        - name: wait-for-mysql
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command: ['sh', '-c', 'until nc -z {{ include "octo.mysql.host" . }} {{ include "octo.mysql.port" . }}; do echo waiting for mysql; sleep 2; done']
+        - name: wait-for-redis
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command: ['sh', '-c', 'until nc -z {{ include "octo.redis.fullname" . }} {{ .Values.redis.service.port | default 6379 }}; do echo waiting for redis; sleep 2; done']
+        - name: wait-for-minio
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command: ['sh', '-c', 'until wget -q -O- http://{{ include "octo.minio.fullname" . }}:{{ .Values.minio.service.apiPort | default 9000 }}/minio/health/live >/dev/null 2>&1; do echo waiting for minio; sleep 2; done']
+      containers:
+        - name: octo-server
+          image: {{ include "octo.image" (dict "repo" .Values.server.image.repository "tag" .Values.server.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          args: ["api"]
+          ports:
+            - name: http
+              containerPort: 8090
+            - name: grpc
+              containerPort: 6979
+          env:
+            - name: TZ
+              value: {{ .Values.timezone | default "UTC" | quote }}
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: MYSQL_ROOT_PASSWORD
+            - name: OCTO_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_MASTER_KEY
+            - name: DMWORK_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_MASTER_KEY
+            - name: OCTO_MINIO_APP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_MINIO_APP_PASSWORD
+            - name: OCTO_WUKONGIM_MANAGER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_WUKONGIM_MANAGER_TOKEN
+            - name: OCTO_NOTIFY_INTERNAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_NOTIFY_INTERNAL_TOKEN
+            - name: OCTO_ADMIN_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_ADMIN_PWD
+            - name: OCTO_WEBHOOK_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_WEBHOOK_SECRET_KEY
+            # DSN built from secret ref via K8s $(VAR) interpolation
+            - name: TS_DB_MYSQLADDR
+              value: "root:$(MYSQL_ROOT_PASSWORD)@tcp({{ include "octo.mysql.host" . }}:{{ include "octo.mysql.port" . }})/{{ include "octo.mysql.database" . }}?charset=utf8mb4&parseTime=true&loc=Local"
+            - name: DM_MYSQL_DSN
+              value: "root:$(MYSQL_ROOT_PASSWORD)@tcp({{ include "octo.mysql.host" . }}:{{ include "octo.mysql.port" . }})/{{ include "octo.mysql.database" . }}?charset=utf8mb4&parseTime=true&loc=Local"
+            - name: TS_DB_REDISADDR
+              value: {{ include "octo.redis.addr" . | quote }}
+            - name: DM_REDIS_ADDR
+              value: {{ include "octo.redis.addr" . | quote }}
+            - name: TS_WUKONGIM_MANAGERTOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_WUKONGIM_MANAGER_TOKEN
+            - name: WUKONGIM_MANAGER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_WUKONGIM_MANAGER_TOKEN
+            - name: TS_MINIO_ACCESSKEYID
+              value: {{ include "octo.minio.appUser" . | quote }}
+            - name: TS_MINIO_SECRETACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_MINIO_APP_PASSWORD
+            - name: TS_MINIO_DOWNLOADURL
+              value: {{ include "octo.minio.serverURL" . | quote }}
+            - name: TS_EXTERNAL_BASEURL
+              value: {{ include "octo.externalBaseURL" . | quote }}
+            - name: TS_EXTERNAL_IP
+              value: {{ .Values.wukongim.externalIP | default "" | quote }}
+            - name: NOTIFY_INTERNAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_NOTIFY_INTERNAL_TOKEN
+            - name: TS_ADMINPWD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_ADMIN_PWD
+            - name: TS_WEBHOOK_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_WEBHOOK_SECRET_KEY
+          readinessProbe:
+            httpGet:
+              path: /v1/ping
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /v1/ping
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 3
+          volumeMounts:
+            - name: config
+              mountPath: /home/configs/tsdd.yaml
+              subPath: tsdd.yaml
+            - name: logs
+              mountPath: /home/logs
+          {{- with .Values.server.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "octo.fullname" . }}-octo-server-config
+        - name: logs
+          emptyDir: {}

--- a/helm/octo/templates/deployment-octo-server.yaml
+++ b/helm/octo/templates/deployment-octo-server.yaml
@@ -33,6 +33,9 @@ spec:
       app.kubernetes.io/component: server
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-octo-server.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "octo.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: server

--- a/helm/octo/templates/deployment-summary.yaml
+++ b/helm/octo/templates/deployment-summary.yaml
@@ -1,0 +1,205 @@
+{{- if .Values.summary.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octo.summaryApi.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: summary-api
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+    - name: internal
+      port: 8081
+      targetPort: internal
+  selector:
+    {{- include "octo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: summary-api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "octo.summaryApi.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: summary-api
+spec:
+  replicas: {{ .Values.summary.api.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: summary-api
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: summary-api
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      initContainers:
+        - name: wait-for-mysql
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command: ['sh', '-c', 'until nc -z {{ include "octo.mysql.host" . }} {{ include "octo.mysql.port" . }}; do echo waiting for mysql; sleep 2; done']
+      containers:
+        - name: summary-api
+          image: {{ include "octo.image" (dict "repo" .Values.summary.api.image.repository "tag" .Values.summary.api.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.summary.api.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: internal
+              containerPort: 8081
+          env:
+            - name: OCTO_SUMMARY_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_SUMMARY_DB_PASSWORD
+            - name: OCTO_SUMMARY_READER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_SUMMARY_READER_PASSWORD
+            - name: MYSQL_DSN
+              value: "summary:$(OCTO_SUMMARY_DB_PASSWORD)@tcp({{ include "octo.mysql.host" . }}:{{ include "octo.mysql.port" . }})/octo_summary?charset=utf8mb4&parseTime=true"
+            - name: IM_MYSQL_DSN
+              value: "summary_reader:$(OCTO_SUMMARY_READER_PASSWORD)@tcp({{ include "octo.mysql.host" . }}:{{ include "octo.mysql.port" . }})/{{ include "octo.mysql.database" . }}?charset=utf8mb4&parseTime=true"
+            - name: OCTO_API_URL
+              value: "http://{{ include "octo.server.fullname" . }}:8090"
+            - name: DMWORK_API_URL
+              value: "http://{{ include "octo.server.fullname" . }}:8090"
+            - name: LLM_API_URL
+              value: {{ .Values.llm.apiURL | default "https://api.example.com/v1" | quote }}
+            - name: LLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: LLM_API_KEY
+            - name: LLM_MODEL
+              value: {{ .Values.llm.model | default "claude-sonnet-4-6" | quote }}
+            - name: API_PORT
+              value: "8080"
+            - name: API_INTERNAL_PORT
+              value: "8081"
+            - name: WORKER_TRIGGER_URL
+              value: "http://{{ include "octo.summaryWorker.fullname" . }}:8082/internal/worker-trigger"
+            - name: WORKER_API_CALLBACK_URL
+              value: "http://{{ include "octo.summaryApi.fullname" . }}:8081/internal/task-event"
+            - name: NOTIFY_INTERNAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_NOTIFY_INTERNAL_TOKEN
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.summary.api.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "octo.summaryWorker.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: summary-worker
+spec:
+  replicas: {{ .Values.summary.worker.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: summary-worker
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: summary-worker
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      initContainers:
+        - name: wait-for-mysql
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command: ['sh', '-c', 'until nc -z {{ include "octo.mysql.host" . }} {{ include "octo.mysql.port" . }}; do echo waiting for mysql; sleep 2; done']
+      containers:
+        - name: summary-worker
+          image: {{ include "octo.image" (dict "repo" .Values.summary.worker.image.repository "tag" .Values.summary.worker.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.summary.worker.image.pullPolicy }}
+          ports:
+            - name: internal
+              containerPort: 8082
+          env:
+            - name: OCTO_SUMMARY_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_SUMMARY_DB_PASSWORD
+            - name: OCTO_SUMMARY_READER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_SUMMARY_READER_PASSWORD
+            - name: MYSQL_DSN
+              value: "summary:$(OCTO_SUMMARY_DB_PASSWORD)@tcp({{ include "octo.mysql.host" . }}:{{ include "octo.mysql.port" . }})/octo_summary?charset=utf8mb4&parseTime=true"
+            - name: IM_MYSQL_DSN
+              value: "summary_reader:$(OCTO_SUMMARY_READER_PASSWORD)@tcp({{ include "octo.mysql.host" . }}:{{ include "octo.mysql.port" . }})/{{ include "octo.mysql.database" . }}?charset=utf8mb4&parseTime=true"
+            - name: OCTO_API_URL
+              value: "http://{{ include "octo.server.fullname" . }}:8090"
+            - name: DMWORK_API_URL
+              value: "http://{{ include "octo.server.fullname" . }}:8090"
+            - name: LLM_API_URL
+              value: {{ .Values.llm.apiURL | default "https://api.example.com/v1" | quote }}
+            - name: LLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: LLM_API_KEY
+            - name: LLM_MODEL
+              value: {{ .Values.llm.model | default "claude-sonnet-4-6" | quote }}
+            - name: WORKER_INTERNAL_PORT
+              value: "8082"
+            - name: WORKER_TRIGGER_URL
+              value: "http://{{ include "octo.summaryWorker.fullname" . }}:8082/internal/worker-trigger"
+            - name: WORKER_API_CALLBACK_URL
+              value: "http://{{ include "octo.summaryApi.fullname" . }}:8081/internal/task-event"
+            - name: NOTIFY_INTERNAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_NOTIFY_INTERNAL_TOKEN
+          readinessProbe:
+            tcpSocket:
+              port: internal
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: internal
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.summary.worker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/helm/octo/templates/deployment-summary.yaml
+++ b/helm/octo/templates/deployment-summary.yaml
@@ -34,6 +34,8 @@ spec:
       app.kubernetes.io/component: summary-api
   template:
     metadata:
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "octo.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: summary-api

--- a/helm/octo/templates/deployment-summary.yaml
+++ b/helm/octo/templates/deployment-summary.yaml
@@ -114,6 +114,23 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octo.summaryWorker.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: summary-worker
+spec:
+  type: ClusterIP
+  ports:
+    - name: internal
+      port: 8082
+      targetPort: internal
+  selector:
+    {{- include "octo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: summary-worker
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/octo/templates/ingress.yaml
+++ b/helm/octo/templates/ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled }}
+{{- $host := .Values.ingress.host | default .Values.domain }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "octo.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ $host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName | quote }}
+  {{- end }}
+  rules:
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "octo.nginx.fullname" . }}
+                port:
+                  number: {{ .Values.nginx.service.port | default 80 }}
+{{- end }}

--- a/helm/octo/templates/job-minio-init.yaml
+++ b/helm/octo/templates/job-minio-init.yaml
@@ -1,0 +1,115 @@
+{{- if .Values.minio.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "octo.fullname" . }}-minio-init
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio-init
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: minio-init
+    spec:
+      restartPolicy: OnFailure
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      initContainers:
+        - name: wait-for-minio
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command:
+            - sh
+            - -c
+            - |
+              until wget -q -O- http://{{ include "octo.minio.fullname" . }}:{{ .Values.minio.service.apiPort | default 9000 }}/minio/health/live >/dev/null 2>&1; do
+                echo "[minio-init] waiting for MinIO..."
+                sleep 3
+              done
+              echo "[minio-init] MinIO is ready"
+      containers:
+        - name: minio-init
+          image: {{ include "octo.image" (dict "repo" .Values.minio.mcImage.repository "tag" .Values.minio.mcImage.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.minio.mcImage.pullPolicy }}
+          env:
+            - name: MINIO_ROOT_USER
+              value: {{ .Values.minio.auth.rootUser | default "octoadmin" | quote }}
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: MINIO_ROOT_PASSWORD
+            - name: OCTO_MINIO_APP_USER
+              value: {{ .Values.minio.auth.appUser | default "octo-app" | quote }}
+            - name: OCTO_MINIO_APP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_MINIO_APP_PASSWORD
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              MINIO_ENDPOINT="http://{{ include "octo.minio.fullname" . }}:{{ .Values.minio.service.apiPort | default 9000 }}"
+
+              root_lc=$(printf %s "${MINIO_ROOT_PASSWORD:-}" | tr 'A-Z' 'a-z')
+              case "$root_lc" in
+                ""|change_me_*|chg_me*)
+                  echo "[minio-init] FATAL: MINIO_ROOT_PASSWORD is empty or a placeholder." >&2; exit 1 ;;
+              esac
+              app_lc=$(printf %s "${OCTO_MINIO_APP_PASSWORD:-}" | tr 'A-Z' 'a-z')
+              case "$app_lc" in
+                ""|change_me_*|chg_me*)
+                  echo "[minio-init] FATAL: OCTO_MINIO_APP_PASSWORD is empty or a placeholder." >&2; exit 1 ;;
+              esac
+
+              echo "[minio-init] setting alias..."
+              until mc alias set local "$MINIO_ENDPOINT" "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null 2>&1; do
+                sleep 2
+              done
+
+              echo "[minio-init] provisioning app user..."
+              mc admin user add local "$OCTO_MINIO_APP_USER" "$OCTO_MINIO_APP_PASSWORD" >/dev/null
+
+              echo "[minio-init] (re)installing octo-app policy..."
+              mc admin policy create local octo-app /etc/minio/octo-app-policy.json 2>/dev/null \
+                || mc admin policy update local octo-app /etc/minio/octo-app-policy.json
+
+              echo "[minio-init] attaching policy to $OCTO_MINIO_APP_USER..."
+              mc admin policy attach local octo-app --user "$OCTO_MINIO_APP_USER" 2>/dev/null || true
+
+              for b in file chat moment sticker report chatbg common download group avatar; do
+                mc mb --ignore-existing "local/$b" >/dev/null
+              done
+
+              echo "[minio-init] setting anonymous download on content buckets..."
+              for b in chat file moment sticker chatbg common avatar; do
+                attempt=1
+                until mc anonymous set download "local/$b" >/dev/null 2>&1; do
+                  if [ "$attempt" -ge 3 ]; then
+                    echo "[minio-init] FATAL: mc anonymous set download local/$b failed after 3 attempts" >&2; exit 1
+                  fi
+                  attempt=$((attempt + 1)); sleep 2
+                done
+                json=$(mc anonymous get --json "local/$b" 2>/dev/null)
+                case "$json" in
+                  *'"permission":"download"'*) ;;
+                  *) echo "[minio-init] FATAL: anonymous policy on local/$b verify failed: $json" >&2; exit 1 ;;
+                esac
+              done
+
+              echo "[minio-init] done"
+          volumeMounts:
+            - name: policy
+              mountPath: /etc/minio/octo-app-policy.json
+              subPath: minio-octo-app-policy.json
+      volumes:
+        - name: policy
+          configMap:
+            name: {{ include "octo.fullname" . }}-misc
+{{- end }}

--- a/helm/octo/templates/secret.yaml
+++ b/helm/octo/templates/secret.yaml
@@ -1,0 +1,24 @@
+{{/*
+Central secret for all OCTO credentials.
+Helm `required` prevents installation when critical values are empty.
+*/}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "octo.secretName" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  MYSQL_ROOT_PASSWORD:          {{ required "secrets.mysqlRootPassword must be set" .Values.secrets.mysqlRootPassword | quote }}
+  MINIO_ROOT_PASSWORD:          {{ required "secrets.minioRootPassword must be set (min 8 chars)" .Values.secrets.minioRootPassword | quote }}
+  OCTO_MINIO_APP_PASSWORD:      {{ required "secrets.minioAppPassword must be set" .Values.secrets.minioAppPassword | quote }}
+  OCTO_MATTER_DB_PASSWORD:      {{ required "secrets.matterDbPassword must be set" .Values.secrets.matterDbPassword | quote }}
+  OCTO_SUMMARY_DB_PASSWORD:     {{ required "secrets.summaryDbPassword must be set" .Values.secrets.summaryDbPassword | quote }}
+  OCTO_SUMMARY_READER_PASSWORD: {{ required "secrets.summaryReaderPassword must be set" .Values.secrets.summaryReaderPassword | quote }}
+  OCTO_MASTER_KEY:              {{ required "secrets.octoMasterKey must be set (32 bytes)" .Values.secrets.octoMasterKey | quote }}
+  OCTO_NOTIFY_INTERNAL_TOKEN:   {{ required "secrets.notifyInternalToken must be set" .Values.secrets.notifyInternalToken | quote }}
+  OCTO_WUKONGIM_MANAGER_TOKEN:  {{ required "secrets.wukongimManagerToken must be set" .Values.secrets.wukongimManagerToken | quote }}
+  OCTO_ADMIN_PWD:               {{ .Values.secrets.adminPwd | default "" | quote }}
+  LLM_API_KEY:                  {{ .Values.secrets.llmApiKey | default "" | quote }}
+  OCTO_WEBHOOK_SECRET_KEY:      {{ .Values.secrets.webhookSecretKey | default "" | quote }}

--- a/helm/octo/templates/statefulset-minio.yaml
+++ b/helm/octo/templates/statefulset-minio.yaml
@@ -61,7 +61,7 @@ spec:
             - name: MINIO_SERVER_URL
               value: {{ include "octo.minio.serverURL" . | quote }}
             - name: MINIO_BROWSER_REDIRECT_URL
-              value: ""
+              value: ""  # intentionally empty: let MinIO use request Host header
           readinessProbe:
             httpGet:
               path: /minio/health/live

--- a/helm/octo/templates/statefulset-minio.yaml
+++ b/helm/octo/templates/statefulset-minio.yaml
@@ -1,0 +1,99 @@
+{{- if .Values.minio.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octo.minio.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  type: ClusterIP
+  ports:
+    - name: api
+      port: {{ .Values.minio.service.apiPort | default 9000 }}
+      targetPort: api
+    - name: console
+      port: {{ .Values.minio.service.consolePort | default 9001 }}
+      targetPort: console
+  selector:
+    {{- include "octo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "octo.minio.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  serviceName: {{ include "octo.minio.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: minio
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: minio
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: minio
+          image: {{ include "octo.image" (dict "repo" .Values.minio.image.repository "tag" .Values.minio.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.minio.image.pullPolicy }}
+          args: ["server", "/data", "--console-address", ":{{ .Values.minio.service.consolePort | default 9001 }}"]
+          ports:
+            - name: api
+              containerPort: {{ .Values.minio.service.apiPort | default 9000 }}
+            - name: console
+              containerPort: {{ .Values.minio.service.consolePort | default 9001 }}
+          env:
+            - name: MINIO_ROOT_USER
+              value: {{ .Values.minio.auth.rootUser | default "octoadmin" | quote }}
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: MINIO_ROOT_PASSWORD
+            - name: MINIO_SERVER_URL
+              value: {{ include "octo.minio.serverURL" . | quote }}
+            - name: MINIO_BROWSER_REDIRECT_URL
+              value: ""
+          readinessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: api
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: api
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          {{- with .Values.minio.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.minio.storage.storageClass }}
+        storageClassName: {{ .Values.minio.storage.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.minio.storage.size | default "50Gi" }}
+{{- end }}

--- a/helm/octo/templates/statefulset-mysql.yaml
+++ b/helm/octo/templates/statefulset-mysql.yaml
@@ -1,0 +1,122 @@
+{{- if .Values.mysql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octo.mysql.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mysql
+spec:
+  type: ClusterIP
+  ports:
+    - name: mysql
+      port: {{ .Values.mysql.service.port | default 3306 }}
+      targetPort: mysql
+  selector:
+    {{- include "octo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: mysql
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "octo.mysql.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mysql
+spec:
+  serviceName: {{ include "octo.mysql.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: mysql
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: mysql
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: mysql
+          image: {{ include "octo.image" (dict "repo" .Values.mysql.image.repository "tag" .Values.mysql.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.mysql.image.pullPolicy }}
+          args:
+            - --default-authentication-plugin=mysql_native_password
+            - --character-set-server=utf8mb4
+            - --collation-server=utf8mb4_general_ci
+          ports:
+            - name: mysql
+              containerPort: 3306
+          env:
+            - name: TZ
+              value: {{ .Values.timezone | default "UTC" | quote }}
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: MYSQL_ROOT_PASSWORD
+            - name: MYSQL_DATABASE
+              value: {{ .Values.mysql.auth.database | default "octo" | quote }}
+            - name: OCTO_MATTER_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_MATTER_DB_PASSWORD
+            - name: OCTO_SUMMARY_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_SUMMARY_DB_PASSWORD
+            - name: OCTO_SUMMARY_READER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_SUMMARY_READER_PASSWORD
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - "MYSQL_PWD=\"$MYSQL_ROOT_PASSWORD\" mysqladmin ping -h localhost -u root --silent"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - "MYSQL_PWD=\"$MYSQL_ROOT_PASSWORD\" mysqladmin ping -h localhost -u root --silent"
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/mysql
+            - name: init-scripts
+              mountPath: /docker-entrypoint-initdb.d/01-extra-dbs.sh
+              subPath: init-extra-dbs.sh
+          {{- with .Values.mysql.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: init-scripts
+          configMap:
+            name: {{ include "octo.fullname" . }}-misc
+            defaultMode: 0755
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.mysql.storage.storageClass }}
+        storageClassName: {{ .Values.mysql.storage.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.mysql.storage.size | default "20Gi" }}
+{{- end }}

--- a/helm/octo/templates/statefulset-redis.yaml
+++ b/helm/octo/templates/statefulset-redis.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.redis.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octo.redis.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis
+      port: {{ .Values.redis.service.port | default 6379 }}
+      targetPort: redis
+  selector:
+    {{- include "octo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "octo.redis.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  serviceName: {{ include "octo.redis.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: redis
+          image: {{ include "octo.image" (dict "repo" .Values.redis.image.repository "tag" .Values.redis.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          command: ["redis-server", "--save", "60", "1", "--loglevel", "warning"]
+          ports:
+            - name: redis
+              containerPort: 6379
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 20
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          {{- with .Values.redis.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.redis.storage.storageClass }}
+        storageClassName: {{ .Values.redis.storage.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.storage.size | default "5Gi" }}
+{{- end }}

--- a/helm/octo/templates/statefulset-redis.yaml
+++ b/helm/octo/templates/statefulset-redis.yaml
@@ -76,5 +76,5 @@ spec:
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.redis.storage.size | default "5Gi" }}
+            storage: {{ .Values.redis.storage.size | default "10Gi" }}
 {{- end }}

--- a/helm/octo/templates/statefulset-wukongim.yaml
+++ b/helm/octo/templates/statefulset-wukongim.yaml
@@ -1,0 +1,129 @@
+{{- if .Values.wukongim.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octo.wukongim.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: wukongim
+spec:
+  type: ClusterIP
+  ports:
+    - name: api
+      port: {{ .Values.wukongim.service.apiPort | default 5001 }}
+      targetPort: api
+    - name: tcp
+      port: {{ .Values.wukongim.service.tcpPort | default 5100 }}
+      targetPort: tcp
+    - name: ws
+      port: {{ .Values.wukongim.service.wsPort | default 5200 }}
+      targetPort: ws
+    - name: monitor
+      port: {{ .Values.wukongim.service.monitorPort | default 5300 }}
+      targetPort: monitor
+  selector:
+    {{- include "octo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: wukongim
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "octo.wukongim.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: wukongim
+spec:
+  serviceName: {{ include "octo.wukongim.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: wukongim
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: wukongim
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: wukongim
+          image: {{ include "octo.image" (dict "repo" .Values.wukongim.image.repository "tag" .Values.wukongim.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.wukongim.image.pullPolicy }}
+          ports:
+            - name: api
+              containerPort: {{ .Values.wukongim.service.apiPort | default 5001 }}
+            - name: tcp
+              containerPort: {{ .Values.wukongim.service.tcpPort | default 5100 }}
+            - name: ws
+              containerPort: {{ .Values.wukongim.service.wsPort | default 5200 }}
+            - name: monitor
+              containerPort: {{ .Values.wukongim.service.monitorPort | default 5300 }}
+          env:
+            - name: WK_MODE
+              value: {{ .Values.wukongim.mode | default "release" | quote }}
+            - name: WK_EXTERNAL_IP
+              value: {{ .Values.wukongim.externalIP | default "" | quote }}
+            - name: WK_EXTERNAL_TCPADDR
+              value: {{ .Values.wukongim.tcpAddr | default "" | quote }}
+            - name: WK_EXTERNAL_WSADDR
+              value: {{ include "octo.wukongim.wsAddr" . | quote }}
+            - name: WK_EXTERNAL_WSSADDR
+              value: {{ .Values.wukongim.wssAddr | default "" | quote }}
+            - name: WK_MANAGERTOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_WUKONGIM_MANAGER_TOKEN
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - |
+                  wget -q -O - --header="token: $WK_MANAGERTOKEN" \
+                    http://localhost:{{ .Values.wukongim.service.apiPort | default 5001 }}/health \
+                    >/dev/null 2>&1
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - |
+                  wget -q -O - --header="token: $WK_MANAGERTOKEN" \
+                    http://localhost:{{ .Values.wukongim.service.apiPort | default 5001 }}/health \
+                    >/dev/null 2>&1
+            initialDelaySeconds: 40
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: data
+              mountPath: /root/wukongim
+            - name: config
+              mountPath: /root/wukongim/wk.yaml
+              subPath: wk.yaml
+          {{- with .Values.wukongim.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "octo.fullname" . }}-wukongim-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.wukongim.storage.storageClass }}
+        storageClassName: {{ .Values.wukongim.storage.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.wukongim.storage.size | default "10Gi" }}
+{{- end }}

--- a/helm/octo/templates/statefulset-wukongim.yaml
+++ b/helm/octo/templates/statefulset-wukongim.yaml
@@ -41,6 +41,9 @@ spec:
       app.kubernetes.io/component: wukongim
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-wukongim.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "octo.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: wukongim

--- a/helm/octo/values.yaml
+++ b/helm/octo/values.yaml
@@ -85,10 +85,10 @@ secrets:
   # Generate: openssl rand -hex 32
   wukongimManagerToken: ""
 
-  # Initial superAdmin password (optional — leave empty to skip auto-bootstrap).
-  # When non-empty AND no superAdmin row exists, octo-server creates a
-  # superAdmin account on startup with password = bcrypt(adminPwd). Idempotent.
-  adminPwd: "superAdmin"
+  # Initial superAdmin password. Must be set explicitly — leave empty to skip
+  # auto-bootstrap. When non-empty AND no superAdmin row exists, octo-server
+  # creates a superAdmin account on startup with password = bcrypt(adminPwd).
+  adminPwd: ""
 
   # Redis AUTH password. Leave empty if Redis runs without authentication
   # (the bundled Redis StatefulSet has no auth by default).
@@ -195,7 +195,9 @@ wukongim:
   resources: {}
 
 # =============================================================================
-# External services (used when the bundled service is disabled)
+# External services — NOT YET SUPPORTED in this chart version.
+# Disabling bundled MySQL/Redis/MinIO/WuKongIM and pointing at external
+# instances is planned for a future release. Keep all *.enabled=true.
 # =============================================================================
 externalMySQL:
   host: ""

--- a/helm/octo/values.yaml
+++ b/helm/octo/values.yaml
@@ -1,0 +1,389 @@
+# =============================================================================
+# OCTO Helm Chart — values.yaml
+# =============================================================================
+# REQUIRED: Before installing, set every value under `secrets:` that has an
+# empty or placeholder default. Generate strong values with:
+#   openssl rand -hex 16   (for 32-byte keys)
+#   openssl rand -hex 32   (for 64-byte tokens)
+# =============================================================================
+
+nameOverride: ""
+fullnameOverride: ""
+
+# =============================================================================
+# Global image settings
+# =============================================================================
+global:
+  # Private registry prefix applied to ALL images (app + infrastructure).
+  # Example: hub.intra.mlamp.cn/octo
+  # When set, every image becomes: <imageRegistry>/<repository>:<tag>
+  # Leave empty to pull from the original registry (Docker Hub, etc.).
+  imageRegistry: ""
+
+  # List of existing Kubernetes Secrets with registry credentials.
+  # Applied to every pod in the chart.
+  # Create with: kubectl create secret docker-registry regcred \
+  #   --docker-server=<registry> --docker-username=<user> \
+  #   --docker-password=<password> -n <namespace>
+  imagePullSecrets: []
+  # - name: regcred
+
+# Busybox image used by all init containers (wait-for-* probes).
+busybox:
+  image:
+    repository: busybox
+    tag: "1.36"
+    pullPolicy: IfNotPresent
+
+# Public domain / hostname the stack is accessible at.
+domain: "octo.local"
+
+# Override the full external base URL (scheme + host + port).
+# Defaults to http://{{ domain }}:{{ nginx.service.port }}
+externalBaseURL: ""
+
+# Kubernetes CoreDNS / kube-dns ClusterIP.
+# Only needed if you use nginx variable-form proxy_pass (not the default).
+# Common values: kubeadm/kind/minikube=10.96.0.10, k3s=10.43.0.10
+dns:
+  clusterIP: "10.96.0.10"
+
+# Global timezone
+timezone: "UTC"
+
+# =============================================================================
+# Secrets — MUST be rotated before deploying
+# =============================================================================
+secrets:
+  # MySQL root password. Characters must be in [A-Za-z0-9._-].
+  # Generate: openssl rand -hex 16
+  mysqlRootPassword: ""
+
+  # MinIO root password (≥8 chars).
+  # Generate: openssl rand -hex 16
+  minioRootPassword: ""
+
+  # MinIO application-scoped IAM password.
+  # Generate: openssl rand -hex 24
+  minioAppPassword: ""
+
+  # MySQL service-account passwords. Characters must be in [A-Za-z0-9._-].
+  # Cannot be the literal strings "matter", "summary", "summary_reader".
+  matterDbPassword: ""
+  summaryDbPassword: ""
+  summaryReaderPassword: ""
+
+  # OCTO master key — exactly 32 bytes.
+  # Generate: openssl rand -hex 16
+  octoMasterKey: ""
+
+  # Inter-service HMAC token (octo-server ↔ matter / summary-api).
+  # Generate: openssl rand -hex 32
+  notifyInternalToken: ""
+
+  # WuKongIM admin manager token.
+  # Generate: openssl rand -hex 32
+  wukongimManagerToken: ""
+
+  # Initial superAdmin password (optional — leave empty to skip auto-bootstrap).
+  # When non-empty AND no superAdmin row exists, octo-server creates a
+  # superAdmin account on startup with password = bcrypt(adminPwd). Idempotent.
+  adminPwd: "superAdmin"
+
+  # Redis AUTH password. Leave empty if Redis runs without authentication
+  # (the bundled Redis StatefulSet has no auth by default).
+  redisPassword: ""
+
+  # LLM API key for octo-matter + smart-summary (optional for smoke tests).
+  llmApiKey: ""
+
+  # Inbound webhook HMAC secret (optional).
+  webhookSecretKey: ""
+
+# =============================================================================
+# LLM configuration (shared by matter + smart-summary)
+# =============================================================================
+llm:
+  apiURL: "https://api.example.com/v1"
+  model: "claude-sonnet-4-6"
+
+# =============================================================================
+# MySQL
+# =============================================================================
+mysql:
+  enabled: true
+  image:
+    repository: mysql
+    tag: "8.0"
+    pullPolicy: IfNotPresent
+  auth:
+    database: "octo"
+  service:
+    port: 3306
+  storage:
+    size: 20Gi
+    storageClass: ""
+  resources: {}
+
+# =============================================================================
+# Redis
+# =============================================================================
+redis:
+  enabled: true
+  image:
+    repository: redis
+    tag: "7-alpine"
+    pullPolicy: IfNotPresent
+  service:
+    port: 6379
+  storage:
+    size: 10Gi
+    storageClass: ""
+  resources: {}
+
+# =============================================================================
+# MinIO
+# =============================================================================
+minio:
+  enabled: true
+  image:
+    repository: minio/minio
+    tag: "RELEASE.2025-04-22T22-12-26Z"
+    pullPolicy: IfNotPresent
+  mcImage:
+    repository: minio/mc
+    tag: "RELEASE.2025-04-16T18-13-26Z"
+    pullPolicy: IfNotPresent
+  auth:
+    rootUser: "octoadmin"
+    appUser: "octo-app"
+  # Override the public S3 endpoint URL (scheme+host+port, no path).
+  # Defaults to externalBaseURL (or http://domain:nginx.port).
+  serverURL: ""
+  service:
+    apiPort: 9000
+    consolePort: 9001
+  storage:
+    size: 50Gi
+    storageClass: ""
+  resources: {}
+
+# =============================================================================
+# WuKongIM
+# =============================================================================
+wukongim:
+  enabled: true
+  image:
+    repository: wukongim/wukongim
+    tag: "v2.2.5-20260422"
+    pullPolicy: IfNotPresent
+  mode: "release"
+  # externalIP is advertised to clients in /route responses.
+  externalIP: ""
+  # Leave wsAddr empty to auto-derive: ws://domain:nginx.port/ws
+  wsAddr: ""
+  wssAddr: ""
+  tcpAddr: ""
+  service:
+    apiPort: 5001
+    tcpPort: 5100
+    wsPort: 5200
+    monitorPort: 5300
+  storage:
+    size: 10Gi
+    storageClass: ""
+  resources: {}
+
+# =============================================================================
+# External services (used when the bundled service is disabled)
+# =============================================================================
+externalMySQL:
+  host: ""
+  port: 3306
+  database: "octo"
+
+externalRedis:
+  # Format: host:port
+  addr: ""
+
+externalMinio:
+  # Format: host:port
+  endpoint: ""
+  rootUser: ""
+  appUser: "octo-app"
+
+externalWukongim:
+  apiURL: ""
+
+# =============================================================================
+# octo-server
+# =============================================================================
+server:
+  image:
+    repository: mininglamposs/octo-server
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+  # ---------------------------------------------------------------------------
+  # Runtime configuration — maps 1:1 to octo-server.yaml (tsdd.yaml).
+  # Values intentionally left empty here are overridden at runtime via
+  # TS_* env vars in the Deployment (credentials, addresses). Only set these
+  # when you need to diverge from the defaults.
+  # ---------------------------------------------------------------------------
+  config:
+    # Runtime mode: debug | release
+    mode: "release"
+
+    # Optional external web-login redirect URL (e.g. for SSO / custom login page).
+    # Corresponds to external.webLoginURL in tsdd.yaml.
+    webLoginURL: ""
+
+    # Test-only SMS verification code bypass. Ignored in release mode.
+    smsCode: ""
+
+    # File storage backend. Only "minio" is currently supported.
+    fileService: "minio"
+
+    logger:
+      # Log verbosity: 0=off  1=error  2=warn  3=info  4=debug
+      level: 2
+      # Log output directory inside the container.
+      dir: "./logs"
+      # Include source file:line in every log line (noisy — off by default).
+      lineNum: false
+
+    register:
+      # Disable user self-registration. Set to false to allow open sign-up.
+      # Note: avoid key name "off" — it is a YAML 1.1 boolean synonym and
+      # will be mis-parsed by Go's yaml.v3.
+      disabled: true
+      # Restrict registration to China mobile numbers only.
+      onlyChina: false
+      # Enable email-based registration (requires support.emailSmtp below).
+      emailOn: false
+
+    # Support / outbound email settings.
+    # Required when register.emailOn: true or for password-reset emails.
+    support:
+      # Sender address (From:) for all outbound emails.
+      email: ""
+      # SMTP server in host:port form.
+      # Port 465 = implicit TLS (SMTPS), 587 = STARTTLS.
+      # Example: "smtp.gmail.com:465"
+      emailSmtp: ""
+      # SMTP login password.
+      emailPwd: ""
+
+# =============================================================================
+# octo-web (SPA frontend)
+# =============================================================================
+web:
+  image:
+    repository: mininglamposs/octo-web
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources: {}
+
+# =============================================================================
+# octo-admin (admin console)
+# =============================================================================
+admin:
+  image:
+    repository: mininglamposs/octo-admin
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources: {}
+
+# =============================================================================
+# octo-matter (tasks/AI assistant)
+# =============================================================================
+matter:
+  image:
+    repository: mininglamposs/octo-matter
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  appEnv: "prod"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+
+# =============================================================================
+# Smart Summary (summary-api + summary-worker)
+# =============================================================================
+summary:
+  enabled: true
+  api:
+    image:
+      repository: mininglamposs/octo-smart-summary-api
+      tag: "latest"
+      pullPolicy: IfNotPresent
+    replicas: 1
+    resources: {}
+  worker:
+    image:
+      repository: mininglamposs/octo-smart-summary-worker
+      tag: "latest"
+      pullPolicy: IfNotPresent
+    replicas: 1
+    resources: {}
+
+# =============================================================================
+# Nginx reverse proxy
+# =============================================================================
+nginx:
+  image:
+    repository: nginx
+    tag: "1.27-alpine"
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 80
+    # nodePort: 30080   # uncomment for NodePort type
+    annotations: {}
+  resources: {}
+
+# =============================================================================
+# Ingress (optional — routes external traffic into the embedded nginx)
+# =============================================================================
+# All complex routing (/api/, /ws, /minio/, URL rewrites, rate-limiting) is
+# handled by the embedded nginx. The Ingress only needs a single catch-all
+# rule pointing at the octo-nginx Service.
+ingress:
+  enabled: false
+
+  # IngressClass name. Common values:
+  #   nginx   — community nginx-ingress-controller
+  #   qcloud  — TKE / Tencent Cloud CLB ingress
+  #   traefik — Traefik ingress controller
+  className: ""
+
+  # Extra annotations forwarded to the Ingress resource.
+  # Defaults below are suitable for nginx-ingress-controller; adjust for
+  # other controllers.
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "1000m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+
+  # Hostname the stack is exposed on. Defaults to .Values.domain.
+  host: ""
+
+  tls:
+    enabled: false
+    # Name of an existing K8s Secret that holds tls.crt + tls.key.
+    # Create with: kubectl create secret tls octo-tls --cert=tls.crt --key=tls.key
+    secretName: ""


### PR DESCRIPTION
## Summary

- Adds `helm/octo` — a production-ready Helm chart (v0.2.1) that deploys the complete OCTO platform on Kubernetes with a single `helm install` from `oci://ghcr.io/mininglamp-oss/octo`
- Packages all components: MySQL, Redis, MinIO, WuKongIM, Nginx, octo-server, octo-web, octo-admin, octo-matter, smart-summary-api/worker
- Supports private image registries via `global.imageRegistry` / `global.imagePullSecrets`
- Auto-derives `wss://` WebSocket address from `externalBaseURL` (no manual config needed)
- Post-install `minio-init` Job provisions buckets, IAM user and policies
- Bilingual README (EN + ZH) with full configuration reference

## Test plan

- [ ] `helm template` renders without errors
- [ ] All image refs correctly prefixed when `global.imageRegistry` is set
- [ ] `helm install` from OCI registry succeeds on a clean namespace
- [ ] All 11 pods reach `1/1 Running` within 3 minutes
- [ ] WebSocket connects over `wss://` when `externalBaseURL` uses HTTPS
- [ ] MinIO buckets and anonymous policies provisioned correctly by init Job

🤖 Generated with [Claude Code](https://claude.com/claude-code)