### PR TITLE
feat(ci): add stale and PR labeler workflows

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  label:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-labeler.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      repo_owner: ${{ github.repository_owner }}
+      repo_name: ${{ github.event.repository.name }}
+    permissions:
+      issues: write
+      pull-requests: write
+    secrets: inherit

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,15 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  # pull_request_target runs in the context of the base repo and retains write
+  # access even for fork PRs — required because the reusable labeler calls the
+  # GitHub REST API to set labels and post comments (both need write tokens).
+  #
+  # Security: this workflow does NOT check out or execute any code from the PR
+  # branch; it only passes the PR number / owner / repo name to a reusable
+  # workflow that performs only API calls against the base repo. This matches
+  # the pattern used by auto-add-to-project.yml and octo-pr-feed.yml.
+  pull_request_target: # zizmor: ignore[dangerous-triggers] metadata-only automation; no PR code executed
     types: [opened, synchronize, reopened]
 
 permissions: {}
@@ -16,4 +24,6 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    secrets: inherit
+    # secrets: intentionally omitted — reusable-pr-labeler.yml uses only the
+    # inherited GITHUB_TOKEN granted via the job-level permissions above.
+

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  stale:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-stale.yml@main
+    permissions:
+      issues: write
+      pull-requests: write


### PR DESCRIPTION
## Changes

- **stale.yml**: four-lane stale management via shared reusable workflow
- **labeler.yml**: auto size labels (XS/S/M/L/XL) + dependency-changed detection

(No ci.yml in this repo, so only the two new workflows are added.)

## Dependencies
Requires PR #25 in Mininglamp-OSS/.github to be merged first.

## Part of P0 automation rollout