### PR TITLE
ci(octo-deployment): add YAML lint and Kustomize manifest validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,113 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.yaml'
+      - '**/*.yml'
+      - 'kustomize/**'
+      - '.github/workflows/ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/*.yaml'
+      - '**/*.yml'
+      - 'kustomize/**'
+      - '.github/workflows/ci.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  yaml-lint:
+    name: yamllint
+    # Skip while PR is in Draft to avoid wasting minutes on work-in-progress.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install yamllint
+        run: |
+          set -euo pipefail
+          python3 -m pip install --user --no-cache-dir 'yamllint==1.35.1'
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run yamllint
+        run: |
+          set -euo pipefail
+          yamllint --version
+          # `relaxed` baseline; line-length disabled (K8s manifests routinely
+          # exceed 80 cols), `truthy` and `comments-indentation` downgraded so
+          # GitHub Actions syntax (`on:` etc.) does not fail the build.
+          yamllint -f github -d "{extends: relaxed, rules: {line-length: disable, document-start: disable, comments-indentation: disable, truthy: {level: warning, check-keys: false}}}" .
+
+  kustomize-validate:
+    name: kustomize build + kubeconform
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    env:
+      KUSTOMIZE_VERSION: '5.8.1'
+      KUBECONFORM_VERSION: '0.7.0'
+      # Pin the schema target so a runner-image bump cannot silently change
+      # what counts as valid. Update intentionally alongside cluster upgrades.
+      KUBERNETES_VERSION: '1.31.0'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install kustomize
+        run: |
+          set -euo pipefail
+          curl -fsSL -o kustomize.tar.gz \
+            "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+          tar -xzf kustomize.tar.gz
+          sudo install -m 0755 kustomize /usr/local/bin/kustomize
+          rm -f kustomize kustomize.tar.gz
+          kustomize version
+
+      - name: Install kubeconform
+        run: |
+          set -euo pipefail
+          curl -fsSL -o kubeconform.tar.gz \
+            "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz"
+          tar -xzf kubeconform.tar.gz
+          sudo install -m 0755 kubeconform /usr/local/bin/kubeconform
+          rm -f kubeconform kubeconform.tar.gz LICENSE
+          kubeconform -v
+
+      - name: Build and validate every overlay
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          overlays=(kustomize/overlays/*/)
+          if [ "${#overlays[@]}" -eq 0 ]; then
+            echo "::error::no overlays found under kustomize/overlays/"
+            exit 1
+          fi
+
+          status=0
+          for overlay in "${overlays[@]}"; do
+            overlay="${overlay%/}"
+            echo "::group::${overlay}"
+            if ! kustomize build "${overlay}" \
+              | kubeconform \
+                  -strict \
+                  -ignore-missing-schemas \
+                  -kubernetes-version "${KUBERNETES_VERSION}" \
+                  -schema-location default \
+                  -summary \
+                  -output text; then
+              echo "::error file=${overlay}/kustomization.yaml::kubeconform validation failed for ${overlay}"
+              status=1
+            fi
+            echo "::endgroup::"
+          done
+          exit "${status}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,21 +65,28 @@ jobs:
       - name: Install kustomize
         run: |
           set -euo pipefail
-          curl -fsSL -o kustomize.tar.gz \
+          # Extract into a scratch directory to avoid collision with the
+          # repo's own kustomize/ directory at the workspace root.
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+          curl -fsSL -o "$tmp/kustomize.tar.gz" \
             "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
-          tar -xzf kustomize.tar.gz
-          sudo install -m 0755 kustomize /usr/local/bin/kustomize
-          rm -f kustomize kustomize.tar.gz
+          tar -xzf "$tmp/kustomize.tar.gz" -C "$tmp"
+          sudo install -m 0755 "$tmp/kustomize" /usr/local/bin/kustomize
           kustomize version
 
       - name: Install kubeconform
         run: |
           set -euo pipefail
-          curl -fsSL -o kubeconform.tar.gz \
+          # Extract into a scratch directory to keep the workspace pristine
+          # (the kubeconform tarball ships a LICENSE file that would otherwise
+          # overwrite the repo's own LICENSE).
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+          curl -fsSL -o "$tmp/kubeconform.tar.gz" \
             "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz"
-          tar -xzf kubeconform.tar.gz
-          sudo install -m 0755 kubeconform /usr/local/bin/kubeconform
-          rm -f kubeconform kubeconform.tar.gz LICENSE
+          tar -xzf "$tmp/kubeconform.tar.gz" -C "$tmp"
+          sudo install -m 0755 "$tmp/kubeconform" /usr/local/bin/kubeconform
           kubeconform -v
 
       - name: Build and validate every overlay


### PR DESCRIPTION
## Summary

Adds a CI pipeline for `octo-deployment` — previously only community automation workflows existed, with no validation on YAML or Kubernetes manifests.

## What's added

### `yaml-lint` job
- Runs `yamllint` against all `.yaml`/`.yml` files in the repo
- Uses `relaxed` config to avoid noise on minor style issues

### `kustomize-validate` job
- Installs `kustomize` and `kubeconform`
- Builds each overlay (`kustomize/overlays/dev`, `kustomize/overlays/prod`) via `kustomize build`
- Pipes output through `kubeconform -strict -summary` to validate against the Kubernetes API schema

## Behavior
- Triggers on PR/push to `main` when `.yaml`/`.yml` files change
- Draft PRs are skipped
- Actions pinned to commit SHA (supply-chain hardening)
- Least-privilege permissions (`contents: read`)
- Concurrent runs cancelled on new push

Closes no issue — infrastructure improvement.