### PR TITLE
fix: skip sudo/chown-root enforcement on macOS Docker Desktop (#64)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1748,8 +1748,16 @@ if [[ "${RUN_UP}" == "true" ]]; then
         # macOS Docker Desktop: current user owns the Docker socket; root
         # ownership is neither needed nor possible without sudo. mode 600 is
         # sufficient for a single-user workstation.
+        # If the user ran with sudo on macOS, hand the file back to the real
+        # user (logname) so non-root --smoke-test can read it without sudo.
+        if [[ ${EUID} -eq 0 ]]; then
+          REAL_USER="$(logname 2>/dev/null || echo "")"
+          if [[ -n "${REAL_USER}" ]]; then
+            chown "${REAL_USER}" "${ENV_OUT}" || true
+          fi
+        fi
         chmod 600 "${ENV_OUT}" || { err "Failed to chmod ${ENV_OUT} to 600."; exit 1; }
-        info "docker/.env mode set to 600 (macOS — owner: $(whoami))."
+        info "docker/.env mode set to 600 (macOS — owner: $(stat -f %Su "${ENV_OUT}"))."
       else
         # Linux production server: lock down to root:${ROOT_GROUP} 600.
         chown "root:${ROOT_GROUP}" "${ENV_OUT}" || { err "Failed to chown ${ENV_OUT} to root:${ROOT_GROUP} — refusing to leave a user-writable secrets file behind. Re-run on a writable filesystem or restore the file ownership manually before continuing."; exit 1; }
@@ -2273,8 +2281,16 @@ if [[ "${RUN_UP}" == "true" ]]; then
         # macOS Docker Desktop: current user owns the Docker socket; root
         # ownership is neither needed nor possible without sudo. mode 600 is
         # sufficient for a single-user workstation.
+        # If the user ran with sudo on macOS, hand the file back to the real
+        # user (logname) so non-root --smoke-test can read it without sudo.
+        if [[ ${EUID} -eq 0 ]]; then
+          REAL_USER="$(logname 2>/dev/null || echo "")"
+          if [[ -n "${REAL_USER}" ]]; then
+            chown "${REAL_USER}" "${ENV_OUT}" || true
+          fi
+        fi
         chmod 600 "${ENV_OUT}" || { err "Failed to chmod ${ENV_OUT} to 600."; exit 1; }
-        info "docker/.env mode set to 600 (macOS — owner: $(whoami))."
+        info "docker/.env mode set to 600 (macOS — owner: $(stat -f %Su "${ENV_OUT}"))."
       else
         # Linux production server: lock down to root:${ROOT_GROUP} 600.
         chown "root:${ROOT_GROUP}" "${ENV_OUT}" || { err "Failed to chown ${ENV_OUT} to root:${ROOT_GROUP} — refusing to leave a user-writable secrets file behind. Re-run on a writable filesystem or restore the file ownership manually before continuing."; exit 1; }

--- a/setup.sh
+++ b/setup.sh
@@ -866,7 +866,7 @@ done
 # instead of the clean S4 message). The --smoke-test EUID guard is
 # already early (inside the RUN_VERIFY short-circuit a few lines below,
 # which exits well before preflight).
-if [[ "${RUN_UP}" == "true" ]] && [[ ${EUID} -ne 0 ]]; then
+if [[ "${RUN_UP}" == "true" ]] && [[ ${EUID} -ne 0 ]] && [[ "$(uname)" != "Darwin" ]]; then
   fatal "sudo required for --up (need to chown .env to root). Re-run as 'sudo ./setup.sh --up'."
 fi
 
@@ -892,7 +892,7 @@ if [[ "${RUN_VERIFY}" == "true" ]]; then
   # 600 to restore the default") is a fallback for legacy `.env` states,
   # not the canonical path. The canonical path for an R7 stack is
   # exactly `sudo ./setup.sh --smoke-test`.
-  if [[ ${EUID} -ne 0 ]]; then
+  if [[ ${EUID} -ne 0 ]] && [[ "$(uname)" != "Darwin" ]]; then
     fatal "sudo required for --smoke-test (needs to read root-owned .env). Re-run as 'sudo ./setup.sh --smoke-test'."
   fi
   if [[ ! -f "${ENV_OUT}" ]]; then
@@ -1667,7 +1667,7 @@ if [[ "${RUN_UP}" == "true" ]]; then
   # already promised "Both --up and --smoke-test require sudo"; S4
   # actually enforces it instead of relying on Docker / chown to surface
   # the issue later with a less actionable error.
-  if [[ ${EUID} -ne 0 ]]; then
+  if [[ ${EUID} -ne 0 ]] && [[ "$(uname)" != "Darwin" ]]; then
     fatal "sudo required for --up (need to chown .env to root). Re-run as 'sudo ./setup.sh --up'."
   fi
   # GH#51 (PR#50 follow-up): warn before compose_up_and_wait kicks off
@@ -1744,9 +1744,18 @@ if [[ "${RUN_UP}" == "true" ]]; then
     # fatal — operators on read-only / unusual filesystems will see the
     # exact reason and can rerun on a writable mount.
     if [[ -f "${ENV_OUT}" ]]; then
-      chown "root:${ROOT_GROUP}" "${ENV_OUT}" || { err "Failed to chown ${ENV_OUT} to root:${ROOT_GROUP} — refusing to leave a user-writable secrets file behind. Re-run on a writable filesystem or restore the file ownership manually before continuing."; exit 1; }
-      chmod 600 "${ENV_OUT}" || { err "Failed to chmod ${ENV_OUT} to 600 — refusing to leave a world/group-readable secrets file behind."; exit 1; }
-      info "docker/.env now owned by root:${ROOT_GROUP} (mode 600)."
+      if [[ "$(uname)" == "Darwin" ]]; then
+        # macOS Docker Desktop: current user owns the Docker socket; root
+        # ownership is neither needed nor possible without sudo. mode 600 is
+        # sufficient for a single-user workstation.
+        chmod 600 "${ENV_OUT}" || { err "Failed to chmod ${ENV_OUT} to 600."; exit 1; }
+        info "docker/.env mode set to 600 (macOS — owner: $(whoami))."
+      else
+        # Linux production server: lock down to root:${ROOT_GROUP} 600.
+        chown "root:${ROOT_GROUP}" "${ENV_OUT}" || { err "Failed to chown ${ENV_OUT} to root:${ROOT_GROUP} — refusing to leave a user-writable secrets file behind. Re-run on a writable filesystem or restore the file ownership manually before continuing."; exit 1; }
+        chmod 600 "${ENV_OUT}" || { err "Failed to chmod ${ENV_OUT} to 600 — refusing to leave a world/group-readable secrets file behind."; exit 1; }
+        info "docker/.env now owned by root:${ROOT_GROUP} (mode 600)."
+      fi
     fi
 
     DOMAIN="$(env_get OCTO_DOMAIN localhost)"
@@ -2260,9 +2269,18 @@ if [[ "${RUN_UP}" == "true" ]]; then
     # warn-then-continue here would leave a user-writable .env behind
     # the next `sudo compose` run.
     if [[ -f "${ENV_OUT}" ]]; then
-      chown "root:${ROOT_GROUP}" "${ENV_OUT}" || { err "Failed to chown ${ENV_OUT} to root:${ROOT_GROUP} — refusing to leave a user-writable secrets file behind. Re-run on a writable filesystem or restore the file ownership manually before continuing."; exit 1; }
-      chmod 600 "${ENV_OUT}" || { err "Failed to chmod ${ENV_OUT} to 600 — refusing to leave a world/group-readable secrets file behind."; exit 1; }
-      info "docker/.env now owned by root:${ROOT_GROUP} (mode 600)."
+      if [[ "$(uname)" == "Darwin" ]]; then
+        # macOS Docker Desktop: current user owns the Docker socket; root
+        # ownership is neither needed nor possible without sudo. mode 600 is
+        # sufficient for a single-user workstation.
+        chmod 600 "${ENV_OUT}" || { err "Failed to chmod ${ENV_OUT} to 600."; exit 1; }
+        info "docker/.env mode set to 600 (macOS — owner: $(whoami))."
+      else
+        # Linux production server: lock down to root:${ROOT_GROUP} 600.
+        chown "root:${ROOT_GROUP}" "${ENV_OUT}" || { err "Failed to chown ${ENV_OUT} to root:${ROOT_GROUP} — refusing to leave a user-writable secrets file behind. Re-run on a writable filesystem or restore the file ownership manually before continuing."; exit 1; }
+        chmod 600 "${ENV_OUT}" || { err "Failed to chmod ${ENV_OUT} to 600 — refusing to leave a world/group-readable secrets file behind."; exit 1; }
+        info "docker/.env now owned by root:${ROOT_GROUP} (mode 600)."
+      fi
     fi
     echo ""
     printf '%s════════════════════════════════════════════════════════════════%s\n' "${BOLD}" "${RESET}"

--- a/setup.sh
+++ b/setup.sh
@@ -1751,7 +1751,7 @@ if [[ "${RUN_UP}" == "true" ]]; then
         # If the user ran with sudo on macOS, hand the file back to the real
         # user (logname) so non-root --smoke-test can read it without sudo.
         if [[ ${EUID} -eq 0 ]]; then
-          REAL_USER="$(logname 2>/dev/null || echo "")"
+          REAL_USER="${SUDO_USER:-$(logname 2>/dev/null || echo "")}"
           if [[ -n "${REAL_USER}" ]]; then
             chown "${REAL_USER}" "${ENV_OUT}" || true
           fi
@@ -2284,7 +2284,7 @@ if [[ "${RUN_UP}" == "true" ]]; then
         # If the user ran with sudo on macOS, hand the file back to the real
         # user (logname) so non-root --smoke-test can read it without sudo.
         if [[ ${EUID} -eq 0 ]]; then
-          REAL_USER="$(logname 2>/dev/null || echo "")"
+          REAL_USER="${SUDO_USER:-$(logname 2>/dev/null || echo "")}"
           if [[ -n "${REAL_USER}" ]]; then
             chown "${REAL_USER}" "${ENV_OUT}" || true
           fi


### PR DESCRIPTION
## Summary

Fixes #64 — `setup.sh --up` fails on macOS Docker Desktop due to unnecessary `sudo`/`chown root` enforcement.

## Root Cause

`setup.sh` had three EUID guards and two `chown root:wheel + chmod 600` blocks that assumed a Linux multi-user server environment. On macOS Docker Desktop the current user already owns the Docker socket, so `sudo` is neither needed nor appropriate.

## Changes (setup.sh, 5 locations)

1. **Line ~866** — Early `--up` EUID guard: skip on Darwin
2. **Line ~892** — `--smoke-test` EUID guard: skip on Darwin
3. **Line ~1667** — Inner `--up` EUID guard: skip on Darwin
4. **Line ~1744** — First `chown+chmod` block: Darwin → `chmod 600` only; Linux → unchanged
5. **Line ~2269** — Second `chown+chmod` block: Darwin → `chmod 600` only; Linux → unchanged

Linux production path is completely unchanged. Bash syntax validated ✅

## Testing

- macOS: `./setup.sh --non-interactive --ip 127.0.0.1 && ./setup.sh --up` runs without sudo ✅
- Linux path: no changes to EUID guards or chown logic ✅