### PR TITLE
fix: add 'dependencies' label to release-drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,7 +13,7 @@ categories:
   - title: "Bug Fixes"
     labels: [bug, fix]
   - title: "CI and Infrastructure"
-    labels: [ci, infra, dependencies-changed]
+    labels: [ci, infra, dependencies-changed, dependencies]
   - title: "Documentation"
     labels: [documentation, docs]
 exclude-labels: [skip-changelog]


### PR DESCRIPTION
Dependabot applies the `dependencies` label to its PRs. The current release-drafter config only lists `dependencies-changed` in the CI/Infrastructure category, so Dependabot PRs don't appear in auto-generated release notes.

## Change
```diff
-    labels: [ci, infra, dependencies-changed]
+    labels: [ci, infra, dependencies-changed, dependencies]
```