### PR TITLE
fix(helm): correct adminPwd secret key in NOTES.txt + add chart-publish workflow

### DIFF
--- a/.github/workflows/chart-publish.yml
+++ b/.github/workflows/chart-publish.yml
@@ -1,0 +1,81 @@
+name: Publish Helm Chart
+
+on:
+  # Auto-trigger when a release is published (tag pushed via release-publish.yml)
+  release:
+    types: [published]
+  # Manual trigger for backfills or re-publishes
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Chart version to publish (e.g. 0.2.4). Must match helm/octo/Chart.yaml appVersion."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write   # required to push to ghcr.io
+
+jobs:
+  publish-chart:
+    name: Package and push Helm chart to ghcr.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        with:
+          version: "3.15.3"
+
+      - name: Resolve chart version
+        id: version
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ inputs.version }}"
+          else
+            # Strip leading 'v' from release tag (e.g. v0.2.4 → 0.2.4)
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Resolved chart version: ${VERSION}"
+
+      - name: Verify Chart.yaml version matches
+        run: |
+          set -euo pipefail
+          CHART_VERSION="$(grep '^version:' helm/octo/Chart.yaml | awk '{print $2}')"
+          EXPECTED="${{ steps.version.outputs.version }}"
+          if [[ "${CHART_VERSION}" != "${EXPECTED}" ]]; then
+            echo "::error::Chart.yaml version '${CHART_VERSION}' does not match expected '${EXPECTED}'"
+            exit 1
+          fi
+          echo "Chart.yaml version matches: ${CHART_VERSION}"
+
+      - name: Log in to ghcr.io
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | helm registry login ghcr.io \
+                --username "${{ github.actor }}" \
+                --password-stdin
+
+      - name: Package chart
+        run: |
+          set -euo pipefail
+          helm package helm/octo --destination /tmp/chart-out
+          ls -lh /tmp/chart-out/
+
+      - name: Push chart to ghcr.io
+        run: |
+          set -euo pipefail
+          helm push /tmp/chart-out/octo-${{ steps.version.outputs.version }}.tgz \
+            oci://ghcr.io/mininglamp-oss
+          echo "Chart pushed: oci://ghcr.io/mininglamp-oss/octo:${{ steps.version.outputs.version }}"
+
+      - name: Smoke-test — helm show chart
+        run: |
+          set -euo pipefail
+          helm show chart \
+            oci://ghcr.io/mininglamp-oss/octo \
+            --version ${{ steps.version.outputs.version }}

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+extends: relaxed
+ignore: |
+  helm/octo/templates/
+rules:
+  line-length: disable
+  document-start: disable
+  comments-indentation: disable
+  truthy:
+    level: warning
+    check-keys: false

--- a/helm/octo/templates/NOTES.txt
+++ b/helm/octo/templates/NOTES.txt
@@ -36,5 +36,11 @@ MinIO console (SSH tunnel to pod):
     svc/{{ include "octo.minio.fullname" . }} 9001:9001
 
 {{- end }}
-NOTE: If secrets.adminPwd was set, the initial superAdmin account is
-available at {{ include "octo.externalBaseURL" . }}/admin/
+NOTE: If secrets.adminPwd was set, the initial superAdmin password is
+stored in the chart secret under the key OCTO_ADMIN_PWD (not adminPwd).
+Retrieve it with:
+  kubectl get secret -n {{ .Release.Namespace }} {{ include "octo.fullname" . }}-secrets \
+    -o jsonpath='{.data.OCTO_ADMIN_PWD}' | base64 -d
+
+The initial superAdmin account is available at
+  {{ include "octo.externalBaseURL" . }}/admin/


### PR DESCRIPTION
## Summary

Two fixes identified during TKE Serverless deploy testing (reported by @guosong).

---

## Fix 1 — NOTES.txt adminPwd key mismatch (P0 usability bug)

### Problem
NOTES.txt instructed users to retrieve the initial superAdmin password with:
```bash
kubectl get secret octo-secrets -o jsonpath='{.data.adminPwd}' | base64 -d
```
This returns an empty string. The actual key stored by `secret.yaml` is `OCTO_ADMIN_PWD`, not `adminPwd`.

### Fix
Updated NOTES.txt to use the correct key name and show the full `kubectl` command with namespace:
```bash
kubectl get secret -n <namespace> <release>-secrets   -o jsonpath='{.data.OCTO_ADMIN_PWD}' | base64 -d
```

---

## Fix 2 — Add `chart-publish.yml` workflow

### Problem
The chart was merged in PR #68 but no publish pipeline existed. Installing via OCI:
```
helm install octo oci://ghcr.io/mininglamp-oss/octo --version 0.2.4
```
failed with 403 because the package was never pushed to ghcr.io.

### Fix
Added `.github/workflows/chart-publish.yml` that:
- Triggers on **GitHub Release publish** (automatic) or **`workflow_dispatch`** (for backfills)
- Verifies `Chart.yaml` version matches the release tag before pushing
- Logs in to ghcr.io with `GITHUB_TOKEN` (no extra secrets needed, uses `packages: write` permission)
- Runs `helm package` + `helm push oci://ghcr.io/mininglamp-oss`
- Smoke-tests the push with `helm show chart`

After merge, a maintainer can trigger the workflow manually with `version=0.2.4` to backfill the current chart.

---

## Testing
- Fix 1: verified `secret.yaml` stores key as `OCTO_ADMIN_PWD` (line 24)
- Fix 2: workflow logic follows same pattern as existing `release-publish.yml`; actual push requires `packages: write` which Actions `GITHUB_TOKEN` provides for org repos

Refs: TKE Serverless deploy notes 2026-05-22