### PR TITLE
fix: add /space redirect to /admin/space in nginx configmap

### DIFF
--- a/helm/octo/templates/configmap-nginx.yaml
+++ b/helm/octo/templates/configmap-nginx.yaml
@@ -134,6 +134,11 @@ data:
         location = /admin {
             return 301 /admin/;
         }
+        # /space is the space-admin entry point in octo-admin (basename=/admin, route=/space).
+        # Redirect /space/* to /admin/space/* so React Router resolves correctly.
+        location ~* ^/space(/.*)?$ {
+            return 301 /admin/space$1;
+        }
         location /admin/ {
             proxy_pass         http://{{ include "octo.admin.fullname" . }}/admin/;
             proxy_http_version 1.1;

--- a/helm/octo/templates/configmap-nginx.yaml
+++ b/helm/octo/templates/configmap-nginx.yaml
@@ -136,8 +136,8 @@ data:
         }
         # /space is the space-admin entry point in octo-admin (basename=/admin, route=/space).
         # Redirect /space/* to /admin/space/* so React Router resolves correctly.
-        location ~* ^/space(/.*)?$ {
-            return 301 /admin/space$1;
+        location ~ ^/space(/.*)?$ {
+            return 301 /admin/space$1$is_args$args;
         }
         location /admin/ {
             proxy_pass         http://{{ include "octo.admin.fullname" . }}/admin/;


### PR DESCRIPTION
## Summary

Add a redirect rule in the nginx configmap template so that `/space` and `/space/*` correctly route to the octo-admin SPA's space management pages.

Closes #88

## Root Cause

`octo-web` navigates to `/space` when the user clicks 「空间管理」. This path is handled by `octo-admin`'s React Router with `basename=/admin` and `route=/space`, meaning the correct URL is `/admin/space`. Without the redirect, `/space` falls through to the `location /` handler and serves the octo-web SPA instead.

## Change

One location block added to `configmap-nginx.yaml`:

```nginx
location ~* ^/space(/.*)?$ {
    return 301 /admin/space$1;
}
```

## Test plan

- [ ] Click 「空间管理」 in octo-web → browser redirects to `/admin/space/...` and shows the space admin UI
- [ ] Direct navigation to `/space` redirects to `/admin/space`
- [ ] `/space/some-id/members` redirects to `/admin/space/some-id/members`

🤖 Generated with [Claude Code](https://claude.com/claude-code)