### PR TITLE
chore(ci): add edited trigger to check-sprint and auto-add workflows

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -12,7 +12,7 @@ on:
   # branch; it only forwards event metadata (issue/PR number) to the reusable
   # workflow, which performs only GitHub API calls to add items to the project.
   pull_request_target: # zizmor: ignore[dangerous-triggers] metadata-only automation; no PR code executed
-    types: [opened]
+    types: [opened, edited]
 
 permissions: {}
 

--- a/.github/workflows/check-sprint.yml
+++ b/.github/workflows/check-sprint.yml
@@ -33,7 +33,7 @@ name: Check Sprint
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
     branches: [main]
 
 permissions: {}


### PR DESCRIPTION
This PR adds the `edited` event to the `pull_request_target.types` trigger in both `check-sprint.yml` and `auto-add-to-project.yml`, enabling the Issue-first Sprint check flow to work correctly when a developer adds a `Closes #<issue>` reference to a PR description after opening.