### PR TITLE
fix: restrict review-feed to ready_for_review and review_requested

### DIFF
--- a/.github/workflows/octo-pr-review-feed.yml
+++ b/.github/workflows/octo-pr-review-feed.yml
@@ -2,7 +2,7 @@ name: Octo PR Review Feed
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review, review_requested, synchronize]
+    types: [ready_for_review, review_requested]
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

Restrict `octo-pr-review-feed.yml` event types to only the two that represent a true **'reviewer needs to act'** signal:

```yaml
types: [ready_for_review, review_requested]
```

## Removed Events

- **`opened`** — fired almost simultaneously with `review_requested` on new PRs, causing two near-identical messages in the project group within seconds (perceived duplicate)
- **`synchronize`** — fires on every commit push; an active PR can generate 10+ messages per day, flooding the reviewer channel with low-signal noise

## Kept Events

- **`ready_for_review`** ✅ — draft → reviewable transition; reviewer should now look
- **`review_requested`** ✅ — someone is explicitly requested to review