### PR TITLE
chore(ci): add octo-ci-status workflow

### DIFF
--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -1,0 +1,24 @@
+name: Octo CI Status
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  actions: read
+
+jobs:
+  notify:
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-ci-status.yml@main
+    with:
+      repo_name: ${{ github.event.workflow_run.repository.name }}
+      workflow_name: ${{ github.event.workflow_run.name }}
+      conclusion: ${{ github.event.workflow_run.conclusion }}
+      run_id: ${{ github.event.workflow_run.id }}
+      run_url: ${{ github.event.workflow_run.html_url }}
+      project_group_id: "288154967f614d7ca1faac21b5f2f8f0"
+      workflow_id: ${{ github.event.workflow_run.workflow_id }}
+    secrets:
+      OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `octo-ci-status.yml` to notify CI results to the octo-deployment Octo group (`288154967f614d7ca1faac21b5f2f8f0`). Triggers on `workflow_run: [CI]` completing on `main`.