### PR TITLE
feat(search): opt-in search profile (Kafka + OpenSearch + es-indexer) for octo-deployment

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -420,6 +420,39 @@ LLM_MODEL=claude-sonnet-4-6
 # Summary services are gated by Docker Compose profiles. To enable them,
 # uncomment COMPOSE_PROFILES below (setup.sh --summary does this for you).
 # COMPOSE_PROFILES=summary
+#
+# The message-search pipeline (Kafka + OpenSearch + es-indexer) is gated by
+# the "search" profile. Enable it with COMPOSE_PROFILES=search (combine
+# profiles with a comma, e.g. COMPOSE_PROFILES=summary,search). With no
+# profile set, NONE of the search services start and the lines below are
+# inert — every one has a default, so a default deployment never fails on a
+# missing search variable. See docker/README.md "Search profile".
+
+# --- Search pipeline (only used when COMPOSE_PROFILES includes "search") ---
+# Host ports for local validation; loopback-bound by default so they never
+# collide with or expose anything on a shared host. Override the *_BIND vars
+# only for cross-host operator access.
+OCTO_SEARCH_OPENSEARCH_PORT=29200
+OCTO_SEARCH_OPENSEARCH_BIND=127.0.0.1
+OCTO_SEARCH_KAFKA_PORT=29092
+OCTO_SEARCH_KAFKA_BIND=127.0.0.1
+# Advertised EXTERNAL host for Kafka clients reaching the loopback port
+# (local seed/producer tooling). Keep localhost for single-host validation.
+OCTO_SEARCH_KAFKA_ADVERTISED_HOST=localhost
+# OpenSearch JVM heap for the single-node search box (raise for larger loads).
+OCTO_SEARCH_OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
+# Local stack disables the OpenSearch security plugin so the indexer talks
+# plain http on octo-net. Set to false + wire ES_USERNAME/ES_PASSWORD for a
+# hardened deployment.
+OCTO_SEARCH_OPENSEARCH_DISABLE_SECURITY=true
+# es-indexer image. Built only on v* tags / manual dispatch in
+# octo-search-indexer; for LOCAL validation build a tag from a checkout of
+# that repo and point this at it (see docker/README.md "Search profile").
+# OCTO_SEARCH_INDEXER_IMAGE=mininglamposs/octo-search-indexer:latest
+# Kafka topics + index name (defaults match the octo-search-indexer contract).
+# OCTO_SEARCH_KAFKA_TOPIC=octo.message.v1
+# OCTO_SEARCH_KAFKA_DLQ_TOPIC=octo.message.v1.dlq
+# OCTO_SEARCH_ES_INDEX=octo-message
 
 # --- Image overrides -------------------------------------------------------
 # OCTO_SERVER_IMAGE=mininglamposs/octo-server:latest
@@ -431,3 +464,8 @@ LLM_MODEL=claude-sonnet-4-6
 # OCTO_WK_IMAGE=wukongim/wukongim:v2.2.4-20260313
 # OCTO_MINIO_IMAGE=minio/minio:RELEASE.2025-04-22T22-12-26Z
 # OCTO_MINIO_MC_IMAGE=minio/mc:RELEASE.2025-04-16T18-13-26Z
+# Search profile images (only used with COMPOSE_PROFILES=search):
+# OCTO_SEARCH_KAFKA_IMAGE=apache/kafka:3.8.0
+# OCTO_SEARCH_OPENSEARCH_IMAGE=octo-search-opensearch-ik:2.17.0   # local build tag (see docker/opensearch/Dockerfile)
+# OCTO_SEARCH_OPENSEARCH_VERSION=2.17.0
+# OCTO_SEARCH_INDEXER_IMAGE=mininglamposs/octo-search-indexer:latest

--- a/docker/README.md
+++ b/docker/README.md
@@ -1181,7 +1181,10 @@ profile. With no profile set it is completely inert:
 - New host ports bind loopback by default (`127.0.0.1:29200` OpenSearch,
   `127.0.0.1:29092` Kafka); new named volumes (`opensearch-data`,
   `kafka-data`, `search-dlq-spill`) carry the same `COMPOSE_PROJECT_NAME`
-  prefix as the rest of the stack, so `down -v` only ever touches your own.
+  prefix as the rest of the stack. Tear them down by **naming the search
+  volumes explicitly** (see "Tear down" below) — **never** a project-wide
+  `docker compose down -v`, which ignores `COMPOSE_PROFILES` and would delete
+  the core data volumes too.
 
 > Merging these manifests deploys nothing. Bringing the profile up is an
 > explicit operator action and, in any shared/staging/production environment,
@@ -1262,16 +1265,40 @@ curl -s -XPOST localhost:29200/octo-message/_search \
 
 ### Tear down (clean)
 
+> ⚠️ **DANGER — never run `docker compose down` or `docker compose down -v`
+> to tear down the search profile.** Those commands **ignore
+> `COMPOSE_PROFILES`** — the profile filter only applies to `up` / `create` /
+> `run`, **not** to `down`. `docker compose down` therefore acts on the **whole
+> `octo` project** and stops every core service (server / nginx / mysql / redis
+> / minio / wukongim …); `down -v` additionally **deletes the core data
+> volumes** (mysql-data, redis-data, minio-data, wukongim-data). Running it to
+> "clean up search" will wipe the entire stack and its data.
+
+Tear the search profile down by **naming exactly the search services**, then
+removing **only the search-specific named volumes** — never a project-wide
+`down`:
+
 ```bash
 cd docker
-COMPOSE_PROFILES=search docker compose down
-# Drop the search data volumes too (local validation only):
-COMPOSE_PROFILES=search docker compose down -v
+# 1. Stop + remove ONLY the search-profile containers (by name). -p octo pins
+#    the project so this never touches another stack; core services are not
+#    listed, so they are left running and untouched.
+docker compose -p octo rm -sf search-kafka search-kafka-init search-opensearch es-indexer
+
+# 2. (local validation only) Remove ONLY the search-specific named volumes.
+#    Core volumes (mysql-data, redis-data, ...) are NOT listed and NOT touched.
+#    Volume names follow `name: ${COMPOSE_PROJECT_NAME:-octo}_*` from the
+#    compose file; for the default project that is the `octo_` prefix. If you
+#    run a non-default COMPOSE_PROJECT_NAME, substitute it here.
+docker volume rm octo_opensearch-data octo_kafka-data octo_search-dlq-spill
 ```
 
-`down -v` only removes this project's volumes (`${COMPOSE_PROJECT_NAME}_*`),
-so it is safe alongside other OCTO stacks as long as your project name is set
-correctly — see "Uninstall / reset" above.
+If you set a custom `COMPOSE_PROJECT_NAME` (e.g. `octo-fz`), use `-p <name>` in
+step 1 and the matching `<name>_opensearch-data` etc. in step 2.
+
+`docker volume rm` errors harmlessly with "no such volume" if a volume was
+never created (e.g. you only ran OpenSearch); that is safe to ignore. It will
+refuse to remove a volume still in use, so always do step 1 first.
 
 ### Kubernetes
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1165,6 +1165,132 @@ above for why a ufw rule alone is not enough).
 
 ---
 
+## Search profile (message-search pipeline)
+
+The message-search pipeline — Kafka + OpenSearch (with the `analysis-ik`
+Chinese analyzer) + the `es-indexer` consumer — is **opt-in** behind the
+Docker Compose `search` profile, exactly like smart-summary's `summary`
+profile. With no profile set it is completely inert:
+
+- A default `docker compose up -d` (or `setup.sh`) starts **zero** search
+  services. The rendered config for the default profile is byte-for-byte
+  identical with and without these additions.
+- Every search variable in `.env` has a default (or is referenced only inside
+  the search services), so a non-search deployment never fails preflight on a
+  missing search variable.
+- New host ports bind loopback by default (`127.0.0.1:29200` OpenSearch,
+  `127.0.0.1:29092` Kafka); new named volumes (`opensearch-data`,
+  `kafka-data`, `search-dlq-spill`) carry the same `COMPOSE_PROJECT_NAME`
+  prefix as the rest of the stack, so `down -v` only ever touches your own.
+
+> Merging these manifests deploys nothing. Bringing the profile up is an
+> explicit operator action and, in any shared/staging/production environment,
+> is gated on owner sign-off.
+
+### Build the es-indexer image for local validation
+
+The `mininglamposs/octo-search-indexer` image is published only on `v*` tags /
+manual dispatch. For local validation, build a tag from a checkout of the
+[octo-search-indexer](https://github.com/Mininglamp-OSS/octo-search-indexer)
+repo and point the stack at it:
+
+```bash
+# in a checkout of octo-search-indexer
+docker build -t octo-search-indexer:local .
+
+# in docker/.env (this repo)
+OCTO_SEARCH_INDEXER_IMAGE=octo-search-indexer:local
+```
+
+The OpenSearch image with the IK plugin is built automatically from
+`docker/opensearch/Dockerfile` on first `up` (no manual step).
+
+### Bring the search profile up
+
+```bash
+cd docker
+# Enable the profile for this shell (or persist COMPOSE_PROFILES=search in .env)
+export COMPOSE_PROFILES=search
+docker compose up -d --build search-opensearch search-kafka search-kafka-init es-indexer
+```
+
+`search-kafka-init` pre-creates the body + DLQ topics (`octo.message.v1`,
+`octo.message.v1.dlq`) — required because the indexer's DLQ producer runs with
+`AllowAutoTopicCreation=false`. The `es-indexer` waits for it plus a healthy
+OpenSearch, then auto-creates the `octo-message` index with the embedded IK
+mapping (`ik_max_word` on the index side, `ik_smart` on the query side).
+
+### End-to-end check (local)
+
+```bash
+# 1. OpenSearch is up and the index was created by the indexer
+curl -s localhost:29200/_cluster/health | grep -o '"status":"[a-z]*"'
+curl -s localhost:29200/octo-message/_count
+
+# 2. Produce a contract message to Kafka and confirm it lands in OpenSearch.
+#    The octo-search-indexer repo ships a seed tool for exactly this:
+#      (in that checkout)
+#      KAFKA_BROKERS=localhost:29092 go run ./harness/seed -mode suite
+#    then re-check the count / search:
+curl -s -XPOST localhost:29200/octo-message/_search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":{"match":{"content":"公园"}}}'
+```
+
+### Observability
+
+- **Consumer lag** (how far behind the indexer is):
+  ```bash
+  docker compose exec search-kafka \
+    /opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server localhost:9092 \
+    --describe --group octo-search-indexer
+  ```
+- **DLQ backlog** (poison-pill topic depth):
+  ```bash
+  docker compose exec search-kafka \
+    /opt/kafka/bin/kafka-get-offsets.sh --bootstrap-server localhost:9092 \
+    --topic octo.message.v1.dlq
+  ```
+- **DLQ spill** (durable local fallback when the DLQ topic is unwritable):
+  ```bash
+  docker compose exec es-indexer ls -la /var/lib/es-indexer/dlq-spill
+  ```
+- **Reconciliation diff** (MySQL source rows vs ES docs): run the
+  `cmd/reconcile` tool from the octo-search-indexer repo against
+  `localhost:29200` — see that repo's `docs/backfill.md`.
+- **Indexer logs**: `docker compose logs -f es-indexer`.
+
+### Tear down (clean)
+
+```bash
+cd docker
+COMPOSE_PROFILES=search docker compose down
+# Drop the search data volumes too (local validation only):
+COMPOSE_PROFILES=search docker compose down -v
+```
+
+`down -v` only removes this project's volumes (`${COMPOSE_PROJECT_NAME}_*`),
+so it is safe alongside other OCTO stacks as long as your project name is set
+correctly — see "Uninstall / reset" above.
+
+### Kubernetes
+
+The k8s manifests live in a standalone, opt-in kustomization at
+`kustomize/search/` that base/overlays do **not** reference. Apply it
+explicitly (and, for shared environments, only after owner sign-off):
+
+```bash
+kubectl apply -k kustomize/search -n <ns>
+```
+
+It adds Kafka + OpenSearch StatefulSets (each with a PVC), an es-indexer
+Deployment, and a dedicated DLQ-spill PVC (required so the indexer's
+crash-resumable spill accounting survives a pod restart). Build/push the
+IK-enabled OpenSearch image and pin a real `octo-search-indexer` tag in
+`kustomize/search/kustomization.yaml` first.
+
+---
+
 ## MinIO bootstrap & credential scoping
 
 The stack ships with an `octo-server` MinIO client that is **not** the

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1006,7 +1006,7 @@ services:
   # default `docker compose up -d` (no COMPOSE_PROFILES, or only "summary")
   # starts ZERO of them. Operators opt in with `COMPOSE_PROFILES=search`.
   #
-  # ISOLATION GUARANTEES (phase 7, YUJ-4530 v4):
+  # ISOLATION GUARANTEES:
   #   - No core service definition (server/nginx/mysql/redis/...) is touched.
   #   - No new REQUIRED env var: every var below has a `:-` default or is
   #     referenced only inside these search-profile services, so a non-search

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1050,6 +1050,10 @@ services:
       # URL-safe Base64 form from `kafka-storage.sh random-uuid`) — some Kafka
       # builds reject a free-form string at format time. Override per stack.
       CLUSTER_ID: ${OCTO_SEARCH_KAFKA_CLUSTER_ID:-3kNqlPkyT16sjDguh9qqKA}
+      # apache/kafka defaults log.dirs to /tmp/kraft-combined-logs, which is
+      # NOT the mounted volume — without this, topics/metadata are lost across
+      # recreate even though kafka-data exists. Point it at the named volume.
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
     volumes:
       - kafka-data:/var/lib/kafka/data
     ports:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1046,8 +1046,10 @@ services:
       # broker auto-create off so a mistyped topic fails loudly.
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
       # KRaft needs a stable cluster id; keep it pinned so a volume reuse does
-      # not trip "cluster id mismatch".
-      CLUSTER_ID: ${OCTO_SEARCH_KAFKA_CLUSTER_ID:-octo-search-kraft-0000001}
+      # not trip "cluster id mismatch". MUST be a valid Kafka UUID (the 22-char
+      # URL-safe Base64 form from `kafka-storage.sh random-uuid`) — some Kafka
+      # builds reject a free-form string at format time. Override per stack.
+      CLUSTER_ID: ${OCTO_SEARCH_KAFKA_CLUSTER_ID:-3kNqlPkyT16sjDguh9qqKA}
     volumes:
       - kafka-data:/var/lib/kafka/data
     ports:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -89,6 +89,20 @@ volumes:
     name: ${COMPOSE_PROJECT_NAME:-octo}_server-logs
   nginx-logs:
     name: ${COMPOSE_PROJECT_NAME:-octo}_nginx-logs
+  # --- search profile (opt-in: COMPOSE_PROFILES=search) ---------------------
+  # These volumes are ONLY attached by the search-profile services below.
+  # Declaring them here is inert for a default (no-profile) `up` — Compose
+  # does not create a named volume until a started service references it.
+  # Same COMPOSE_PROJECT_NAME prefixing as every other volume so a second
+  # clone / `down -v` only ever touches its own data (INCIDENT-2026-05-16-001).
+  opensearch-data:
+    name: ${COMPOSE_PROJECT_NAME:-octo}_opensearch-data
+  kafka-data:
+    name: ${COMPOSE_PROJECT_NAME:-octo}_kafka-data
+  # DLQ spill must survive an indexer restart, otherwise the crash-resumable
+  # spill accounting (octo-search-indexer phase 6) is defeated.
+  search-dlq-spill:
+    name: ${COMPOSE_PROJECT_NAME:-octo}_search-dlq-spill
 
 services:
   # ---------------------------------------------------------------------------
@@ -982,3 +996,172 @@ services:
       # window does not wedge the worker into `(unhealthy)` while the
       # mysql init script is still finishing.
       start_period: 30s
+
+  # ===========================================================================
+  # Search infrastructure (message-search pipeline) — STRICTLY ADDITIVE
+  # ===========================================================================
+  # Kafka (KRaft single broker) + OpenSearch (single node, analysis-ik) +
+  # es-indexer (Kafka -> OpenSearch bulk indexer). Mirrors the smart-summary
+  # pattern: every service here is gated behind `profiles: ["search"]`, so a
+  # default `docker compose up -d` (no COMPOSE_PROFILES, or only "summary")
+  # starts ZERO of them. Operators opt in with `COMPOSE_PROFILES=search`.
+  #
+  # ISOLATION GUARANTEES (phase 7, YUJ-4530 v4):
+  #   - No core service definition (server/nginx/mysql/redis/...) is touched.
+  #   - No new REQUIRED env var: every var below has a `:-` default or is
+  #     referenced only inside these search-profile services, so a non-search
+  #     deployment never fails preflight on a missing variable.
+  #   - Reuses the existing octo-net network; new named volumes only.
+  #   - New host ports bind loopback by default (override the *_BIND vars).
+  #   - These services do NOT depend on `preflight` / core services and do not
+  #     alter the default profile set.
+  #
+  # NOTE: merging this file deploys nothing. Bringing the search profile up is
+  # an explicit, owner-gated operator action (`COMPOSE_PROFILES=search`).
+  # ---------------------------------------------------------------------------
+  search-kafka:
+    image: ${OCTO_SEARCH_KAFKA_IMAGE:-apache/kafka:3.8.0}
+    restart: unless-stopped
+    profiles: ["search"]
+    environment:
+      TZ: ${TZ:-UTC}
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      # Internal listener for in-network clients (es-indexer, octo-server
+      # producer in a later phase); EXTERNAL is loopback-published for local
+      # validation tooling (the seed/producer harness). The advertised
+      # EXTERNAL host is configurable so a non-localhost validator can reach it.
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:29092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://search-kafka:9092,EXTERNAL://${OCTO_SEARCH_KAFKA_ADVERTISED_HOST:-localhost}:${OCTO_SEARCH_KAFKA_PORT:-29092}
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@search-kafka:9093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      # The body + DLQ topics are created up front by search-kafka-init (the
+      # indexer's DLQ producer runs with AllowAutoTopicCreation=false). Leave
+      # broker auto-create off so a mistyped topic fails loudly.
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      # KRaft needs a stable cluster id; keep it pinned so a volume reuse does
+      # not trip "cluster id mismatch".
+      CLUSTER_ID: ${OCTO_SEARCH_KAFKA_CLUSTER_ID:-octo-search-kraft-0000001}
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+    ports:
+      - "${OCTO_SEARCH_KAFKA_BIND:-127.0.0.1}:${OCTO_SEARCH_KAFKA_PORT:-29092}:29092"
+    networks:
+      - octo-net
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1 || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 12
+      start_period: 30s
+
+  # One-shot: create the body + DLQ topics (indexer DLQ producer has
+  # AllowAutoTopicCreation=false, so the DLQ topic MUST pre-exist). Idempotent
+  # via --if-not-exists; exits 0 once both topics are present.
+  search-kafka-init:
+    image: ${OCTO_SEARCH_KAFKA_IMAGE:-apache/kafka:3.8.0}
+    restart: "no"
+    profiles: ["search"]
+    depends_on:
+      search-kafka:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -eu
+        BOOT=search-kafka:9092
+        for t in "${OCTO_SEARCH_KAFKA_TOPIC:-octo.message.v1}" "${OCTO_SEARCH_KAFKA_DLQ_TOPIC:-octo.message.v1.dlq}"; do
+          /opt/kafka/bin/kafka-topics.sh --bootstrap-server "$$BOOT" \
+            --create --if-not-exists --topic "$$t" \
+            --partitions "${OCTO_SEARCH_KAFKA_PARTITIONS:-1}" \
+            --replication-factor 1
+        done
+        echo "[search-kafka-init] topics ready"
+    networks:
+      - octo-net
+
+  search-opensearch:
+    # Built locally to bake in the analysis-ik plugin (index uses ik_max_word /
+    # query uses ik_smart). The plugin version MUST match the OpenSearch
+    # version — both are pinned via the build arg below.
+    image: ${OCTO_SEARCH_OPENSEARCH_IMAGE:-octo-search-opensearch-ik:2.17.0}
+    build:
+      context: ./opensearch
+      dockerfile: Dockerfile
+      args:
+        OPENSEARCH_VERSION: ${OCTO_SEARCH_OPENSEARCH_VERSION:-2.17.0}
+    restart: unless-stopped
+    profiles: ["search"]
+    environment:
+      TZ: ${TZ:-UTC}
+      discovery.type: single-node
+      bootstrap.memory_lock: "true"
+      OPENSEARCH_JAVA_OPTS: ${OCTO_SEARCH_OPENSEARCH_JAVA_OPTS:--Xms512m -Xmx512m}
+      # Local-stack default: disable the security plugin so the indexer and
+      # validation tooling can talk plain http on the internal network. For a
+      # hardened deployment, set OCTO_SEARCH_OPENSEARCH_DISABLE_SECURITY=false
+      # and wire credentials via ES_USERNAME/ES_PASSWORD on the indexer.
+      DISABLE_SECURITY_PLUGIN: ${OCTO_SEARCH_OPENSEARCH_DISABLE_SECURITY:-true}
+      DISABLE_INSTALL_DEMO_CONFIG: "true"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - opensearch-data:/usr/share/opensearch/data
+    ports:
+      - "${OCTO_SEARCH_OPENSEARCH_BIND:-127.0.0.1}:${OCTO_SEARCH_OPENSEARCH_PORT:-29200}:9200"
+    networks:
+      - octo-net
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://localhost:9200/_cluster/health >/dev/null || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 18
+      start_period: 30s
+
+  es-indexer:
+    # Built only on v* tags / manual dispatch (see octo-search-indexer
+    # .github/workflows/docker-publish.yml). For LOCAL validation, build a
+    # local tag from a checkout of that repo and set OCTO_SEARCH_INDEXER_IMAGE
+    # to it (see docker/README.md "Search profile"). Default points at the
+    # published :latest, which only exists once a release tag has been cut.
+    image: ${OCTO_SEARCH_INDEXER_IMAGE:-mininglamposs/octo-search-indexer:latest}
+    restart: unless-stopped
+    profiles: ["search"]
+    depends_on:
+      search-kafka-init:
+        condition: service_completed_successfully
+      search-opensearch:
+        condition: service_healthy
+    environment:
+      TZ: ${TZ:-UTC}
+      # The indexer idles (no backend connection) unless ES_INDEXER_ENABLED=true
+      # AND brokers + ES are set. Within the search profile we set all three so
+      # the pipeline runs; outside the profile this service does not exist.
+      ES_INDEXER_ENABLED: "true"
+      KAFKA_BROKERS: search-kafka:9092
+      KAFKA_TOPIC: ${OCTO_SEARCH_KAFKA_TOPIC:-octo.message.v1}
+      KAFKA_DLQ_TOPIC: ${OCTO_SEARCH_KAFKA_DLQ_TOPIC:-octo.message.v1.dlq}
+      KAFKA_GROUP_ID: ${OCTO_SEARCH_INDEXER_GROUP_ID:-octo-search-indexer}
+      ES_ADDRESSES: http://search-opensearch:9200
+      ES_INDEX: ${OCTO_SEARCH_ES_INDEX:-octo-message}
+      ES_USERNAME: ${OCTO_SEARCH_ES_USERNAME:-}
+      ES_PASSWORD: ${OCTO_SEARCH_ES_PASSWORD:-}
+      INDEXER_BATCH_SIZE: ${OCTO_SEARCH_INDEXER_BATCH_SIZE:-500}
+      # Spill path lives on a named volume so DLQ-write outages survive an
+      # indexer restart (crash-resumable spill accounting).
+      INDEXER_DLQ_SPILL_DIR: /var/lib/es-indexer/dlq-spill
+    volumes:
+      - search-dlq-spill:/var/lib/es-indexer/dlq-spill
+    networks:
+      - octo-net

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -93,8 +93,14 @@ volumes:
   # These volumes are ONLY attached by the search-profile services below.
   # Declaring them here is inert for a default (no-profile) `up` — Compose
   # does not create a named volume until a started service references it.
-  # Same COMPOSE_PROJECT_NAME prefixing as every other volume so a second
-  # clone / `down -v` only ever touches its own data (INCIDENT-2026-05-16-001).
+  # The COMPOSE_PROJECT_NAME prefix isolates volumes across DIFFERENT projects
+  # (a `down -v` in project A never touches project B). It does NOT make
+  # `down -v` profile-aware: within ONE project, `docker compose down -v`
+  # deletes ALL of that project's volumes, core ones included — `down` ignores
+  # COMPOSE_PROFILES. To remove just these search volumes, name them
+  # explicitly (`docker volume rm <project>_opensearch-data ...`); never run a
+  # project-wide `down -v` to "clean up search". See docker/README.md
+  # "Search profile" → "Tear down".
   opensearch-data:
     name: ${COMPOSE_PROJECT_NAME:-octo}_opensearch-data
   kafka-data:

--- a/docker/opensearch/Dockerfile
+++ b/docker/opensearch/Dockerfile
@@ -1,0 +1,13 @@
+# OpenSearch + analysis-ik plugin for the OCTO message-search pipeline
+# (octo-deployment search profile). The es-indexer index mapping uses the IK
+# analyzers (ik_max_word on the index side, ik_smart on the query side), so the
+# plugin MUST be installed in the OpenSearch image, and its version MUST match
+# the OpenSearch version. Both are pinned via the build arg below; keep them in
+# lockstep with octo-search-indexer/harness/opensearch-ik.Dockerfile.
+ARG OPENSEARCH_VERSION=2.17.0
+FROM opensearchproject/opensearch:${OPENSEARCH_VERSION}
+
+ARG OPENSEARCH_VERSION=2.17.0
+# infinilabs hosts analysis-ik builds for OpenSearch.
+RUN /usr/share/opensearch/bin/opensearch-plugin install --batch \
+    https://release.infinilabs.com/analysis-ik/stable/opensearch-analysis-ik-${OPENSEARCH_VERSION}.zip

--- a/kustomize/search/README.md
+++ b/kustomize/search/README.md
@@ -1,0 +1,43 @@
+# Search pipeline (opt-in, standalone)
+
+Kafka + OpenSearch (analysis-ik) + es-indexer for the OCTO message-search
+pipeline. This kustomization is **intentionally not referenced** by
+`kustomize/base` or any overlay — applying the default base/overlays deploys
+zero search resources. It is additive and opt-in.
+
+## Apply (owner-gated for shared environments)
+
+```bash
+kubectl apply -k kustomize/search -n <ns>
+```
+
+## Before applying
+
+1. **OpenSearch image with IK**: build `docker/opensearch/Dockerfile`
+   (OpenSearch + `analysis-ik`, versions pinned in lockstep), push to your
+   registry, and set the `octo-search-opensearch-ik` image tag in
+   `kustomization.yaml`.
+2. **es-indexer image**: published only on `v*` tags / manual dispatch in
+   octo-search-indexer — pin a real tag in `kustomization.yaml` (not a
+   floating `latest` for production).
+3. **Topics**: the indexer's DLQ producer uses `AllowAutoTopicCreation=false`.
+   Pre-create `octo.message.v1` and `octo.message.v1.dlq` once Kafka is up,
+   e.g.:
+   ```bash
+   kubectl exec -n <ns> statefulset/search-kafka -- \
+     /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 \
+     --create --if-not-exists --topic octo.message.v1 --partitions 1 --replication-factor 1
+   kubectl exec -n <ns> statefulset/search-kafka -- \
+     /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 \
+     --create --if-not-exists --topic octo.message.v1.dlq --partitions 1 --replication-factor 1
+   ```
+
+## Resources
+
+- `search-kafka.yaml` — Kafka (KRaft single broker) StatefulSet + headless Service.
+- `search-opensearch.yaml` — OpenSearch (single node, IK) StatefulSet + headless Service.
+- `es-indexer.yaml` — es-indexer Deployment (DLQ spill on a PVC).
+- `search-pvc.yaml` — PVCs: OpenSearch data, Kafka data, DLQ spill.
+
+The DLQ-spill PVC is required: without durable spill storage the indexer's
+crash-resumable DLQ accounting is defeated on a pod restart.

--- a/kustomize/search/README.md
+++ b/kustomize/search/README.md
@@ -20,9 +20,12 @@ kubectl apply -k kustomize/search -n <ns>
 2. **es-indexer image**: published only on `v*` tags / manual dispatch in
    octo-search-indexer — pin a real tag in `kustomization.yaml` (not a
    floating `latest` for production).
-3. **Topics**: the indexer's DLQ producer uses `AllowAutoTopicCreation=false`.
-   Pre-create `octo.message.v1` and `octo.message.v1.dlq` once Kafka is up,
-   e.g.:
+3. **Topics**: created automatically by the `search-kafka-init` Job (the k8s
+   equivalent of the compose init service) — required because broker
+   auto-create is off and the indexer's DLQ producer uses
+   `AllowAutoTopicCreation=false`. The Job waits for the broker, then creates
+   `octo.message.v1` and `octo.message.v1.dlq` idempotently. To stage them
+   manually instead (e.g. different partition counts):
    ```bash
    kubectl exec -n <ns> statefulset/search-kafka -- \
      /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 \
@@ -35,6 +38,7 @@ kubectl apply -k kustomize/search -n <ns>
 ## Resources
 
 - `search-kafka.yaml` — Kafka (KRaft single broker) StatefulSet + headless Service.
+- `search-kafka-init.yaml` — one-shot Job creating the body + DLQ topics.
 - `search-opensearch.yaml` — OpenSearch (single node, IK) StatefulSet + headless Service.
 - `es-indexer.yaml` — es-indexer Deployment (DLQ spill on a PVC).
 - `search-pvc.yaml` — PVCs: OpenSearch data, Kafka data, DLQ spill.

--- a/kustomize/search/es-indexer.yaml
+++ b/kustomize/search/es-indexer.yaml
@@ -1,0 +1,59 @@
+# es-indexer: consumes Kafka octo.message.v1 and bulk-indexes into OpenSearch
+# (idempotent _id=message_id upsert; IK analyzers via the embedded mapping).
+# The DLQ spill mounts a PVC so DLQ-write outages survive a pod restart.
+#
+# NOTE: image is built only on v* tags / manual dispatch in octo-search-indexer.
+# Pin a real published tag in kustomization.yaml before applying.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: es-indexer
+  labels:
+    app: es-indexer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: es-indexer
+  template:
+    metadata:
+      labels:
+        app: es-indexer
+    spec:
+      containers:
+        - name: es-indexer
+          image: mininglamposs/octo-search-indexer:latest
+          imagePullPolicy: Always
+          env:
+            - name: ES_INDEXER_ENABLED
+              value: "true"
+            - name: KAFKA_BROKERS
+              value: "search-kafka:9092"
+            - name: KAFKA_TOPIC
+              value: "octo.message.v1"
+            - name: KAFKA_DLQ_TOPIC
+              value: "octo.message.v1.dlq"
+            - name: KAFKA_GROUP_ID
+              value: "octo-search-indexer"
+            - name: ES_ADDRESSES
+              value: "http://search-opensearch:9200"
+            - name: ES_INDEX
+              value: "octo-message"
+            - name: INDEXER_BATCH_SIZE
+              value: "500"
+            - name: INDEXER_DLQ_SPILL_DIR
+              value: "/var/lib/es-indexer/dlq-spill"
+          volumeMounts:
+            - name: search-dlq-spill
+              mountPath: /var/lib/es-indexer/dlq-spill
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: search-dlq-spill
+          persistentVolumeClaim:
+            claimName: search-dlq-spill

--- a/kustomize/search/kustomization.yaml
+++ b/kustomize/search/kustomization.yaml
@@ -15,6 +15,7 @@ kind: Kustomization
 resources:
   - search-pvc.yaml
   - search-kafka.yaml
+  - search-kafka-init.yaml
   - search-opensearch.yaml
   - es-indexer.yaml
 

--- a/kustomize/search/kustomization.yaml
+++ b/kustomize/search/kustomization.yaml
@@ -1,0 +1,30 @@
+# Search pipeline (Kafka + OpenSearch + es-indexer) — STANDALONE, OPT-IN.
+#
+# This kustomization is INTENTIONALLY NOT referenced by kustomize/base or any
+# overlay (dev/prod). Applying the default base/overlays deploys ZERO search
+# resources. An operator opts in explicitly and on a separate, owner-gated
+# action, e.g.:
+#
+#   kubectl apply -k kustomize/search -n <ns>
+#
+# Everything here is additive: it adds new workloads, services, and PVCs and
+# does not modify any core OCTO resource. See README.md in this directory.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - search-pvc.yaml
+  - search-kafka.yaml
+  - search-opensearch.yaml
+  - es-indexer.yaml
+
+images:
+  - name: apache/kafka
+    newTag: "3.8.0"
+  # Build this locally with the analysis-ik plugin baked in (see
+  # docker/opensearch/Dockerfile) and push to your registry, then point this
+  # at it. The plugin version MUST match the OpenSearch version.
+  - name: octo-search-opensearch-ik
+    newTag: "2.17.0"
+  - name: mininglamposs/octo-search-indexer
+    newTag: latest

--- a/kustomize/search/search-kafka-init.yaml
+++ b/kustomize/search/search-kafka-init.yaml
@@ -1,0 +1,49 @@
+# One-shot topic creation for the search pipeline. REQUIRED because broker
+# auto-create is off and the es-indexer's DLQ producer runs with
+# AllowAutoTopicCreation=false — the body + DLQ topics must pre-exist. This
+# Job is the k8s equivalent of the compose `search-kafka-init` service. It is
+# idempotent (--if-not-exists) and retries until the broker is reachable.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: search-kafka-init
+  labels:
+    app: search-kafka-init
+spec:
+  backoffLimit: 30
+  template:
+    metadata:
+      labels:
+        app: search-kafka-init
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: kafka-init
+          image: apache/kafka:3.8.0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              BOOT=search-kafka:9092
+              # Wait for the broker to accept API calls (the StatefulSet has no
+              # Job-visible readiness gate across objects, so poll here).
+              i=0
+              until /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server "$BOOT" >/dev/null 2>&1; do
+                i=$((i+1))
+                if [ "$i" -gt 60 ]; then echo "[init] broker not ready after 5m" >&2; exit 1; fi
+                echo "[init] waiting for $BOOT ..."; sleep 5
+              done
+              for t in octo.message.v1 octo.message.v1.dlq; do
+                /opt/kafka/bin/kafka-topics.sh --bootstrap-server "$BOOT" \
+                  --create --if-not-exists --topic "$t" \
+                  --partitions 1 --replication-factor 1
+              done
+              echo "[init] topics ready"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi

--- a/kustomize/search/search-kafka.yaml
+++ b/kustomize/search/search-kafka.yaml
@@ -40,6 +40,12 @@ spec:
       labels:
         app: search-kafka
     spec:
+      # apache/kafka runs as a non-root user (uid/gid 1000). Freshly provisioned
+      # PVCs are often root-owned, so set fsGroup to make the data mount
+      # group-writable — otherwise the broker cannot format/write KRaft metadata
+      # under KAFKA_LOG_DIRS and the pod crash-loops before readiness.
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: kafka
           image: apache/kafka:3.8.0

--- a/kustomize/search/search-kafka.yaml
+++ b/kustomize/search/search-kafka.yaml
@@ -66,8 +66,10 @@ spec:
               value: "1"
             - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
               value: "false"
+            # Valid Kafka UUID (22-char URL-safe Base64, from
+            # `kafka-storage.sh random-uuid`); pin per cluster.
             - name: CLUSTER_ID
-              value: "octo-search-kraft-0000001"
+              value: "3kNqlPkyT16sjDguh9qqKA"
           volumeMounts:
             - name: search-kafka-data
               mountPath: /var/lib/kafka/data

--- a/kustomize/search/search-kafka.yaml
+++ b/kustomize/search/search-kafka.yaml
@@ -1,0 +1,94 @@
+# Kafka (KRaft single broker) for the message-search pipeline. Single-node,
+# in-cluster only (ClusterIP, no external exposure). Topics are created by the
+# es-indexer's expectations (DLQ producer has AllowAutoTopicCreation=false), so
+# operators should pre-create octo.message.v1 / octo.message.v1.dlq once the
+# broker is up (a one-shot Job or kafka-topics.sh exec — see README).
+apiVersion: v1
+kind: Service
+metadata:
+  name: search-kafka
+  labels:
+    app: search-kafka
+spec:
+  clusterIP: None
+  selector:
+    app: search-kafka
+  ports:
+    - name: broker
+      port: 9092
+      targetPort: 9092
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: search-kafka
+  labels:
+    app: search-kafka
+spec:
+  serviceName: search-kafka
+  replicas: 1
+  selector:
+    matchLabels:
+      app: search-kafka
+  template:
+    metadata:
+      labels:
+        app: search-kafka
+    spec:
+      containers:
+        - name: kafka
+          image: apache/kafka:3.8.0
+          ports:
+            - name: broker
+              containerPort: 9092
+          env:
+            - name: KAFKA_NODE_ID
+              value: "1"
+            - name: KAFKA_PROCESS_ROLES
+              value: "broker,controller"
+            - name: KAFKA_LISTENERS
+              value: "PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093"
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: "PLAINTEXT://search-kafka:9092"
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT"
+            - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+              value: "1@search-kafka:9093"
+            - name: KAFKA_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: "PLAINTEXT"
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+              value: "false"
+            - name: CLUSTER_ID
+              value: "octo-search-kraft-0000001"
+          volumeMounts:
+            - name: search-kafka-data
+              mountPath: /var/lib/kafka/data
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 12
+      volumes:
+        - name: search-kafka-data
+          persistentVolumeClaim:
+            claimName: search-kafka-data

--- a/kustomize/search/search-kafka.yaml
+++ b/kustomize/search/search-kafka.yaml
@@ -11,6 +11,11 @@ metadata:
     app: search-kafka
 spec:
   clusterIP: None
+  # Publish the broker's DNS A record before it is Ready. KRaft resolves
+  # search-kafka for KAFKA_CONTROLLER_QUORUM_VOTERS during startup, which
+  # happens before the readiness probe passes — without this the name can be
+  # unresolvable and the single broker deadlocks unready.
+  publishNotReadyAddresses: true
   selector:
     app: search-kafka
   ports:
@@ -70,6 +75,11 @@ spec:
             # `kafka-storage.sh random-uuid`); pin per cluster.
             - name: CLUSTER_ID
               value: "3kNqlPkyT16sjDguh9qqKA"
+            # apache/kafka defaults log.dirs to /tmp/kraft-combined-logs (NOT
+            # the PVC mount) — set it to the mounted path so topics + KRaft
+            # metadata survive a pod replacement/reschedule.
+            - name: KAFKA_LOG_DIRS
+              value: "/var/lib/kafka/data"
           volumeMounts:
             - name: search-kafka-data
               mountPath: /var/lib/kafka/data

--- a/kustomize/search/search-opensearch.yaml
+++ b/kustomize/search/search-opensearch.yaml
@@ -1,0 +1,78 @@
+# OpenSearch (single node, analysis-ik) for the message-search pipeline.
+# The image MUST have the analysis-ik plugin baked in and the plugin version
+# MUST match the OpenSearch version (see docker/opensearch/Dockerfile — build
+# and push that to your registry, then set the image tag in kustomization.yaml).
+apiVersion: v1
+kind: Service
+metadata:
+  name: search-opensearch
+  labels:
+    app: search-opensearch
+spec:
+  clusterIP: None
+  selector:
+    app: search-opensearch
+  ports:
+    - name: http
+      port: 9200
+      targetPort: 9200
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: search-opensearch
+  labels:
+    app: search-opensearch
+spec:
+  serviceName: search-opensearch
+  replicas: 1
+  selector:
+    matchLabels:
+      app: search-opensearch
+  template:
+    metadata:
+      labels:
+        app: search-opensearch
+    spec:
+      containers:
+        - name: opensearch
+          image: octo-search-opensearch-ik:2.17.0
+          ports:
+            - name: http
+              containerPort: 9200
+          env:
+            - name: discovery.type
+              value: single-node
+            - name: bootstrap.memory_lock
+              value: "true"
+            - name: OPENSEARCH_JAVA_OPTS
+              value: "-Xms512m -Xmx512m"
+            # Local/in-cluster default disables the security plugin. For a
+            # hardened deployment set this to false and wire ES_USERNAME /
+            # ES_PASSWORD on the es-indexer.
+            - name: DISABLE_SECURITY_PLUGIN
+              value: "true"
+            - name: DISABLE_INSTALL_DEMO_CONFIG
+              value: "true"
+          volumeMounts:
+            - name: search-opensearch-data
+              mountPath: /usr/share/opensearch/data
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          readinessProbe:
+            httpGet:
+              path: /_cluster/health
+              port: 9200
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 18
+      volumes:
+        - name: search-opensearch-data
+          persistentVolumeClaim:
+            claimName: search-opensearch-data

--- a/kustomize/search/search-opensearch.yaml
+++ b/kustomize/search/search-opensearch.yaml
@@ -43,8 +43,15 @@ spec:
           env:
             - name: discovery.type
               value: single-node
+            # Memory locking is OFF for k8s: bootstrap.memory_lock=true requires
+            # the IPC_LOCK capability + an unlimited memlock rlimit on the pod
+            # (the compose service supplies this via `ulimits:`), which a plain
+            # StatefulSet does not have — with it on, OpenSearch fails its
+            # memory-lock bootstrap check and stays unready. To enable it on a
+            # cluster that supports it, add securityContext.capabilities
+            # IPC_LOCK + a memlock rlimit, then set this to "true".
             - name: bootstrap.memory_lock
-              value: "true"
+              value: "false"
             - name: OPENSEARCH_JAVA_OPTS
               value: "-Xms512m -Xmx512m"
             # Local/in-cluster default disables the security plugin. For a

--- a/kustomize/search/search-opensearch.yaml
+++ b/kustomize/search/search-opensearch.yaml
@@ -34,6 +34,12 @@ spec:
       labels:
         app: search-opensearch
     spec:
+      # OpenSearch runs as a non-root user (uid/gid 1000). Freshly provisioned
+      # PVCs are often root-owned, so set fsGroup to make the data mount
+      # group-writable — otherwise OpenSearch cannot create files under
+      # /usr/share/opensearch/data and the pod exits before readiness.
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: opensearch
           image: octo-search-opensearch-ik:2.17.0

--- a/kustomize/search/search-pvc.yaml
+++ b/kustomize/search/search-pvc.yaml
@@ -1,0 +1,41 @@
+# Persistent volumes for the search pipeline. The DLQ-spill PVC is REQUIRED:
+# without durable spill storage the es-indexer's crash-resumable DLQ
+# accounting (octo-search-indexer phase 6) is defeated on a pod restart.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: search-opensearch-data
+  labels:
+    app: search-opensearch
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: search-kafka-data
+  labels:
+    app: search-kafka
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: search-dlq-spill
+  labels:
+    app: es-indexer
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
## What

Orchestrate the message-search pipeline (Kafka + OpenSearch + es-indexer) into
octo-deployment, **strictly additive** and gated behind a Docker Compose
`search` profile — mirroring the existing smart-summary `summary` profile.

> ⚠️ **Merging this PR deploys nothing.** It is manifest-only. Bringing the
> search profile up (`COMPOSE_PROFILES=search`) is an explicit operator action,
> and applying it to **any** environment beyond a local validation stack is
> gated on owner sign-off. No CI/CD here builds or deploys these services.

## Isolation guarantees (verified)

- **Profile-gated**: a default `docker compose up -d` starts **zero** search
  services. The rendered default-profile config is **byte-for-byte identical**
  to `main` (verified by diffing `docker compose config` output).
- **No core service changed**: the compose diff is append-only (no removed or
  modified lines in existing service bodies).
- **No new required env var**: every search variable has a `:-` default or is
  referenced only inside search-profile services, so a non-search deployment
  never fails preflight on a missing variable. (Preflight is untouched.)
- **Reuses `octo-net`**; new named volumes (`opensearch-data`, `kafka-data`,
  `search-dlq-spill`) carry the same `COMPOSE_PROJECT_NAME` prefix; new host
  ports bind loopback by default (`127.0.0.1:29200`/`29092`).
- **k8s**: standalone, opt-in `kustomize/search/` that base/overlays do **not**
  reference (verified `kustomize build base`/`overlays/dev` contain no search
  resources).

## Contents

- `docker/docker-compose.yaml` (append-only): `search-kafka` (KRaft),
  `search-kafka-init` (one-shot topic create — the indexer's DLQ producer uses
  `AllowAutoTopicCreation=false`), `search-opensearch` (single node + IK),
  `es-indexer` — all `profiles: ["search"]`. DLQ spill on a named volume.
- `docker/opensearch/Dockerfile`: OpenSearch + `analysis-ik` (version-pinned).
- `.env.example`: documented, fully-defaulted search section + opt-in note.
- `kustomize/search/`: standalone manifests (Kafka/OpenSearch StatefulSets +
  PVCs, es-indexer Deployment, topic-init Job, dedicated DLQ-spill PVC).
- Docs: `docker/README.md` (bring-up / e2e / observability / teardown) +
  `kustomize/search/README.md`.

## Validation (local only)

Brought the profile up in an isolated local project, ran end-to-end
(seed → Kafka → es-indexer → OpenSearch): **5 docs indexed**, IK Chinese recall
works (公园/北京), 2 poison pills routed to the DLQ topic, consumer lag 0.
Verified Kafka data persists across a broker recreate (`KAFKA_LOG_DIRS` on the
volume). Torn down clean; the unrelated running stack and its volumes were
untouched. **Did not touch any shared/test/production environment, did not open
`Kafka.On` anywhere shared, did not wire a scheduler.**

## Review

- /codex review: PASS (converged over several rounds — valid Kafka cluster
  UUID, k8s topic-init Job, OpenSearch `memory_lock=false` in k8s,
  `KAFKA_LOG_DIRS` persistence, `publishNotReadyAddresses`, PVC `fsGroup`).
- yamllint (CI config) clean; kubeconform: 9/9 resources valid; hadolint clean;
  `docker compose config` valid for both default and search profiles.
