### PR TITLE
ci: always-run CI Gate + drop PR path filter (OCT-7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,6 @@ on:
       - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
-    paths:
-      - '**/*.yaml'
-      - '**/*.yml'
-      - 'kustomize/**'
-      - '.github/workflows/ci.yml'
 
 permissions:
   contents: read
@@ -118,3 +113,31 @@ jobs:
             echo "::endgroup::"
           done
           exit "${status}"
+
+  ci-gate:
+    name: CI Gate
+    # Aggregate gate: always runs so the required status check ALWAYS reports.
+    # The workflow now triggers on every PR to main (the old pull_request path
+    # filter was removed because workflow-level path filtering prevents GitHub
+    # from creating any check run, deadlocking required-status checks on PRs
+    # that touch no yaml/kustomize files). Fails iff a needed job failed or was
+    # cancelled; 'skipped'/'success' count as passing. Branch protection should
+    # require ONLY the "CI Gate" context for this repo.
+    if: ${{ always() }}
+    needs: [yaml-lint, kustomize-validate]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify upstream CI results
+        env:
+          RESULTS: ${{ join(needs.*.result, ',') }}
+        run: |
+          set -euo pipefail
+          echo "needed job results: ${RESULTS}"
+          IFS=',' read -ra items <<< "${RESULTS}"
+          for r in "${items[@]}"; do
+            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+              echo "::error::CI Gate: a required job concluded '${r}'"
+              exit 1
+            fi
+          done
+          echo "CI Gate: all required jobs passed or were skipped"


### PR DESCRIPTION
Part of OCT-7: make CI-green an enforced merge gate.

This repo used **workflow-level** `pull_request.paths` filtering. A PR touching no yaml/kustomize files would not trigger CI at all, so any required check would never report → perma-blocked PR.

Changes:
- Remove `pull_request.paths` so CI runs on every PR to main (jobs are cheap; `push.paths` kept).
- Add always-run **CI Gate** (`if: always()`, `needs: [yaml-lint, kustomize-validate]`) that fails iff a needed job failed/was cancelled.

After merge, branch protection will require only the `CI Gate` context.