### PR TITLE
feat(search): wire opt-in search backend + scripted hot-upgrade flow

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -454,6 +454,45 @@ OCTO_SEARCH_OPENSEARCH_DISABLE_SECURITY=true
 # OCTO_SEARCH_KAFKA_DLQ_TOPIC=octo.message.v1.dlq
 # OCTO_SEARCH_ES_INDEX=octo-message
 
+# --- octo-server search wiring (read by octo-server, not the search box) ----
+# OCTO_SEARCH_BACKEND is the single switch octo-server reads to decide whether
+# any message-search surface serves. Three states:
+#   disabled — search off; the frontend hides the search entry and the server
+#              never dials OpenSearch (clean boot, no error log noise).
+#   es       — serve from OpenSearch (the target state once search is on).
+#   zinc     — roll back to the legacy WuKongIM->Zinc path.
+# Default is "disabled" so a vanilla `docker compose up` runs search-free and
+# clean. The upgrade flow (docker/README.md "Turn search on") flips it to "es"
+# as its final step. Leaving it UNSET makes octo-server assume the legacy "ES
+# on" default and hammer a non-existent OpenSearch on the first search call.
+OCTO_SEARCH_BACKEND=disabled
+# Where the octo-server reader finds OpenSearch and which read alias it queries.
+# Only consulted when OCTO_SEARCH_BACKEND=es.
+# OCTO_SEARCH_OS_ADDRS=http://search-opensearch:9200
+# OCTO_SEARCH_OS_READ_ALIAS=wukongim-messages-read
+# Per-deployment HMAC key for the opaque search pagination cursor. Unset falls
+# back to a published (forgeable, authz-free) constant; set a random value for
+# any real search deployment: openssl rand -hex 32
+# OCTO_SEARCH_CURSOR_HMAC=
+# Real-time producer (searchetl -> Kafka) master switch. Keep false until the
+# upgrade flow has seeded the extraction cursor to the message high-watermark;
+# turning it on with a zero cursor re-streams the entire message history.
+OCTO_SEARCH_PRODUCER_ON=false
+# Broker list octo-server's producer connects to (in-network DNS name).
+# OCTO_SEARCH_KAFKA_BROKERS=search-kafka:9092
+
+# --- Search upgrade tooling (`search-tools` profile, one-shot jobs) ---------
+# Message shard tables the cursor-seed + backfill jobs operate on. Defaults
+# match the 5 WuKongIM message shards.
+# OCTO_SEARCH_SHARD_TABLES=message,message1,message2,message3,message4
+# Backfill rate limit (docs/s) and keyset batch size.
+# OCTO_SEARCH_BACKFILL_RATE=5000
+# OCTO_SEARCH_BACKFILL_BATCH=1000
+# Reconcile window for the backfill correctness gate (epoch seconds; 0/0 means
+# "from the beginning of time to now" — the right default for a full backfill).
+# OCTO_SEARCH_BACKFILL_FROM=0
+# OCTO_SEARCH_BACKFILL_TO=0
+
 # --- Image overrides -------------------------------------------------------
 # OCTO_SERVER_IMAGE=mininglamposs/octo-server:latest
 # OCTO_WEB_IMAGE=mininglamposs/octo-web:latest

--- a/docker/README.md
+++ b/docker/README.md
@@ -1205,6 +1205,22 @@ docker build -t octo-search-indexer:local .
 OCTO_SEARCH_INDEXER_IMAGE=octo-search-indexer:local
 ```
 
+This one image carries all three pipeline binaries — `es-indexer` (the
+long-running consumer, the default entrypoint), `backfill` (the one-shot
+historical loader), and `reconcile` (the correctness gate) — so the upgrade
+flow below needs no separate Go toolchain or second image.
+
+> **Image availability (community deployments).** The published
+> `mininglamposs/octo-search-indexer:latest` tag only exists once a release tag
+> has been cut, and the IK-enabled OpenSearch image
+> (`octo-search-opensearch-ik`) is built locally from
+> `docker/opensearch/Dockerfile` (it is not pushed to a public registry). For a
+> from-scratch community deployment, treat both as **prerequisites**: build the
+> indexer image from a checkout as shown above (or pin a published `v*` tag once
+> one exists), and let Compose build the OpenSearch+IK image on first `up`
+> (`--build`). The IK plugin download pulls from `release.infinilabs.com` at
+> build time, so that host must be reachable from wherever you build.
+
 The OpenSearch image with the IK plugin is built automatically from
 `docker/opensearch/Dockerfile` on first `up` (no manual step).
 
@@ -1222,6 +1238,159 @@ docker compose up -d --build search-opensearch search-kafka search-kafka-init es
 `AllowAutoTopicCreation=false`. The `es-indexer` waits for it plus a healthy
 OpenSearch, then auto-creates the `octo-message` index with the embedded IK
 mapping (`ik_max_word` on the index side, `ik_smart` on the query side).
+
+Bringing the profile up only stands up the **infrastructure** (Kafka,
+OpenSearch, the consumer). It does **not** start indexing your message history
+or flip octo-server onto OpenSearch — that is the "Turn search on" upgrade
+below. A fresh `octo-message` index at this point is empty and the alias is
+unbound; octo-server stays on `OCTO_SEARCH_BACKEND=disabled` until you complete
+the upgrade.
+
+### Turn search on (zero-downtime upgrade for a running stack)
+
+This upgrades a stack that has been running **search-off** to a live search
+deployment without taking the core IM service down. The ordering is
+deliberate — **seed the cursor to the message high-watermark, turn the
+real-time producer on, THEN backfill history** — so no live message is missed
+during the load and the historical stream is never double-ingested. Backfill
+and the live stream overlap safely because every ES write is an idempotent
+upsert keyed on `message_id`.
+
+The whole flow is scripted with an exit-code gate (`G1`..`G5`) after each step:
+
+```bash
+cd docker
+docker/scripts/search-upgrade.sh            # run all 6 steps from the start
+# or resume mid-flow:  docker/scripts/search-upgrade.sh --from 4
+# or just re-run the gates against the current state: --check
+```
+
+The script **persists each state flip into `docker/.env` as it makes it**
+(`COMPOSE_PROFILES=search`, then `OCTO_SEARCH_PRODUCER_ON=true`, then
+`OCTO_SEARCH_BACKEND=es`), so a later ordinary `docker compose up -d` keeps
+search on instead of silently reverting to the search-off defaults. No manual
+`.env` edit is required.
+
+What the script does, and the gate that proves each step:
+
+| Step | Action | Gate (exit-code decisive) |
+|------|--------|---------------------------|
+| 1 | `--profile search up -d` — Kafka + OpenSearch + es-indexer | OpenSearch cluster reports green/yellow |
+| 2 | Seed `octo_etl_es_cursor.last_id = MAX(id)` per shard (`search-cursor-seed` one-shot) | **G1**: every shard cursor ≥ its `MAX(id)` |
+| 3 | Turn the producer on (`OCTO_SEARCH_PRODUCER_ON=true`, recreate octo-server) | **G2**: octo-server up with `TS_KAFKA_ON=true` |
+| 4 | One-shot historical backfill + inline reconcile (`search-backfill`) | **G3**: backfill exits 0 (reconcile count+sample pass) |
+| 5 | Bind the read alias → physical `octo-message` index (atomic, single-pointing) | **G4**: alias resolves to exactly one index |
+| 6 | Switch the reader to `es` (`OCTO_SEARCH_BACKEND=es`, recreate octo-server) | **G5**: reader on `es` and an alias-backed search succeeds |
+
+After a successful run, `docker/.env` ends up carrying:
+
+```dotenv
+COMPOSE_PROFILES=search
+OCTO_SEARCH_BACKEND=es
+OCTO_SEARCH_PRODUCER_ON=true
+```
+
+> `G5` asserts the alias-backed search **succeeds** (the alias resolves and
+> OpenSearch answers), not that the corpus is non-empty — a brand-new install
+> with zero messages upgrades correctly and passes.
+
+**Why each step matters**
+
+- **Step 2 before step 3 (cursor seed before producer):** the searchetl cursor
+  defaults to `0`. If the producer starts there, it re-streams the entire
+  message history into Kafka on top of the one-shot backfill — a full double
+  ingest. Seeding each shard cursor to its current `MAX(id)` first means the
+  producer only carries messages newer than the cut-over. The seed is
+  idempotent and monotonic (`GREATEST`), so re-running never rewinds a cursor.
+- **Step 3 before step 4 (producer before backfill):** turning the live stream
+  on first guarantees no message written *during* the historical load is lost;
+  the overlap is safe because of `_id=message_id` idempotency.
+- **Step 5 after step 4 (alias only after reconcile passes):** the read alias
+  `wukongim-messages-read` is what the reader queries; the indexer/backfill
+  write the *physical* `octo-message` index and deliberately do **not**
+  auto-bind the alias. Binding it only after the reconcile gate (G3) passes
+  guarantees the reader never sees a half-loaded corpus.
+- **Step 6 last (reader flip last):** octo-server only reads OpenSearch once
+  `OCTO_SEARCH_BACKEND=es`. Until then the search entry is hidden client-side
+  and the corpus can be built in the background with zero user-visible impact.
+
+> The two upgrade jobs live behind a **separate** `search-tools` profile, so the
+> everyday `--profile search up -d` never triggers a history reload or a cursor
+> mutation as a side effect. They only run when the script invokes them
+> explicitly (`--profile search-tools run --rm …`).
+
+#### Manual run-through (if you are not using the script)
+
+If you run the steps by hand, the inline env overrides below only affect that
+one recreate. **Persist the flips into `docker/.env`** (`COMPOSE_PROFILES=search`,
+`OCTO_SEARCH_PRODUCER_ON=true`, `OCTO_SEARCH_BACKEND=es`) so a later
+`docker compose up -d` does not revert to the search-off defaults — the script
+does this for you automatically.
+
+```bash
+cd docker
+export COMPOSE_PROFILES=search
+
+# 1. infra
+docker compose up -d --build search-opensearch search-kafka search-kafka-init es-indexer
+
+# 2. seed cursor to high-watermark  (G1)
+COMPOSE_PROFILES=search-tools docker compose run --rm search-cursor-seed
+
+# 3. producer on  (G2)
+OCTO_SEARCH_PRODUCER_ON=true docker compose up -d octo-server
+
+# 4. backfill + inline reconcile gate  (G3 — non-zero exit STOPs here)
+COMPOSE_PROFILES=search-tools docker compose run --rm search-backfill
+
+# 5. bind alias atomically  (G4)
+docker compose exec -T search-opensearch curl -sS -XPOST \
+  http://localhost:9200/_aliases -H 'Content-Type: application/json' -d '{
+    "actions":[
+      {"remove":{"index":"*","alias":"wukongim-messages-read","must_exist":false}},
+      {"add":{"index":"octo-message","alias":"wukongim-messages-read"}}
+    ]}'
+
+# 6. reader -> es  (G5)
+OCTO_SEARCH_BACKEND=es OCTO_SEARCH_PRODUCER_ON=true docker compose up -d octo-server
+
+# 7. persist the end state so `up -d` keeps search on
+printf 'COMPOSE_PROFILES=search\nOCTO_SEARCH_PRODUCER_ON=true\nOCTO_SEARCH_BACKEND=es\n' >> .env
+```
+
+#### Rollback
+
+Search can be turned off (or rolled back to the legacy Zinc path) without data
+loss, because MySQL is the source of truth and OpenSearch is rebuildable:
+
+- **Reader rollback (fastest):** set `OCTO_SEARCH_BACKEND=disabled` (search off,
+  entry hidden) or `=zinc` (legacy path) in `docker/.env` and
+  `docker compose up -d octo-server`. The OpenSearch corpus is left intact for a
+  later retry.
+- **Alias rollback:** if you keep an older physical index around, re-point the
+  alias with the same atomic `_aliases` call (swap the `add` target). See
+  `scripts/forward-migrate.sh` in the octo-search-indexer repo for the staged
+  reindex/alias pattern.
+- **Stop the producer:** set `OCTO_SEARCH_PRODUCER_ON=false` and recreate
+  octo-server; the searchetl scheduler then idles (zero overhead). The cursor is
+  preserved, so re-enabling resumes from where it left off (no re-seed needed).
+
+### Resource baseline (with vs without search)
+
+The `search` profile adds three long-running containers on top of the core
+stack. Rough single-node footprint (idle-to-light load; tune via the `.env`
+vars noted):
+
+| Component | Extra memory (default) | Notes |
+|-----------|------------------------|-------|
+| OpenSearch (single node, IK) | ~1 GiB | JVM heap is `-Xms512m -Xmx512m` (`OCTO_SEARCH_OPENSEARCH_JAVA_OPTS`); the box wants roughly 2× heap headroom. Raise heap for larger corpora. |
+| Kafka (KRaft single broker) | ~0.5–1 GiB | Single broker, RF=1; fine for a single-host deployment. |
+| es-indexer (consumer) | ~50–100 MiB | Lightweight Go worker. |
+
+Plus disk for three named volumes (`opensearch-data`, `kafka-data`,
+`search-dlq-spill`) and a transient `search-backfill-state` volume for the
+backfill checkpoint. A search-off deployment carries **none** of this — the core
+stack (server/nginx/mysql/redis/minio/wukongim) is byte-for-byte unchanged.
 
 ### End-to-end check (local)
 
@@ -1283,14 +1452,14 @@ cd docker
 # 1. Stop + remove ONLY the search-profile containers (by name). -p octo pins
 #    the project so this never touches another stack; core services are not
 #    listed, so they are left running and untouched.
-docker compose -p octo rm -sf search-kafka search-kafka-init search-opensearch es-indexer
+docker compose -p octo rm -sf search-kafka search-kafka-init search-opensearch es-indexer search-cursor-seed search-backfill
 
 # 2. (local validation only) Remove ONLY the search-specific named volumes.
 #    Core volumes (mysql-data, redis-data, ...) are NOT listed and NOT touched.
 #    Volume names follow `name: ${COMPOSE_PROJECT_NAME:-octo}_*` from the
 #    compose file; for the default project that is the `octo_` prefix. If you
 #    run a non-default COMPOSE_PROJECT_NAME, substitute it here.
-docker volume rm octo_opensearch-data octo_kafka-data octo_search-dlq-spill
+docker volume rm octo_opensearch-data octo_kafka-data octo_search-dlq-spill octo_search-backfill-state
 ```
 
 If you set a custom `COMPOSE_PROJECT_NAME` (e.g. `octo-fz`), use `-p <name>` in

--- a/docker/README.md
+++ b/docker/README.md
@@ -1260,8 +1260,8 @@ The whole flow is scripted with an exit-code gate (`G1`..`G5`) after each step:
 
 ```bash
 cd docker
-docker/scripts/search-upgrade.sh            # run all 6 steps from the start
-# or resume mid-flow:  docker/scripts/search-upgrade.sh --from 4
+scripts/search-upgrade.sh                    # run all 6 steps from the start
+# or resume mid-flow:  scripts/search-upgrade.sh --from 4
 # or just re-run the gates against the current state: --check
 ```
 
@@ -1327,9 +1327,20 @@ one recreate. **Persist the flips into `docker/.env`** (`COMPOSE_PROFILES=search
 `docker compose up -d` does not revert to the search-off defaults — the script
 does this for you automatically.
 
+> ⚠️ **`COMPOSE_PROFILES` is a single comma-separated list — union, never
+> overwrite.** If you already run another profile (e.g. `summary`), a bare
+> `COMPOSE_PROFILES=search` (exported here, or appended to `.env`) silently drops
+> it, because Compose takes the *last* assignment of a key. Add `search` to the
+> existing value instead of replacing it. The script's `persist_profile` does
+> this merge for you; the manual steps below show the equivalent by hand.
+
 ```bash
 cd docker
-export COMPOSE_PROFILES=search
+# Union `search` into any profile you already run (e.g. summary), don't clobber.
+# Read only the COMPOSE_PROFILES line from .env — never `source` .env (it holds
+# passwords / DSNs that are not safe to eval as shell).
+existing="$(grep -E '^COMPOSE_PROFILES=' .env | tail -1 | cut -d= -f2-)"
+export COMPOSE_PROFILES="${existing:+$existing,}search"
 
 # 1. infra
 docker compose up -d --build search-opensearch search-kafka search-kafka-init es-indexer
@@ -1354,8 +1365,19 @@ docker compose exec -T search-opensearch curl -sS -XPOST \
 # 6. reader -> es  (G5)
 OCTO_SEARCH_BACKEND=es OCTO_SEARCH_PRODUCER_ON=true docker compose up -d octo-server
 
-# 7. persist the end state so `up -d` keeps search on
-printf 'COMPOSE_PROFILES=search\nOCTO_SEARCH_PRODUCER_ON=true\nOCTO_SEARCH_BACKEND=es\n' >> .env
+# 7. persist the end state so `up -d` keeps search on.
+#    NOTE: append OCTO_SEARCH_* freely, but COMPOSE_PROFILES must be MERGED, not
+#    appended — a second COMPOSE_PROFILES=search line would override (drop) any
+#    profile already in .env. Rewrite the single COMPOSE_PROFILES line in place
+#    (portable awk, no sed -i flavor issues):
+printf 'OCTO_SEARCH_PRODUCER_ON=true\nOCTO_SEARCH_BACKEND=es\n' >> .env
+if grep -qE '^COMPOSE_PROFILES=' .env; then
+  awk -F= 'BEGIN{OFS="="}
+    $1=="COMPOSE_PROFILES" && $0 !~ /(,|=)search(,|$)/ {$0=$0",search"}
+    {print}' .env > .env.tmp && mv .env.tmp .env
+else
+  echo 'COMPOSE_PROFILES=search' >> .env
+fi
 ```
 
 #### Rollback

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -109,6 +109,12 @@ volumes:
   # spill accounting (octo-search-indexer phase 6) is defeated.
   search-dlq-spill:
     name: ${COMPOSE_PROJECT_NAME:-octo}_search-dlq-spill
+  # Backfill checkpoint + DLQ spill (one-shot historical loader, `search-tools`
+  # profile). Persisted so a backfill that is interrupted (SIGTERM / host
+  # reboot) resumes from its last keyset high-watermark instead of re-scanning
+  # from zero. Separate from search-dlq-spill (the live indexer's spill).
+  search-backfill-state:
+    name: ${COMPOSE_PROJECT_NAME:-octo}_search-backfill-state
 
 services:
   # ---------------------------------------------------------------------------
@@ -715,6 +721,56 @@ services:
       # Leave OCTO_ADMIN_PWD empty in .env to skip auto-bootstrap
       # (create admin manually via API).
       TS_ADMINPWD: ${OCTO_ADMIN_PWD:-}
+      # -----------------------------------------------------------------
+      # Message search backend (opt-in `search` profile)
+      # -----------------------------------------------------------------
+      # OCTO_SEARCH_BACKEND is the SINGLE switch octo-server reads to decide
+      # whether any message-search surface serves. It is read directly via
+      # os.Getenv (NOT the TS_/Viper path), three explicit states:
+      #
+      #   disabled — every _search* endpoint returns SEARCH_DISABLED and the
+      #              client app_config advertises search_enabled=false, so the
+      #              frontend hides the search entry instead of probing a dead
+      #              backend. The server NEVER dials OpenSearch (the ES client
+      #              is built lazily on first request, and the backend gate
+      #              short-circuits before that), so a no-search deployment
+      #              boots clean with zero UPSTREAM_UNAVAILABLE noise.
+      #   es       — the OpenSearch _search* endpoints serve (legacy Zinc off).
+      #   zinc     — rollback to the legacy WuKongIM→Zinc path (ES off).
+      #
+      # Default here is `disabled`: a vanilla `docker compose up` runs no
+      # search infrastructure, so the only correct posture is "search off,
+      # cleanly". The `search` profile upgrade (docker/README.md "Turn search
+      # on") flips this to `es` and restarts octo-server as its final step.
+      # Leaving it UNSET would make octo-server assume the pre-switch default
+      # (ES on) and hammer a non-existent OpenSearch on the first search call.
+      OCTO_SEARCH_BACKEND: ${OCTO_SEARCH_BACKEND:-disabled}
+      # Where the reader finds OpenSearch + which read alias it queries. Only
+      # consulted when OCTO_SEARCH_BACKEND=es; harmless (unread) when disabled.
+      # The reader queries the ALIAS, never the physical index — the alias is
+      # bound to the physical `octo-message` index by the upgrade flow only
+      # after backfill + reconcile pass (see docker/README.md "Turn search on").
+      OCTO_SEARCH_OS_ADDRS: ${OCTO_SEARCH_OS_ADDRS:-http://search-opensearch:9200}
+      OCTO_SEARCH_OS_READ_ALIAS: ${OCTO_SEARCH_OS_READ_ALIAS:-wukongim-messages-read}
+      # Per-deployment HMAC key for the opaque search pagination cursor. Unset
+      # falls back to a published constant (forgeable but carries no authz);
+      # set a random value in .env for any real search deployment.
+      OCTO_SEARCH_CURSOR_HMAC: ${OCTO_SEARCH_CURSOR_HMAC:-}
+      # -----------------------------------------------------------------
+      # Real-time search producer (searchetl → Kafka) — OFF by default
+      # -----------------------------------------------------------------
+      # The searchetl module streams new messages into Kafka for the indexer
+      # to consume. It is gated by Kafka.On (Viper key kafka.on ← TS_KAFKA_ON);
+      # OFF means the scheduler never starts (zero overhead) and is the correct
+      # state for a no-search deployment. The `search` profile upgrade turns it
+      # on ONLY AFTER the extraction cursor has been seeded to each message
+      # shard's high-watermark — otherwise the cursor starts at 0 and the
+      # producer re-streams the entire message history (a full double-ingest on
+      # top of the one-shot backfill). See docker/README.md "Turn search on".
+      TS_KAFKA_ON: ${OCTO_SEARCH_PRODUCER_ON:-false}
+      TS_KAFKA_BROKERS: ${OCTO_SEARCH_KAFKA_BROKERS:-search-kafka:9092}
+      TS_KAFKA_TOPIC: ${OCTO_SEARCH_KAFKA_TOPIC:-octo.message.v1}
+      TS_KAFKA_DLQTOPIC: ${OCTO_SEARCH_KAFKA_DLQ_TOPIC:-octo.message.v1.dlq}
     depends_on:
       preflight:
         condition: service_completed_successfully
@@ -1175,5 +1231,131 @@ services:
       INDEXER_DLQ_SPILL_DIR: /var/lib/es-indexer/dlq-spill
     volumes:
       - search-dlq-spill:/var/lib/es-indexer/dlq-spill
+    networks:
+      - octo-net
+
+  # ===========================================================================
+  # Search upgrade tooling (one-shot) — `search-tools` profile, NOT `search`
+  # ===========================================================================
+  # These two jobs implement the irreversible "light search up" steps of the
+  # upgrade flow (docker/README.md "Turn search on"). They are gated behind a
+  # SEPARATE profile so that the everyday `COMPOSE_PROFILES=search up -d` (which
+  # brings up the infrastructure: Kafka + OpenSearch + indexer) NEVER triggers a
+  # historical reload or a cursor mutation as a side effect. The upgrade script
+  # (docker/scripts/search-upgrade.sh) runs them explicitly, in order, each with
+  # an exit-code gate.
+  #
+  #   1. search-cursor-seed — seeds the searchetl extraction cursor to each
+  #      message shard's current MAX(id) BEFORE the real-time producer is turned
+  #      on. Without this the cursor starts at 0 and the producer would re-stream
+  #      the entire message history (a full double-ingest on top of backfill).
+  #   2. search-backfill — one-shot historical loader (MySQL shards →
+  #      OpenSearch, bypassing Kafka) with an inline reconcile gate. Exits
+  #      non-zero on any count/sample mismatch so the upgrade script stops before
+  #      the alias is bound.
+  #
+  # Both are idempotent and resumable; both only ever appear with
+  # `--profile search-tools`.
+  # ---------------------------------------------------------------------------
+  search-cursor-seed:
+    image: mysql:8.0
+    restart: "no"
+    profiles: ["search-tools"]
+    environment:
+      TZ: ${TZ:-UTC}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-octo}
+      # Comma-separated message shard tables (defaults match the searchetl /
+      # backfill contract: the 5 WuKongIM message shards).
+      OCTO_SEARCH_SHARD_TABLES: ${OCTO_SEARCH_SHARD_TABLES:-message,message1,message2,message3,message4}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -eu
+        # Seed octo_etl_es_cursor.last_id = MAX(id) for every shard so the
+        # real-time producer (turned on in the next step) only streams messages
+        # newer than the backfill cut-over, never the full history.
+        #
+        # Idempotent + monotonic: GREATEST(existing,new) so re-running never
+        # rewinds a cursor that has already advanced past this point (which
+        # would replay messages). INSERT ... ON DUPLICATE KEY UPDATE upserts the
+        # per-shard row that searchetl's own ensureCursor also creates.
+        #
+        # Requires the octo_etl_es_cursor table to exist — octo-server creates
+        # it via the searchetl migration on first boot, so run this only after
+        # the core stack has come up at least once.
+        DB="${MYSQL_DATABASE:-octo}"
+        run_sql() { MYSQL_PWD="$$MYSQL_ROOT_PASSWORD" mysql -h mysql -u root -N -B "$$DB" -e "$$1"; }
+        echo "[cursor-seed] verifying octo_etl_es_cursor exists in $$DB"
+        if [ "$$(run_sql "SHOW TABLES LIKE 'octo_etl_es_cursor';" | wc -l)" -eq 0 ]; then
+          echo "[cursor-seed] FATAL: table octo_etl_es_cursor not found — bring the core stack up once so octo-server runs the searchetl migration, then retry." >&2
+          exit 1
+        fi
+        IFS=','
+        for t in $$OCTO_SEARCH_SHARD_TABLES; do
+          t="$$(echo "$$t" | tr -d ' ')"
+          [ -z "$$t" ] && continue
+          # Validate the shard name as a strict SQL identifier before it is
+          # interpolated into a statement. The list is operator-controlled, not
+          # remote input, but a typo or hostile value must not become arbitrary
+          # SQL run as root. Reject anything outside [A-Za-z0-9_].
+          case "$$t" in
+            *[!A-Za-z0-9_]*)
+              echo "[cursor-seed] FATAL: invalid shard table name '$$t' (allowed: A-Za-z0-9_)" >&2
+              exit 1
+              ;;
+          esac
+          if [ "$$(run_sql "SHOW TABLES LIKE '$$t';" | wc -l)" -eq 0 ]; then
+            echo "[cursor-seed] WARN: shard table '$$t' not present, skipping"
+            continue
+          fi
+          MAXID="$$(run_sql "SELECT COALESCE(MAX(id),0) FROM \`$$t\`;")"
+          run_sql "INSERT INTO octo_etl_es_cursor (shard_table,last_id) VALUES ('$$t',$$MAXID) ON DUPLICATE KEY UPDATE last_id=GREATEST(last_id,VALUES(last_id));"
+          NOW="$$(run_sql "SELECT last_id FROM octo_etl_es_cursor WHERE shard_table='$$t';")"
+          echo "[cursor-seed] $$t: MAX(id)=$$MAXID cursor now=$$NOW"
+        done
+        echo "[cursor-seed] done — searchetl cursor seeded to high-watermark"
+    depends_on:
+      mysql:
+        condition: service_healthy
+    networks:
+      - octo-net
+
+  search-backfill:
+    image: ${OCTO_SEARCH_INDEXER_IMAGE:-mininglamposs/octo-search-indexer:latest}
+    restart: "no"
+    profiles: ["search-tools"]
+    # Run the bundled one-shot backfill binary (the same image also ships
+    # es-indexer + reconcile). Bypasses Kafka: reads the MySQL shards directly
+    # and bulk-writes the physical octo-message index, then runs the inline
+    # reconcile gate (count + field-level sample). A mismatch exits non-zero so
+    # the upgrade script stops before binding the read alias.
+    entrypoint: ["/usr/local/bin/backfill"]
+    command:
+      - "-mysql-dsn=root:${MYSQL_ROOT_PASSWORD}@tcp(mysql:3306)/${MYSQL_DATABASE:-octo}?charset=utf8mb4&parseTime=true&loc=Local"
+      - "-tables=${OCTO_SEARCH_SHARD_TABLES:-message,message1,message2,message3,message4}"
+      - "-es=http://search-opensearch:9200"
+      - "-es-index=${OCTO_SEARCH_ES_INDEX:-octo-message}"
+      - "-es-user=${OCTO_SEARCH_ES_USERNAME:-}"
+      - "-es-pass=${OCTO_SEARCH_ES_PASSWORD:-}"
+      - "-spill-dir=/var/lib/octo-backfill/dlq"
+      - "-checkpoint=/var/lib/octo-backfill/checkpoint.json"
+      - "-rate=${OCTO_SEARCH_BACKFILL_RATE:-5000}"
+      - "-batch=${OCTO_SEARCH_BACKFILL_BATCH:-1000}"
+      - "-reconcile"
+      - "-from=${OCTO_SEARCH_BACKFILL_FROM:-0}"
+      - "-to=${OCTO_SEARCH_BACKFILL_TO:-0}"
+    volumes:
+      - search-backfill-state:/var/lib/octo-backfill
+    # Only depends on the core mysql service (always defined). It deliberately
+    # does NOT hard-depend on search-opensearch (a `search`-profile service):
+    # a depends_on across profiles makes `docker compose config` reject the
+    # stack whenever the other profile is inactive. The upgrade script
+    # (search-upgrade.sh) gates on a healthy OpenSearch via an explicit
+    # exit-code check before invoking this job, so the ordering guarantee lives
+    # in the script, not in a fragile cross-profile depends_on.
+    depends_on:
+      mysql:
+        condition: service_healthy
     networks:
       - octo-net

--- a/docker/scripts/search-upgrade.sh
+++ b/docker/scripts/search-upgrade.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Hot-upgrade an already-running OCTO stack from "search off" to "search on"
+# WITHOUT downtime for the core IM service. Idempotent and re-entrant: every
+# step is safe to re-run, and each ends with an exit-code gate (G1..G5) so the
+# whole flow is mechanically verifiable in CI or by an operator.
+# -----------------------------------------------------------------------------
+# State machine (producer-first + high-watermark cursor-seed ordering):
+#
+#   no search
+#     -> (1) docker compose --profile search up -d   (Kafka + OpenSearch + indexer)
+#     -> (2) seed searchetl cursor to each shard's MAX(id)        [G1]
+#     -> (3) turn the real-time producer on (octo-server restart) [G2]
+#     -> (4) one-shot backfill of history + inline reconcile gate [G3]
+#     -> (5) bind read alias -> physical octo-message index       [G4]
+#     -> (6) switch octo-server reader to es + restart            [G5]
+#   search live
+#
+# Why this order: the producer is turned on (step 3) BEFORE backfill (step 4)
+# so no live message written during the historical load is missed — the cursor
+# was seeded to the high-watermark first (step 2) so the producer only streams
+# messages newer than the cut-over, never the full history. Backfill and the
+# live stream overlap safely because the ES doc _id = message_id makes every
+# write an idempotent upsert.
+#
+# Usage:
+#   docker/scripts/search-upgrade.sh            # run all steps from the start
+#   docker/scripts/search-upgrade.sh --from 3   # resume at step N (1..6)
+#   docker/scripts/search-upgrade.sh --check     # run only the verification
+#                                                # gates against current state
+#
+# All `docker compose` calls run from docker/ with the repo's compose file.
+# Override OCTO_SEARCH_* in docker/.env exactly as the compose file documents.
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKER_DIR="$(cd "$HERE/.." && pwd)"
+cd "$DOCKER_DIR"
+
+# Pull the index / alias / shard settings from docker/.env (the same file
+# Compose reads) so this script resolves them from the SAME source of truth the
+# running stack uses. Without this, a documented OCTO_SEARCH_* override in .env
+# would steer octo-server / the compose jobs one way while the script bound or
+# checked another (wrong alias, wrong shards, a G5 that passes against an alias
+# octo-server is not configured to read).
+#
+# We do NOT `source` the whole file (it holds passwords / DSNs that are not safe
+# to eval as shell); we read only the three keys this script needs, and only
+# when not already set in the environment (shell env wins, matching Compose).
+ENV_FILE="${ENV_FILE:-$DOCKER_DIR/.env}"
+env_get() {
+  # last uncommented KEY=VALUE wins (Compose semantics); strip surrounding quotes.
+  [ -f "$ENV_FILE" ] || return 0
+  grep -E "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2- | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/"
+}
+: "${OCTO_SEARCH_ES_INDEX:=$(env_get OCTO_SEARCH_ES_INDEX)}"
+: "${OCTO_SEARCH_OS_READ_ALIAS:=$(env_get OCTO_SEARCH_OS_READ_ALIAS)}"
+: "${OCTO_SEARCH_SHARD_TABLES:=$(env_get OCTO_SEARCH_SHARD_TABLES)}"
+
+# Resolve the docker compose CLI (v2 plugin or legacy binary).
+if docker compose version >/dev/null 2>&1; then
+  DC=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  DC=(docker-compose)
+else
+  echo "FATAL: neither 'docker compose' nor 'docker-compose' is available" >&2
+  exit 2
+fi
+
+ES_INDEX="${OCTO_SEARCH_ES_INDEX:-octo-message}"
+READ_ALIAS="${OCTO_SEARCH_OS_READ_ALIAS:-wukongim-messages-read}"
+SHARDS="${OCTO_SEARCH_SHARD_TABLES:-message,message1,message2,message3,message4}"
+
+log()  { printf '\n\033[1m=== %s ===\033[0m\n' "$*"; }
+ok()   { printf '\033[32m[PASS]\033[0m %s\n' "$*"; }
+fail() { printf '\033[31m[FAIL]\033[0m %s\n' "$*" >&2; exit 1; }
+
+# persist_env durably writes KEY=VALUE into docker/.env so the live state set by
+# a step survives the NEXT ordinary `docker compose up -d` (otherwise a recreate
+# before the operator hand-edits .env would silently revert search to off). It
+# replaces an existing uncommented assignment in place, else appends. Compose
+# auto-loads docker/.env from this directory, so this is the single source of
+# truth the running stack reads (and the file this script sourced on startup).
+persist_env() {
+  local key="$1" val="$2"
+  touch "$ENV_FILE"
+  if grep -qE "^${key}=" "$ENV_FILE"; then
+    # in-place replace (portable: rewrite via tmp file, no sed -i flavor issues)
+    awk -v k="$key" -v v="$val" \
+      'BEGIN{FS=OFS="="} $1==k{print k"="v; next} {print}' \
+      "$ENV_FILE" > "$ENV_FILE.tmp" && mv "$ENV_FILE.tmp" "$ENV_FILE"
+  else
+    printf '%s=%s\n' "$key" "$val" >> "$ENV_FILE"
+  fi
+  echo "  persisted ${key}=${val} -> ${ENV_FILE}"
+}
+
+# persist_profile adds a profile to COMPOSE_PROFILES in docker/.env WITHOUT
+# clobbering profiles already enabled (e.g. `summary`). It reads the current
+# value (env wins over .env, like Compose), unions in the new profile, and
+# writes the comma-joined, de-duplicated result back.
+persist_profile() {
+  local add="$1" current merged
+  current="${COMPOSE_PROFILES:-$(env_get COMPOSE_PROFILES)}"
+  # union: keep existing order, append `add` only if not already present.
+  merged="$(printf '%s' "$current" | tr ',' '\n' | sed '/^[[:space:]]*$/d' \
+    | awk -v a="$add" '{print} $0==a{seen=1} END{if(!seen)print a}' \
+    | paste -sd, -)"
+  COMPOSE_PROFILES="$merged"
+  persist_env COMPOSE_PROFILES "$merged"
+}
+
+# os_curl runs a curl INSIDE the search-opensearch container so we do not depend
+# on the host being able to reach the loopback-bound OpenSearch port, and it
+# works regardless of OCTO_SEARCH_OPENSEARCH_BIND. First arg is the URL path;
+# any further args pass through to curl (e.g. -XPOST -d '{...}').
+os_curl() {
+  local path="$1"; shift
+  "${DC[@]}" exec -T search-opensearch \
+    curl -sS -H 'Content-Type: application/json' "$@" "http://localhost:9200${path}"
+}
+
+# --------------------------------------------------------------------------
+# Steps
+# --------------------------------------------------------------------------
+
+step1_infra_up() {
+  log "Step 1/6: bring the search infrastructure up (Kafka + OpenSearch + indexer)"
+  # Persist the profile so a future `docker compose up -d` keeps the search
+  # infrastructure running (and so the search-tools jobs below resolve). Merges
+  # into any existing COMPOSE_PROFILES (e.g. summary) rather than replacing it.
+  persist_profile search
+  COMPOSE_PROFILES=search "${DC[@]}" up -d --build \
+    search-opensearch search-kafka search-kafka-init es-indexer
+  echo "Waiting for OpenSearch to report a non-red cluster status..."
+  for _ in $(seq 1 40); do
+    status="$(os_curl "/_cluster/health" 2>/dev/null | grep -o '"status":"[a-z]*"' || true)"
+    case "$status" in
+      *green*|*yellow*) ok "OpenSearch cluster is up ($status)"; return 0 ;;
+    esac
+    sleep 3
+  done
+  fail "OpenSearch did not become ready in time"
+}
+
+step2_seed_cursor() {
+  log "Step 2/6: seed the searchetl extraction cursor to each shard's high-watermark"
+  # One-shot job; --abort-on-container-exit surfaces its exit code as ours.
+  COMPOSE_PROFILES=search-tools "${DC[@]}" run --rm search-cursor-seed
+  gate_G1
+}
+
+step3_producer_on() {
+  log "Step 3/6: turn the real-time producer on (octo-server restart, TS_KAFKA_ON=true)"
+  # Persist BEFORE recreating so the live state and docker/.env never diverge —
+  # a later ordinary `docker compose up -d` will not silently revert the flip.
+  persist_env OCTO_SEARCH_PRODUCER_ON true
+  "${DC[@]}" up -d octo-server
+  gate_G2
+}
+
+step4_backfill() {
+  log "Step 4/6: one-shot historical backfill + inline reconcile gate"
+  gate_opensearch_reachable
+  COMPOSE_PROFILES=search-tools "${DC[@]}" run --rm search-backfill
+  gate_G3
+}
+
+step5_bind_alias() {
+  log "Step 5/6: bind the read alias -> physical index (atomic, single-pointing)"
+  # remove the alias from ANY index it currently points at (must_exist:false so
+  # the first bind does not error), then add it to the physical index — one
+  # atomic _aliases call, no half-new/half-old window.
+  os_curl "/_aliases" -XPOST -d "{
+    \"actions\": [
+      { \"remove\": { \"index\": \"*\", \"alias\": \"${READ_ALIAS}\", \"must_exist\": false } },
+      { \"add\":    { \"index\": \"${ES_INDEX}\", \"alias\": \"${READ_ALIAS}\" } }
+    ]
+  }" | grep -q '"acknowledged":true' || fail "alias bind call was not acknowledged"
+  gate_G4
+}
+
+step6_reader_es() {
+  log "Step 6/6: switch the octo-server reader to es + restart"
+  # Persist BEFORE recreating so docker/.env reflects the live reader backend.
+  persist_env OCTO_SEARCH_BACKEND es
+  "${DC[@]}" up -d octo-server
+  gate_G5
+}
+
+# --------------------------------------------------------------------------
+# Gates (each is exit-code decisive)
+# --------------------------------------------------------------------------
+
+gate_opensearch_reachable() {
+  os_curl "/_cluster/health" >/dev/null 2>&1 \
+    || fail "OpenSearch is not reachable — run step 1 first"
+}
+
+# G1: every present shard's cursor >= that shard's MAX(id) (seeded, not zero).
+gate_G1() {
+  log "Gate G1: searchetl cursor seeded to high-watermark"
+  local bad=0
+  # Split the comma-separated shard list without disturbing the default IFS the
+  # `read` below relies on for tab-splitting MySQL's -B output.
+  local shard_list
+  shard_list="$(echo "$SHARDS" | tr ',' ' ')"
+  for t in $shard_list; do
+    t="$(echo "$t" | tr -d ' ')"; [ -z "$t" ] && continue
+    # Reject anything that is not a strict SQL identifier before interpolating.
+    case "$t" in
+      *[!A-Za-z0-9_]*) fail "G1: invalid shard table name '$t' (allowed: A-Za-z0-9_)" ;;
+    esac
+    exists="$("${DC[@]}" exec -T mysql sh -lc \
+      "MYSQL_PWD=\"\$MYSQL_ROOT_PASSWORD\" mysql -N -B \"\${MYSQL_DATABASE:-octo}\" -e \"SHOW TABLES LIKE '$t';\"" 2>/dev/null | wc -l)"
+    [ "$exists" -eq 0 ] && { echo "  $t: absent (skipped)"; continue; }
+    read -r maxid cur <<EOF2
+$("${DC[@]}" exec -T mysql sh -lc \
+  "MYSQL_PWD=\"\$MYSQL_ROOT_PASSWORD\" mysql -N -B \"\${MYSQL_DATABASE:-octo}\" -e \"SELECT COALESCE(MAX(id),0), COALESCE((SELECT last_id FROM octo_etl_es_cursor WHERE shard_table='$t'),-1) FROM \\\`$t\\\`;\"" 2>/dev/null)
+EOF2
+    if [ "${cur:--1}" -ge "${maxid:-0}" ] && [ "${cur:--1}" -ge 0 ]; then
+      echo "  $t: cursor=$cur >= max=$maxid"
+    else
+      echo "  $t: cursor=$cur < max=$maxid  <-- NOT seeded"; bad=1
+    fi
+  done
+  if [ "$bad" -eq 0 ]; then
+    ok "all shard cursors at/above high-watermark"
+  else
+    fail "G1: a shard cursor is below its MAX(id) — producer would double-ingest history"
+  fi
+}
+
+# G2: the producer is running (octo-server up with TS_KAFKA_ON=true).
+gate_G2() {
+  log "Gate G2: real-time producer is on"
+  local on
+  # shellcheck disable=SC2016  # ${TS_KAFKA_ON} must expand INSIDE the container, not here.
+  on="$("${DC[@]}" exec -T octo-server sh -lc 'echo "${TS_KAFKA_ON:-}"' 2>/dev/null | tr -d '\r')"
+  [ "$on" = "true" ] || fail "G2: octo-server TS_KAFKA_ON is '$on', expected 'true'"
+  # The searchetl scheduler logs a start line when Kafka.On gates it through.
+  ok "octo-server is running with TS_KAFKA_ON=true (producer scheduler active)"
+}
+
+# G3: when run right after step 4, the backfill job exited 0 — which means its
+# INLINE reconcile gate passed (the job fails non-zero on any count/sample
+# mismatch). This gate then re-asserts the index is readable. In --check mode it
+# CANNOT re-derive the historical reconcile (the backfill is not re-run), so it
+# only verifies the index is readable and says so honestly.
+gate_G3() {
+  if [ "${CHECK_MODE:-0}" = "1" ]; then
+    log "Gate G3: index readable (--check: reconcile NOT re-verified here)"
+  else
+    log "Gate G3: backfill exited 0 (inline reconcile passed) + index readable"
+  fi
+  local count
+  count="$(os_curl "/${ES_INDEX}/_count" 2>/dev/null | grep -o '"count":[0-9]*' | head -1 | cut -d: -f2)"
+  [ -n "${count:-}" ] || fail "G3: could not read ${ES_INDEX} doc count"
+  echo "  ${ES_INDEX} doc count = $count"
+  if [ "${CHECK_MODE:-0}" = "1" ]; then
+    echo "  (--check only reads _count; reconcile correctness is proven by the"
+    echo "   backfill exit code at step 4 — re-run 'search-upgrade.sh --from 4'"
+    echo "   to re-gate it.)"
+    ok "index ${ES_INDEX} is readable (reconcile not re-verified in --check)"
+  else
+    ok "backfill reconcile gate passed at step 4; index ${ES_INDEX} is readable"
+  fi
+}
+
+# G4: the read alias resolves to exactly one index — the physical index.
+gate_G4() {
+  log "Gate G4: read alias bound to the physical index (single-pointing)"
+  local bound
+  bound="$(os_curl "/_alias/${READ_ALIAS}" 2>/dev/null || true)"
+  echo "$bound" | grep -q "\"${ES_INDEX}\"" \
+    || fail "G4: alias ${READ_ALIAS} is not bound to ${ES_INDEX} (got: $bound)"
+  # Reject a multi-index alias (half-new/half-old would serve partial data).
+  # The _alias response is keyed by index name, each carrying one "aliases"
+  # object, so the count of "aliases" occurrences == number of indices bound.
+  local n
+  n="$(echo "$bound" | grep -o '"aliases"' | wc -l | tr -d ' ')"
+  [ "$n" -eq 1 ] || fail "G4: alias ${READ_ALIAS} points at $n indices (must be exactly 1): $bound"
+  ok "alias ${READ_ALIAS} -> ${ES_INDEX} (single-pointing)"
+}
+
+# G5: the reader is on es AND a real query through the alias SUCCEEDS (the alias
+# resolves and OpenSearch answers). A zero-message deployment is a valid pass —
+# we assert the search path works, not that the corpus is non-empty.
+gate_G5() {
+  log "Gate G5: reader switched to es and the alias serves real results"
+  local be
+  # shellcheck disable=SC2016  # ${OCTO_SEARCH_BACKEND} must expand INSIDE the container, not here.
+  be="$("${DC[@]}" exec -T octo-server sh -lc 'echo "${OCTO_SEARCH_BACKEND:-}"' 2>/dev/null | tr -d '\r')"
+  [ "$be" = "es" ] || fail "G5: octo-server OCTO_SEARCH_BACKEND is '$be', expected 'es'"
+  # A match_all through the read alias must SUCCEED (a real response with a hit
+  # total proves the alias resolves to a real index and OpenSearch is serving).
+  # We deliberately do NOT require hits>=1: a brand-new / empty install upgrades
+  # correctly and legitimately has zero messages.
+  local resp hits
+  resp="$(os_curl "/${READ_ALIAS}/_search" -XPOST -d '{"size":0,"query":{"match_all":{}}}' 2>/dev/null || true)"
+  echo "$resp" | grep -q '"hits"' \
+    || fail "G5: alias ${READ_ALIAS} did not answer a search (got: $resp)"
+  hits="$(echo "$resp" | grep -o '"value":[0-9]*' | head -1 | cut -d: -f2)"
+  echo "  alias ${READ_ALIAS} total hits = ${hits:-0}"
+  if [ "${hits:-0}" -ge 1 ]; then
+    ok "reader on es; alias-backed search returns ${hits} hit(s) — search is live"
+  else
+    ok "reader on es; alias-backed search succeeds (corpus currently empty — valid for a fresh install)"
+  fi
+}
+
+run_all_gates() {
+  gate_opensearch_reachable
+  gate_G1; gate_G2; gate_G3; gate_G4; gate_G5
+  if [ "${CHECK_MODE:-0}" = "1" ]; then
+    log "Gates G1,G2,G4,G5 verified live; G3 confirmed the index is readable (reconcile not re-run in --check)."
+  else
+    log "All gates G1..G5 passed — search is live and self-consistent."
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Driver
+# --------------------------------------------------------------------------
+FROM_STEP=1
+CHECK_MODE=0
+case "${1:-}" in
+  --check) CHECK_MODE=1; run_all_gates; exit 0 ;;
+  --from)  FROM_STEP="${2:-1}" ;;
+  "" ) ;;
+  *) echo "usage: $0 [--from N | --check]"; exit 2 ;;
+esac
+
+[ "$FROM_STEP" -le 1 ] && step1_infra_up
+[ "$FROM_STEP" -le 2 ] && step2_seed_cursor
+[ "$FROM_STEP" -le 3 ] && step3_producer_on
+[ "$FROM_STEP" -le 4 ] && step4_backfill
+[ "$FROM_STEP" -le 5 ] && step5_bind_alias
+[ "$FROM_STEP" -le 6 ] && step6_reader_es
+
+log "Upgrade complete — search is live."
+echo "  The live state has been persisted to ${ENV_FILE}:"
+echo "    COMPOSE_PROFILES=search"
+echo "    OCTO_SEARCH_BACKEND=es"
+echo "    OCTO_SEARCH_PRODUCER_ON=true"
+echo "  so a future 'docker compose up -d' keeps search on. Re-run with --check"
+echo "  at any time to re-assert gates G1..G5 against the running stack."

--- a/docker/scripts/search-upgrade.sh
+++ b/docker/scripts/search-upgrade.sh
@@ -332,6 +332,16 @@ case "${1:-}" in
   *) echo "usage: $0 [--from N | --check]"; exit 2 ;;
 esac
 
+# Validate --from: must be an integer 1..6 (the step count). Without this guard,
+# `--from 7` would skip every step and `--from foo` would crash inside the `-le`
+# arithmetic — either way the script could fall through to "Upgrade complete" and
+# report a false success without having run anything.
+if ! [[ "$FROM_STEP" =~ ^[1-6]$ ]]; then
+  echo "error: --from must be an integer 1..6 (got '${FROM_STEP}')" >&2
+  echo "usage: $0 [--from N | --check]" >&2
+  exit 2
+fi
+
 [ "$FROM_STEP" -le 1 ] && step1_infra_up
 [ "$FROM_STEP" -le 2 ] && step2_seed_cursor
 [ "$FROM_STEP" -le 3 ] && step3_producer_on


### PR DESCRIPTION
## What

Complete the opt-in message-search pipeline so a **default deployment runs search-free and clean**, and add a **scripted, gated hot-upgrade** that turns search on without core-service downtime.

PR #114 made the search infrastructure (Kafka + OpenSearch + es-indexer) opt-in behind the `search` compose profile. This PR closes the remaining wiring gaps so the profile is actually self-consistent, and ships the upgrade flow to light search up on a running stack.

## octo-server search wiring (compose env)

- **`OCTO_SEARCH_BACKEND` defaults to `disabled`.** This is the single switch octo-server reads (directly via `os.Getenv`) to decide whether any search surface serves. A vanilla `docker compose up` now hides the search entry client-side and **never dials OpenSearch** — clean boot, no `UPSTREAM_UNAVAILABLE` log noise. Leaving it unset would make octo-server assume its legacy "ES on" default and hammer a non-existent OpenSearch on the first search call.
- **`OCTO_SEARCH_OS_ADDRS` / `OCTO_SEARCH_OS_READ_ALIAS`** point the reader at the in-network OpenSearch and the read alias (the reader queries the alias, never the physical index).
- **`TS_KAFKA_ON` (real-time producer) defaults off.** Turned on only after the extraction cursor is seeded to the message high-watermark.

## Upgrade tooling (separate `search-tools` profile)

Two one-shot jobs, gated behind a **separate** profile so the everyday `--profile search up -d` never triggers a history reload or a cursor mutation as a side effect:

- `search-cursor-seed` — idempotent, monotonic seed of the searchetl cursor to each shard's `MAX(id)` (shard names validated as strict SQL identifiers).
- `search-backfill` — one-shot historical loader + inline reconcile gate (exits non-zero on any count/sample mismatch).

## `scripts/search-upgrade.sh`

Drives the 6-step state machine with an **exit-code gate `G1`..`G5`** after each step:

1. infra up → OpenSearch green/yellow
2. seed cursor → **G1**: every shard cursor ≥ its `MAX(id)`
3. producer on → **G2**: octo-server up with `TS_KAFKA_ON=true`
4. backfill + reconcile → **G3**: backfill exits 0 (reconcile passed)
5. bind read alias (atomic, single-pointing) → **G4**: alias resolves to exactly one index
6. reader → `es` → **G5**: reader on `es` and an alias-backed search succeeds

Supports `--from N` (resume) and `--check` (re-assert gates). It reads index/alias/shard settings from `docker/.env` (same source as Compose; shell env wins) and **persists each state flip back into `docker/.env`** (merging, not clobbering, an existing `COMPOSE_PROFILES` like `summary`) so a later `docker compose up -d` keeps search on.

## Docs

- README "Turn search on" runbook: gate table, why-each-step ordering rationale, manual run-through, and rollback.
- Resource baseline (with vs without search).
- Image-availability note flagging the indexer image and the IK OpenSearch image as prerequisites for community deployments.
- `.env.example` documents every new variable.

## Backward compatibility

The default-profile rendered config is unchanged; all new services and volumes are profile-gated and inert without an explicit opt-in. Verified `docker compose config` for the default profile carries no search services.

## Validation

- `docker compose config` validates for default / `search` / `search-tools` / combined `summary,search,search-tools`; default profile lists **zero** search services and renders `OCTO_SEARCH_BACKEND=disabled`, `TS_KAFKA_ON=false`.
- `search-upgrade.sh`: `bash -n` + shellcheck clean.
- End-to-end against throwaway MySQL + OpenSearch(IK): cursor-seed sets cursors to `MAX(id)` (monotonic, no rewind; bad shard name rejected); backfill indexed 5 docs with reconcile PASS; atomic alias bind is single-pointing and idempotent; alias-backed search + IK Chinese recall return hits.

## Merge order

⚠️ Depends on Mininglamp-OSS/octo-search-indexer#15 (bundles the `backfill` binary the `search-backfill` job runs). Merge that first.



Closes #122