### PR TITLE
feat(search): add opt-in searchetl-producer service to the search profile

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -481,6 +481,45 @@ OCTO_SEARCH_PRODUCER_ON=false
 # Broker list octo-server's producer connects to (in-network DNS name).
 # OCTO_SEARCH_KAFKA_BROKERS=search-kafka:9092
 
+# --- Standalone searchetl-producer service (search profile) ----------------
+# The realtime write side (MySQL shards -> Kafka) can run as its own container
+# (service: searchetl-producer) instead of inside octo-server. It is part of the
+# "search" profile, so it is DEPLOYED whenever the profile is up — but it stays
+# OFF by default and idles (connects to nothing) until explicitly enabled.
+#
+# 🔴 Cut-over discipline: enable the standalone producer ONLY after stopping the
+# octo-server built-in producer (OCTO_SEARCH_PRODUCER_ON=false). Both share the
+# same cursor + Redis run-lock; the supported posture is one active producer at a
+# time. Seed the cursor to the high-watermark first (search-cursor-seed), same as
+# turning the built-in producer on, or the producer re-streams history.
+#
+# Master switch — OFF by default (opt-in at the runtime cut-over):
+OCTO_SEARCH_STANDALONE_PRODUCER_ON=false
+# Source MySQL DSN. Defaults to the core stack's root account + DB; override to
+# use a least-privilege account (message* read + octo_etl_es_cursor read/write).
+# Holds a credential — keep it out of logs/configmaps; prefer a Docker/k8s secret.
+# OCTO_SEARCH_PRODUCER_MYSQL_DSN=root:${MYSQL_ROOT_PASSWORD}@tcp(mysql:3306)/octo?charset=utf8mb4&parseTime=true&loc=Local
+# Redis run-lock endpoint. MUST be the same Redis host + logical DB the built-in
+# producer used, or the two will not mutually exclude during cut-over.
+# OCTO_SEARCH_PRODUCER_REDIS_ADDR=redis:6379
+# OCTO_SEARCH_PRODUCER_REDIS_PASSWORD=
+# OCTO_SEARCH_PRODUCER_REDIS_TLS=false
+# OCTO_SEARCH_PRODUCER_REDIS_TLS_SKIP_VERIFY=false
+# OCTO_SEARCH_PRODUCER_REDIS_TLS_CA_FILE=
+# Polling cadence / safety (defaults mirror the built-in producer). lag MUST be
+# > 0 (the producer rejects lag<=0; lag=0 risks silent missed reads).
+# OCTO_SEARCH_PRODUCER_TICK_SECONDS=60
+# OCTO_SEARCH_PRODUCER_LAG_SECONDS=600
+# OCTO_SEARCH_PRODUCER_BATCH=5000
+# Connection pool (explicit; ConnMaxLifetime must stay below MySQL wait_timeout).
+# OCTO_SEARCH_PRODUCER_DB_MAX_OPEN=8
+# OCTO_SEARCH_PRODUCER_DB_MAX_IDLE=4
+# OCTO_SEARCH_PRODUCER_DB_CONN_MAX_LIFETIME=30m
+# In-container observability HTTP bind (healthz/readyz/metrics).
+# OCTO_SEARCH_PRODUCER_OBS_ADDR=:9090
+# Note: OCTO_SEARCH_KAFKA_BROKERS / _KAFKA_TOPIC / _KAFKA_DLQ_TOPIC and
+# OCTO_SEARCH_SHARD_TABLES (above) are shared with es-indexer + the upgrade jobs.
+
 # --- Search upgrade tooling (`search-tools` profile, one-shot jobs) ---------
 # Message shard tables the cursor-seed + backfill jobs operate on. Defaults
 # match the 5 WuKongIM message shards.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1168,9 +1168,10 @@ above for why a ufw rule alone is not enough).
 ## Search profile (message-search pipeline)
 
 The message-search pipeline — Kafka + OpenSearch (with the `analysis-ik`
-Chinese analyzer) + the `es-indexer` consumer — is **opt-in** behind the
-Docker Compose `search` profile, exactly like smart-summary's `summary`
-profile. With no profile set it is completely inert:
+Chinese analyzer) + the `es-indexer` consumer + the `searchetl-producer`
+(realtime write side) — is **opt-in** behind the Docker Compose `search`
+profile, exactly like smart-summary's `summary` profile. With no profile set it
+is completely inert:
 
 - A default `docker compose up -d` (or `setup.sh`) starts **zero** search
   services. The rendered config for the default profile is byte-for-byte
@@ -1205,10 +1206,11 @@ docker build -t octo-search-indexer:local .
 OCTO_SEARCH_INDEXER_IMAGE=octo-search-indexer:local
 ```
 
-This one image carries all three pipeline binaries — `es-indexer` (the
-long-running consumer, the default entrypoint), `backfill` (the one-shot
-historical loader), and `reconcile` (the correctness gate) — so the upgrade
-flow below needs no separate Go toolchain or second image.
+This one image carries all four pipeline binaries — `es-indexer` (the
+long-running consumer, the default entrypoint), `searchetl-producer` (the
+long-running realtime write-side producer), `backfill` (the one-shot historical
+loader), and `reconcile` (the correctness gate) — so the upgrade flow below
+needs no separate Go toolchain or second image.
 
 > **Image availability (community deployments).** The published
 > `mininglamposs/octo-search-indexer:latest` tag only exists once a release tag
@@ -1245,6 +1247,46 @@ or flip octo-server onto OpenSearch — that is the "Turn search on" upgrade
 below. A fresh `octo-message` index at this point is empty and the alias is
 unbound; octo-server stays on `OCTO_SEARCH_BACKEND=disabled` until you complete
 the upgrade.
+
+### Standalone `searchetl-producer` service (write side)
+
+The realtime write side (poll MySQL message shards → enrich → Kafka) can run as
+its own container, `searchetl-producer`, instead of inside the octo-server
+process. It is part of the `search` profile (same image as `es-indexer`, with
+`entrypoint` overridden to `/usr/local/bin/searchetl-producer`), so it is
+**deployed** whenever the profile is up — but it is **OFF by default and idles**:
+
+- `PRODUCER_ENABLED` defaults to `false` (driven by
+  `OCTO_SEARCH_STANDALONE_PRODUCER_ON`). With it unset/false the binary connects
+  to **no** backend — bringing the search profile up is exactly zero behavior
+  change. The container exists but does nothing until you opt in.
+- The producer and the octo-server built-in producer
+  (`OCTO_SEARCH_PRODUCER_ON`) share the **same** extraction cursor
+  (`octo_etl_es_cursor`) and the **same** Redis run-lock. The supported posture
+  is **one active producer at a time**. The lock + cursor CAS make a brief
+  overlap safe (no double-ingest, no gap), but you should not run both
+  deliberately.
+
+To move the write side from octo-server to the standalone service on a running
+search deployment (owner-gated, after the cursor is already at the
+high-watermark from the steps below):
+
+```bash
+cd docker
+# 1. Stop the octo-server built-in producer.
+OCTO_SEARCH_PRODUCER_ON=false docker compose up -d octo-server
+# 2. Turn the standalone producer on (it picks up the shared cursor and the
+#    Redis lock, continuing from the current watermark within seconds).
+OCTO_SEARCH_STANDALONE_PRODUCER_ON=true docker compose up -d searchetl-producer
+```
+
+Roll back by reversing the two: stop the standalone producer
+(`OCTO_SEARCH_STANDALONE_PRODUCER_ON=false`, recreate `searchetl-producer`) and
+turn the built-in producer back on. The cursor is shared, so the rollback
+continues from the same watermark; snapshot the tiny `octo_etl_es_cursor` table
+before the cut-over so a corrupted cursor can be restored. In-container
+liveness/readiness/metrics are served on `PRODUCER_OBS_ADDR` (default `:9090`):
+`/healthz`, `/readyz`, `/metrics`.
 
 ### Turn search on (zero-downtime upgrade for a running stack)
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1234,6 +1234,80 @@ services:
     networks:
       - octo-net
 
+  # searchetl-producer (MySQL shards -> Kafka polling ETL). The realtime WRITE
+  # side of the search pipeline, run as a standalone service alongside es-indexer
+  # (the READ side: Kafka -> OpenSearch). Same image, different binary: the image
+  # default entrypoint is es-indexer, so this service overrides entrypoint to
+  # /usr/local/bin/searchetl-producer.
+  #
+  # 🔴 OFF BY DEPLOY, OPT-IN BY ROLLOUT: PRODUCER_ENABLED defaults to false even
+  # inside the search profile. Bringing the search profile up therefore deploys
+  # this container but it IDLES (connects to NO backend) — exactly zero behavior
+  # change. Turning the standalone producer ON is a deliberate, owner-gated
+  # runtime cut-over (set OCTO_SEARCH_STANDALONE_PRODUCER_ON=true) that the
+  # operator performs only AFTER stopping the octo-server built-in producer
+  # (OCTO_SEARCH_PRODUCER_ON=false). The two MUST NOT run at once against the same
+  # cursor — the Redis run-lock + cursor CAS make a brief overlap safe, but the
+  # supported posture is one active producer at a time.
+  #
+  # Cursor table prerequisite: like the built-in producer, this only INSERT
+  # IGNOREs the per-shard cursor row; the octo_etl_es_cursor table itself is
+  # created by octo-server's searchetl migration. Bring the core stack up once
+  # before turning the producer on (the same prerequisite as search-cursor-seed).
+  searchetl-producer:
+    image: ${OCTO_SEARCH_INDEXER_IMAGE:-mininglamposs/octo-search-indexer:latest}
+    restart: unless-stopped
+    profiles: ["search"]
+    entrypoint: ["/usr/local/bin/searchetl-producer"]
+    depends_on:
+      search-kafka-init:
+        condition: service_completed_successfully
+      mysql:
+        condition: service_healthy
+    environment:
+      TZ: ${TZ:-UTC}
+      # 🔴 Opt-in master switch — OFF by default. The producer binary idles (no
+      # MySQL/Kafka/Redis connection) unless PRODUCER_ENABLED=true AND brokers +
+      # DSN + Redis are all set. Defaulting to false makes the search-profile
+      # deploy behavior-neutral; flip OCTO_SEARCH_STANDALONE_PRODUCER_ON=true in
+      # .env only at the runtime cut-over.
+      PRODUCER_ENABLED: ${OCTO_SEARCH_STANDALONE_PRODUCER_ON:-false}
+      # Source MySQL (same host + schema as octo-server — the producer reads the
+      # message shards and the shared octo_etl_es_cursor watermark). Credentials
+      # come from the core stack's MYSQL_ROOT_PASSWORD; not echoed to logs.
+      PRODUCER_MYSQL_DSN: ${OCTO_SEARCH_PRODUCER_MYSQL_DSN:-root:${MYSQL_ROOT_PASSWORD}@tcp(mysql:3306)/${MYSQL_DATABASE:-octo}?charset=utf8mb4&parseTime=true&loc=Local}
+      PRODUCER_TABLES: ${OCTO_SEARCH_SHARD_TABLES:-message,message1,message2,message3,message4}
+      # Kafka — same brokers + topics as es-indexer consumes (one body topic +
+      # one DLQ topic). The body topic carries the searchmsg contract; the DLQ
+      # topic carries the producer's forensic dead-letter envelopes.
+      PRODUCER_KAFKA_BROKERS: ${OCTO_SEARCH_KAFKA_BROKERS:-search-kafka:9092}
+      PRODUCER_KAFKA_TOPIC: ${OCTO_SEARCH_KAFKA_TOPIC:-octo.message.v1}
+      PRODUCER_KAFKA_DLQ_TOPIC: ${OCTO_SEARCH_KAFKA_DLQ_TOPIC:-octo.message.v1.dlq}
+      # Redis distributed run-lock (anti double-run across replicas AND across the
+      # old/new producer during cut-over). MUST be the same Redis host + logical
+      # DB as octo-server's built-in producer used, or the lock will not mutually
+      # exclude them. Password (when set) is mounted, never logged.
+      PRODUCER_REDIS_ADDR: ${OCTO_SEARCH_PRODUCER_REDIS_ADDR:-redis:6379}
+      PRODUCER_REDIS_PASSWORD: ${OCTO_SEARCH_PRODUCER_REDIS_PASSWORD:-}
+      PRODUCER_REDIS_TLS: ${OCTO_SEARCH_PRODUCER_REDIS_TLS:-false}
+      PRODUCER_REDIS_TLS_INSECURE_SKIP_VERIFY: ${OCTO_SEARCH_PRODUCER_REDIS_TLS_SKIP_VERIFY:-false}
+      PRODUCER_REDIS_TLS_CA_FILE: ${OCTO_SEARCH_PRODUCER_REDIS_TLS_CA_FILE:-}
+      # Polling cadence / safety. lag MUST stay > 0 (the producer rejects lag<=0;
+      # lag=0 risks silent missed reads). Defaults mirror the built-in producer
+      # (tick 60s, lag 600s, batch 5000).
+      PRODUCER_TICK_SECONDS: ${OCTO_SEARCH_PRODUCER_TICK_SECONDS:-60}
+      PRODUCER_LAG_SECONDS: ${OCTO_SEARCH_PRODUCER_LAG_SECONDS:-600}
+      PRODUCER_BATCH: ${OCTO_SEARCH_PRODUCER_BATCH:-5000}
+      # Connection pool (explicit — never bare driver defaults). ConnMaxLifetime
+      # must stay below MySQL wait_timeout.
+      PRODUCER_DB_MAX_OPEN_CONNS: ${OCTO_SEARCH_PRODUCER_DB_MAX_OPEN:-8}
+      PRODUCER_DB_MAX_IDLE_CONNS: ${OCTO_SEARCH_PRODUCER_DB_MAX_IDLE:-4}
+      PRODUCER_DB_CONN_MAX_LIFETIME: ${OCTO_SEARCH_PRODUCER_DB_CONN_MAX_LIFETIME:-30m}
+      # Observability HTTP server (healthz/readyz/metrics) inside the container.
+      PRODUCER_OBS_ADDR: ${OCTO_SEARCH_PRODUCER_OBS_ADDR:-:9090}
+    networks:
+      - octo-net
+
   # ===========================================================================
   # Search upgrade tooling (one-shot) — `search-tools` profile, NOT `search`
   # ===========================================================================

--- a/kustomize/search/README.md
+++ b/kustomize/search/README.md
@@ -40,7 +40,15 @@ kubectl apply -k kustomize/search -n <ns>
 - `search-kafka.yaml` — Kafka (KRaft single broker) StatefulSet + headless Service.
 - `search-kafka-init.yaml` — one-shot Job creating the body + DLQ topics.
 - `search-opensearch.yaml` — OpenSearch (single node, IK) StatefulSet + headless Service.
-- `es-indexer.yaml` — es-indexer Deployment (DLQ spill on a PVC).
+- `es-indexer.yaml` — es-indexer Deployment (Kafka → OpenSearch consumer; DLQ spill on a PVC).
+- `searchetl-producer.yaml` — searchetl-producer Deployment (MySQL → Kafka write side).
+  **Opt-in, OFF by default**: `PRODUCER_ENABLED=false`, so applying this
+  kustomization deploys the workload but it idles (connects to no backend) —
+  zero behavior change. It reads the source MySQL DSN + Redis addr from the
+  existing `octo-server-secret` (`DM_MYSQL_DSN` / `DM_REDIS_ADDR`). Turn it on
+  (`PRODUCER_ENABLED=true`) only at the runtime cut-over, after stopping the
+  octo-server built-in producer — the two share the cursor + Redis run-lock and
+  must not run together. Seed the cursor to the high-watermark first.
 - `search-pvc.yaml` — PVCs: OpenSearch data, Kafka data, DLQ spill.
 
 The DLQ-spill PVC is required: without durable spill storage the indexer's

--- a/kustomize/search/kustomization.yaml
+++ b/kustomize/search/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - search-kafka-init.yaml
   - search-opensearch.yaml
   - es-indexer.yaml
+  - searchetl-producer.yaml
 
 images:
   - name: apache/kafka

--- a/kustomize/search/searchetl-producer.yaml
+++ b/kustomize/search/searchetl-producer.yaml
@@ -1,0 +1,126 @@
+# searchetl-producer: the realtime WRITE side of the search pipeline. Polls the
+# MySQL message shards, enriches each row into the searchmsg contract, and
+# produces to Kafka octo.message.v1 (forensic envelopes to the .dlq topic) for
+# es-indexer to consume. Same image as es-indexer, different binary (the image
+# default entrypoint is es-indexer, so this overrides command).
+#
+# 🔴 OPT-IN, OFF BY DEFAULT: PRODUCER_ENABLED is "false" here, so applying this
+# kustomization DEPLOYS the workload but it IDLES (connects to no backend) — zero
+# behavior change. Turning it on is a deliberate, owner-gated runtime cut-over:
+# set PRODUCER_ENABLED=true (and stop the octo-server built-in producer first —
+# the two share the cursor + Redis run-lock; run one at a time). Seed the cursor
+# to the message high-watermark before enabling, or the producer re-streams all
+# history.
+#
+# NOTE: image is built only on v* tags / manual dispatch in octo-search-indexer.
+# Pin a real published tag in kustomization.yaml before applying.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: searchetl-producer
+  labels:
+    app: searchetl-producer
+spec:
+  # Single active producer: cross-replica mutual exclusion is enforced by the
+  # Redis run-lock, but there is no benefit to extra replicas (single-active by
+  # design). Keep replicas at 1.
+  replicas: 1
+  selector:
+    matchLabels:
+      app: searchetl-producer
+  template:
+    metadata:
+      labels:
+        app: searchetl-producer
+    spec:
+      containers:
+        - name: searchetl-producer
+          image: mininglamposs/octo-search-indexer:latest
+          imagePullPolicy: Always
+          command: ["/usr/local/bin/searchetl-producer"]
+          env:
+            # 🔴 Opt-in master switch — OFF by default. Flip to "true" only at the
+            # runtime cut-over, after stopping the octo-server built-in producer.
+            - name: PRODUCER_ENABLED
+              value: "false"
+            # Source MySQL: reuse the IM database DSN the core stack already holds
+            # (the message shards + the shared octo_etl_es_cursor live there). For
+            # a least-privilege account, point this at a dedicated Secret key with
+            # message* read + octo_etl_es_cursor read/write.
+            - name: PRODUCER_MYSQL_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: octo-server-secret
+                  key: DM_MYSQL_DSN
+                  # optional: the disabled-by-default pod must reach its idle
+                  # /healthz+/readyz posture even before the search secret exists.
+                  # A non-optional ref makes k8s fail the pod (CreateContainerConfigError)
+                  # before the binary runs. When the producer is turned on the
+                  # operator ensures this key is present (cut-over prerequisite).
+                  optional: true
+            - name: PRODUCER_TABLES
+              value: "message,message1,message2,message3,message4"
+            # Kafka — same brokers + topics es-indexer consumes.
+            - name: PRODUCER_KAFKA_BROKERS
+              value: "search-kafka:9092"
+            - name: PRODUCER_KAFKA_TOPIC
+              value: "octo.message.v1"
+            - name: PRODUCER_KAFKA_DLQ_TOPIC
+              value: "octo.message.v1.dlq"
+            # Redis run-lock — MUST be the same Redis host + logical DB the
+            # built-in producer used, or the lock will not mutually exclude them.
+            - name: PRODUCER_REDIS_ADDR
+              valueFrom:
+                secretKeyRef:
+                  name: octo-server-secret
+                  key: DM_REDIS_ADDR
+                  # optional for the same reason as PRODUCER_MYSQL_DSN above —
+                  # the idle default pod must not fail on a missing secret key.
+                  optional: true
+            # Polling cadence / safety (lag MUST stay > 0; the producer rejects
+            # lag<=0, which risks silent missed reads).
+            - name: PRODUCER_TICK_SECONDS
+              value: "60"
+            - name: PRODUCER_LAG_SECONDS
+              value: "600"
+            - name: PRODUCER_BATCH
+              value: "5000"
+            # Explicit connection pool (never bare driver defaults).
+            - name: PRODUCER_DB_MAX_OPEN_CONNS
+              value: "8"
+            - name: PRODUCER_DB_MAX_IDLE_CONNS
+              value: "4"
+            - name: PRODUCER_DB_CONN_MAX_LIFETIME
+              value: "30m"
+            # Observability HTTP server (healthz/readyz/metrics).
+            - name: PRODUCER_OBS_ADDR
+              value: ":9090"
+          ports:
+            - name: obs
+              containerPort: 9090
+          # Liveness: the process is up and serving HTTP. Readiness: the obs
+          # server reports ready. The binary serves /healthz + /readyz in BOTH
+          # states — actively producing AND idling (PRODUCER_ENABLED=false) — so a
+          # deliberately-disabled pod stays healthy/ready (idling-is-ready) under
+          # these probes instead of crashlooping. No backend is dialed while idle.
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: obs
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: obs
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi


### PR DESCRIPTION
## What

Wire the standalone `searchetl-producer` (MySQL shards → Kafka, the realtime
**write** side) into the `search` profile alongside `es-indexer` (Kafka →
OpenSearch, the **read** side), in both Docker Compose and the opt-in
`kustomize/search` overlay. Same image as `es-indexer`, entrypoint/command
overridden to `/usr/local/bin/searchetl-producer`.

## 🔴 Behavior-neutral by construction

`PRODUCER_ENABLED` defaults to **false** (driven by
`OCTO_SEARCH_STANDALONE_PRODUCER_ON` / the manifest's `"false"`). Bringing the
search profile up therefore **deploys the container but it idles** — it connects
to no backend, so this change is exactly zero behavior change until an operator
opts in at the runtime cut-over.

The standalone producer and the octo-server built-in producer
(`OCTO_SEARCH_PRODUCER_ON`) share the `octo_etl_es_cursor` cursor and the Redis
run-lock and must run **one at a time**; enabling the standalone one is gated on
stopping the built-in one (documented cut-over + rollback steps in the READMEs).

## Changes
- **docker-compose**: `searchetl-producer` in `profiles:[search]`, depends on
  `search-kafka-init` + `mysql`, full `PRODUCER_*` env (DSN / brokers / topics /
  Redis lock / tick / lag / batch / pool / obs), every var with a safe default so
  a non-search deploy never fails preflight.
- **kustomize/search**: `searchetl-producer` Deployment (replicas 1, single-active
  by Redis lock), liveness/readiness probes on the obs port, source MySQL DSN +
  Redis addr from the existing `octo-server-secret` (`optional: true` so the idle
  default pod starts even before the secret keys exist).
- **.env.example / README / kustomize README**: the new service, its opt-in
  posture, and the cut-over + rollback steps.

## Verification
- `docker compose config` — **default** profile passes and **excludes** the
  producer; **search** profile passes and **includes** it with
  `PRODUCER_ENABLED=false`.
- `kubectl kustomize kustomize/search` renders the producer Deployment with the
  pinned image tag.
- Light config/manifest change — independent model review (gpt-5.5) run on the
  paired code change covered the producer's enabled/idle semantics; both findings
  fixed.

## Merge order
⚠️ Merge **Mininglamp-OSS/octo-search-indexer#18 first**, then this — the image
must ship the `searchetl-producer` binary (with the forensic DLQ envelope +
first-tick refinements) this deployment references.

Depends on: Mininglamp-OSS/octo-search-indexer#18
