### PR TITLE
feat(search): standalone searchetl-producer compose service (default OFF + mutual-exclusion guard)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -484,9 +484,13 @@ OCTO_SEARCH_PRODUCER_ON=false
 # --- Standalone realtime producer (`search-producer` profile) --------------
 # 🔴 MUTUAL EXCLUSION: the standalone producer and the built-in producer
 # (OCTO_SEARCH_PRODUCER_ON above) share the SAME cursor table + Redis lock.
-# NEVER set both to true — doing so double-writes/reorders Kafka. The compose
-# `search-producer-guard` service hard-fails (exit 1) if both are true, so the
-# standalone stack refuses to start in that state. Pick exactly ONE.
+# NEVER set both to a truthy value — doing so double-writes/reorders Kafka. The
+# compose `search-producer-guard` service hard-fails (exit 1) if BOTH are truthy,
+# so the standalone stack refuses to start in that state. Pick exactly ONE.
+# The guard is fail-closed: it treats any value the underlying producers accept
+# as ON — case-insensitive 1, t, true, on, yes (superset of Go strconv.ParseBool
+# 1/t/true used by the built-in producer's Viper cast, and the standalone's
+# "true"-only check). So OCTO_SEARCH_PRODUCER_ON=1 counts as ON, not a bypass.
 # This standalone path is opt-in OFF and lives in its own profile; enable with:
 #   COMPOSE_PROFILES=search,search-producer  AND  OCTO_SEARCH_STANDALONE_PRODUCER_ON=true
 # AND only AFTER: (a) the extraction cursor has been seeded to each message

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -481,6 +481,22 @@ OCTO_SEARCH_PRODUCER_ON=false
 # Broker list octo-server's producer connects to (in-network DNS name).
 # OCTO_SEARCH_KAFKA_BROKERS=search-kafka:9092
 
+# --- Standalone realtime producer (`search-producer` profile) --------------
+# 🔴 MUTUAL EXCLUSION: the standalone producer and the built-in producer
+# (OCTO_SEARCH_PRODUCER_ON above) share the SAME cursor table + Redis lock.
+# NEVER set both to true — doing so double-writes/reorders Kafka. The compose
+# `search-producer-guard` service hard-fails (exit 1) if both are true, so the
+# standalone stack refuses to start in that state. Pick exactly ONE.
+# This standalone path is opt-in OFF and lives in its own profile; enable with:
+#   COMPOSE_PROFILES=search,search-producer  AND  OCTO_SEARCH_STANDALONE_PRODUCER_ON=true
+# AND only AFTER: (a) the extraction cursor has been seeded to each message
+# shard's high-watermark (else a zero cursor re-streams the entire history,
+# same caveat as OCTO_SEARCH_PRODUCER_ON above), and (b) the cut-over has been
+# validated on im-test.xming.ai (cursor continuity / no Kafka gap / DLQ ok).
+OCTO_SEARCH_STANDALONE_PRODUCER_ON=false
+# Stability lag window (seconds) for the standalone producer; must be > 0.
+# OCTO_SEARCH_STANDALONE_PRODUCER_LAG_SECONDS=600
+
 # --- Search upgrade tooling (`search-tools` profile, one-shot jobs) ---------
 # Message shard tables the cursor-seed + backfill jobs operate on. Defaults
 # match the 5 WuKongIM message shards.

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1235,6 +1235,89 @@ services:
       - octo-net
 
   # ===========================================================================
+  # Standalone realtime producer (MySQL -> Kafka) — `search-producer` profile
+  # ===========================================================================
+  # The octo-search-indexer image also bundles a standalone searchetl-producer
+  # binary (MySQL shards -> Kafka), an ALTERNATIVE to octo-server's BUILT-IN
+  # producer (TS_KAFKA_ON / OCTO_SEARCH_PRODUCER_ON).
+  #
+  # 🔴 MUTUAL EXCLUSION — NEVER run both producers at once. They share the SAME
+  # extraction cursor table (octo_etl_es_cursor) and the SAME Redis run-lock
+  # (searchetl:etl:run). The lock only serializes a single tick; it does NOT
+  # stop both from advancing the cursor and double-writing/reordering Kafka.
+  #
+  # Defense in depth:
+  #   (1) own profile `search-producer` — neither a vanilla `up` nor
+  #       COMPOSE_PROFILES=search instantiates it;
+  #   (2) opt-in OFF — PRODUCER_ENABLED defaults to false even when instantiated;
+  #   (3) HARD compose-time guard — search-producer-guard (below) refuses to let
+  #       this service start while the built-in producer is also on. This is the
+  #       mechanical mutual-exclusion gate, not just a comment.
+  # The cut-over (enable standalone + disable built-in) is a SEPARATE manual gate
+  # validated on im-test.xming.ai first — NOT part of bringing this up.
+  search-producer-guard:
+    image: ${OCTO_PREFLIGHT_IMAGE:-busybox:1.36}
+    restart: "no"
+    profiles: ["search-producer"]
+    environment:
+      STANDALONE_ON: ${OCTO_SEARCH_STANDALONE_PRODUCER_ON:-false}
+      BUILTIN_ON: ${OCTO_SEARCH_PRODUCER_ON:-false}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -eu
+        # Mirrors the `preflight` / `minio-init` guard pattern: a one-shot
+        # busybox assertion gated by service_completed_successfully. Fail-fast
+        # (exit 1) on the forbidden state so the standalone producer can never
+        # boot alongside the built-in one — the P0 double-write guard.
+        std=$$(printf %s "$$STANDALONE_ON" | tr 'A-Z' 'a-z')
+        blt=$$(printf %s "$$BUILTIN_ON" | tr 'A-Z' 'a-z')
+        if [ "$$std" = "true" ] && [ "$$blt" = "true" ]; then
+          echo "[search-producer-guard] FATAL: both producers enabled —" >&2
+          echo "[search-producer-guard]   OCTO_SEARCH_STANDALONE_PRODUCER_ON=true AND OCTO_SEARCH_PRODUCER_ON=true." >&2
+          echo "[search-producer-guard]   They share the cursor + Redis lock; running both double-writes Kafka." >&2
+          echo "[search-producer-guard]   Set exactly ONE to true. Refusing to start." >&2
+          exit 1
+        fi
+        echo "[search-producer-guard] ok: standalone=$$std builtin=$$blt (not both on)"
+    networks:
+      - octo-net
+
+  search-producer:
+    image: ${OCTO_SEARCH_INDEXER_IMAGE:-mininglamposs/octo-search-indexer:latest}
+    entrypoint: ["/usr/local/bin/searchetl-producer"]
+    restart: unless-stopped
+    profiles: ["search-producer"]
+    environment:
+      TZ: ${TZ:-UTC}
+      # Master switch — OFF by default. Distinct from the built-in producer's
+      # OCTO_SEARCH_PRODUCER_ON. Both true is the forbidden state the guard blocks.
+      PRODUCER_ENABLED: ${OCTO_SEARCH_STANDALONE_PRODUCER_ON:-false}
+      # Required when PRODUCER_ENABLED=true (binary fail-fasts otherwise).
+      # Same passwordless redis:6379 + root DSN convention as the rest of the stack.
+      PRODUCER_MYSQL_DSN: "root:${MYSQL_ROOT_PASSWORD}@tcp(mysql:3306)/${MYSQL_DATABASE:-octo}?charset=utf8mb4&parseTime=true&loc=Local"
+      PRODUCER_KAFKA_BROKERS: ${OCTO_SEARCH_KAFKA_BROKERS:-search-kafka:9092}
+      PRODUCER_REDIS_ADDR: redis:6379
+      # Defaulted by the binary; pinned to match the rest of the pipeline.
+      PRODUCER_KAFKA_TOPIC: ${OCTO_SEARCH_KAFKA_TOPIC:-octo.message.v1}
+      PRODUCER_KAFKA_DLQ_TOPIC: ${OCTO_SEARCH_KAFKA_DLQ_TOPIC:-octo.message.v1.dlq}
+      PRODUCER_TABLES: ${OCTO_SEARCH_SHARD_TABLES:-message,message1,message2,message3,message4}
+      PRODUCER_LAG_SECONDS: ${OCTO_SEARCH_STANDALONE_PRODUCER_LAG_SECONDS:-600}
+    # mysql/redis are core; the guard is same-profile so this depends_on is safe.
+    # search-kafka is in the `search` profile — NO cross-profile depends_on (see
+    # search-backfill note). Operator must bring `search` infra up first; the
+    # producer idles cleanly (or, if enabled without brokers, fail-fasts loudly).
+    depends_on:
+      search-producer-guard:
+        condition: service_completed_successfully
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - octo-net
+
+  # ===========================================================================
   # Search upgrade tooling (one-shot) — `search-tools` profile, NOT `search`
   # ===========================================================================
   # These two jobs implement the irreversible "light search up" steps of the

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1270,16 +1270,33 @@ services:
         # busybox assertion gated by service_completed_successfully. Fail-fast
         # (exit 1) on the forbidden state so the standalone producer can never
         # boot alongside the built-in one — the P0 double-write guard.
-        std=$$(printf %s "$$STANDALONE_ON" | tr 'A-Z' 'a-z')
-        blt=$$(printf %s "$$BUILTIN_ON" | tr 'A-Z' 'a-z')
-        if [ "$$std" = "true" ] && [ "$$blt" = "true" ]; then
+        # Truthy normalization (fail-closed). The two guarded producers parse
+        # their enable flags with DIFFERENT, non-identical truthy sets:
+        #   - built-in producer: octo-server TS_KAFKA_ON -> Viper cast.ToBool ->
+        #     strconv.ParseBool, which accepts 1 t T TRUE true True (NOT on/yes).
+        #   - standalone: PRODUCER_ENABLED -> strings.EqualFold(env,"true"),
+        #     i.e. only the "true" variants.
+        # A literal `= "true"` check let OCTO_SEARCH_PRODUCER_ON=1 slip past the
+        # guard (ParseBool("1") is ON) so BOTH producers ran and double-wrote the
+        # shared cursor + Kafka. The guard now normalizes with the UNION of both
+        # parsers' truthy sets PLUS conservative ops aliases (on/yes): if a value
+        # would be ON for EITHER producer, the guard counts it ON. This is the
+        # fail-closed bias — over-block rather than let both run.
+        is_on() {
+          v=$$(printf %s "$${1:-}" | tr 'A-Z' 'a-z')
+          case "$$v" in
+            1|t|true|on|yes) return 0 ;;
+            *) return 1 ;;
+          esac
+        }
+        if is_on "$$STANDALONE_ON" && is_on "$$BUILTIN_ON"; then
           echo "[search-producer-guard] FATAL: both producers enabled —" >&2
-          echo "[search-producer-guard]   OCTO_SEARCH_STANDALONE_PRODUCER_ON=true AND OCTO_SEARCH_PRODUCER_ON=true." >&2
+          echo "[search-producer-guard]   OCTO_SEARCH_STANDALONE_PRODUCER_ON=$$STANDALONE_ON AND OCTO_SEARCH_PRODUCER_ON=$$BUILTIN_ON (both truthy)." >&2
           echo "[search-producer-guard]   They share the cursor + Redis lock; running both double-writes Kafka." >&2
-          echo "[search-producer-guard]   Set exactly ONE to true. Refusing to start." >&2
+          echo "[search-producer-guard]   Set exactly ONE to a truthy value. Refusing to start." >&2
           exit 1
         fi
-        echo "[search-producer-guard] ok: standalone=$$std builtin=$$blt (not both on)"
+        echo "[search-producer-guard] ok: standalone=$$STANDALONE_ON builtin=$$BUILTIN_ON (not both on)"
     networks:
       - octo-net
 


### PR DESCRIPTION
## What

Adds an opt-in **standalone realtime producer** (MySQL → Kafka) to the docker compose stack, reusing the `searchetl-producer` binary already bundled in the `octo-search-indexer` image. This is an alternative to octo-server's built-in producer (`TS_KAFKA_ON` / `OCTO_SEARCH_PRODUCER_ON`).

Scope is strictly two files: `docker/docker-compose.yaml` and `docker/.env.example`.

### Changes
- **`search-producer`** service — gated behind a dedicated `search-producer` profile. Neither a vanilla `up` nor `COMPOSE_PROFILES=search` instantiates it. Master switch `PRODUCER_ENABLED` defaults to `false`.
- **`search-producer-guard`** — a one-shot busybox assertion service (mirrors the existing `preflight` / `minio-init` guard pattern). It **hard-fails (exit 1)** when both the standalone and built-in producers are enabled. The two producers share the same extraction cursor table (`octo_etl_es_cursor`) and the same Redis run-lock (`searchetl:etl:run`); the lock only serializes a single tick, it does **not** stop both from advancing the cursor and double-writing/reordering Kafka. The guard turns "mutual exclusion" from a comment into a mechanical compose-time gate.
- **`OCTO_SEARCH_STANDALONE_PRODUCER_ON`** toggle (default `false`) in `.env.example`, with mutual-exclusion + cursor-seed warnings.

## 🔒 Default OFF, no cut-over

This PR is **preparation only**. The new toggle defaults OFF and both new services live in their own profile, so nothing changes for existing deployments. **Enabling the standalone producer and disabling the built-in one is a SEPARATE manual gate** — validated on staging first (cursor continuity / no Kafka gap / DLQ ok). That cut-over is **not** part of this PR.

## Defense in depth (mutual exclusion)
1. Own profile `search-producer` — not instantiated by default or by the `search` profile.
2. Opt-in OFF — `PRODUCER_ENABLED` defaults to false even when instantiated.
3. Hard compose-time guard — `search-producer-guard` refuses to start the standalone producer while the built-in one is also on.

## Acceptance gates (all run)

| # | Gate | Expected | Result |
|---|------|----------|--------|
| 1 | `config --services` (search,search-producer) contains both new services | `search-producer` + `search-producer-guard` present | ✅ `SVC_OK`, `GUARD_OK` |
| 2 | No profile → neither new service appears | absent | ✅ `ISOLATED_DEFAULT_OK` |
| 3 | Only `search` profile → neither new service appears | absent | ✅ `ISOLATED_SEARCH_OK` |
| 4 | Parsed `PRODUCER_ENABLED` default | `"false"` | ✅ `PRODUCER_ENABLED: "false"` |
| 5 | Guard with both toggles `true` → run guard | exit ≠ 0 (blocked) | ✅ `forbidden_exit=1` |
| 6 | Guard with only standalone `true` → run guard | exit 0 | ✅ `allowed_exit=0` |
| 7 | `.env.example` contains new toggle | match | ✅ `ENV_OK` |
| 8 | Diff file scope | exactly compose + .env.example | ✅ 2 files, +99 |

All gates executed on a live docker engine (Compose v5.1.0); the guard container was actually run for gates 5 & 6.

## Review
- Structural / scope review: PASS (diff is exactly 2 config files; YAML validates via `docker compose config`; guard shell logic verified live).
- Independent model review: PASS with 2 non-blocking follow-ups (documented below).

### Non-blocking follow-ups (out of scope here)
- The guard sits only in the standalone producer's dependency chain. A later, separate enablement of the built-in producer on an already-running standalone stack would not re-trigger the guard. Adding the guard to octo-server's startup path would require modifying built-in producer wiring and a cross-profile `depends_on` (which breaks `docker compose config` when the other profile is inactive) — both intentionally avoided here. The cut-over runbook covers this human gate.
- The guard treats only the literal lowercased `true` as enabled. The repo-wide `.env` convention uses literal `true`/`false`, so this matches current usage; broader truthy-value normalization (`1`/`t`) could be a hardening follow-up.

## Test plan
Static validation only (`docker compose config` + a live guard container run). Runtime verification (cursor continuity / Kafka / DLQ) happens at the separate cut-over gate, not here.
