### PR TITLE
feat(deploy): make search-producer-guard a shared bidirectional mutex

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -485,8 +485,11 @@ OCTO_SEARCH_PRODUCER_ON=false
 # 🔴 MUTUAL EXCLUSION: the standalone producer and the built-in producer
 # (OCTO_SEARCH_PRODUCER_ON above) share the SAME cursor table + Redis lock.
 # NEVER set both to a truthy value — doing so double-writes/reorders Kafka. The
-# compose `search-producer-guard` service hard-fails (exit 1) if BOTH are truthy,
-# so the standalone stack refuses to start in that state. Pick exactly ONE.
+# compose `search-producer-guard` is now an unprofiled SHARED service that BOTH
+# producers depend_on: octo-server (built-in) and search-producer (standalone).
+# It hard-fails (exit 1) if BOTH are truthy, so whichever side you start/recreate
+# in that state refuses to come up — bidirectional, not just on standalone up.
+# Pick exactly ONE.
 # The guard is fail-closed: it treats any value the underlying producers accept
 # as ON — case-insensitive 1, t, true, on, yes (superset of Go strconv.ParseBool
 # 1/t/true used by the built-in producer's Viper cast, and the standalone's

--- a/docker/README.md
+++ b/docker/README.md
@@ -1380,6 +1380,36 @@ else
 fi
 ```
 
+> ⚠️ **互斥守卫现已双向生效 — 在 standalone 仍在跑时单独 `up -d octo-server` 会让 octo-server 短暂宕机**
+>
+> `search-producer-guard` 已升格为无 profile 的共享守卫：`octo-server`（内置 producer）与 `search-producer`（standalone）都 `depends_on` 它。任一方在「两个 producer 同时为真」的禁忌态下启动/重建都会被守卫 `exit 1` 拦下。
+>
+> 具体到本 runbook 上面第 3/6 步的 `OCTO_SEARCH_PRODUCER_ON=true docker compose up -d octo-server`：**如果 standalone producer（`OCTO_SEARCH_STANDALONE_PRODUCER_ON=true` + `search-producer` profile）此刻仍在运行**，这条命令不仅会被守卫 fail-fast 拒绝，**还会先把正在运行的 octo-server 一起拆掉**——因为 `OCTO_SEARCH_PRODUCER_ON` 同时改了 octo-server 自身的 `TS_KAFKA_ON`，compose 会 recreate octo-server：旧的 running 实例被销毁，新实例因守卫失败卡在 `Created` 永不 running。**净结果：octo-server 直接下线**，不是「旧实例继续跑、只是拒绝新配置」。
+>
+> 这是 **fail-closed 的预期行为**（宕机优于两个 producer 双写共享 cursor + Kafka），只在 both-on 禁忌态触发，默认路径 / 单开任一路径都不受影响。但操作时务必知道这一点。
+>
+> **正确切流顺序：先关 standalone，再开内置。**
+> ```bash
+> cd docker
+> # 1. 关掉 standalone producer
+> docker compose stop search-producer
+> # 2. 在 docker/.env 把 standalone toggle 关掉，并从 COMPOSE_PROFILES 去掉 search-producer
+> #    OCTO_SEARCH_STANDALONE_PRODUCER_ON=false
+> # 3. 再开内置 producer
+> OCTO_SEARCH_PRODUCER_ON=true docker compose up -d octo-server
+> ```
+>
+> **如果已经手滑撞了守卫（octo-server 已经 down）：** 把冲突的 toggle 改回去再 `up` 即可**干净恢复**——守卫会重跑并 `exit 0`，octo-server 回到 running/healthy（实测无残留、无不可恢复状态）。二选一：
+> ```bash
+> cd docker
+> # (a) 仍想用 standalone → 把内置关回去，octo-server 以 builtin=off 恢复
+> OCTO_SEARCH_PRODUCER_ON=false docker compose up -d octo-server
+>
+> # (b) 想切到内置 → 先停 standalone（并在 .env 关掉 standalone toggle），再开内置
+> docker compose stop search-producer
+> OCTO_SEARCH_PRODUCER_ON=true docker compose up -d octo-server
+> ```
+
 #### Rollback
 
 Search can be turned off (or rolled back to the legacy Zinc path) without data

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -774,6 +774,11 @@ services:
     depends_on:
       preflight:
         condition: service_completed_successfully
+      # Shared mutual-exclusion guard (same pattern as preflight above). Blocks
+      # octo-server's built-in producer from starting while the standalone
+      # search-producer is also on — the other half of the bidirectional gate.
+      search-producer-guard:
+        condition: service_completed_successfully
       mysql:
         condition: service_healthy
       redis:
@@ -1250,15 +1255,21 @@ services:
   #   (1) own profile `search-producer` — neither a vanilla `up` nor
   #       COMPOSE_PROFILES=search instantiates it;
   #   (2) opt-in OFF — PRODUCER_ENABLED defaults to false even when instantiated;
-  #   (3) HARD compose-time guard — search-producer-guard (below) refuses to let
-  #       this service start while the built-in producer is also on. This is the
-  #       mechanical mutual-exclusion gate, not just a comment.
+  #   (3) HARD compose-time guard — search-producer-guard (below) is a shared,
+  #       unprofiled gate that BOTH producers depend_on. Whether you start/
+  #       recreate the standalone producer OR octo-server's built-in one, the
+  #       guard refuses (exit 1) if the other producer is also on. Bidirectional
+  #       mechanical mutual-exclusion, not just a comment.
   # The cut-over (enable standalone + disable built-in) is a SEPARATE manual gate
   # validated on im-test.xming.ai first — NOT part of bringing this up.
+  # Shared mutual-exclusion guard (NO profile — instantiated unconditionally).
+  # Both producers depend_on it: octo-server (built-in producer) and
+  # search-producer (standalone). Whichever side starts/recreates in the
+  # forbidden "both producers truthy" state is fail-closed (exit 1) here, so
+  # the double-write is blocked in BOTH directions, not just on standalone up.
   search-producer-guard:
     image: ${OCTO_PREFLIGHT_IMAGE:-busybox:1.36}
     restart: "no"
-    profiles: ["search-producer"]
     environment:
       STANDALONE_ON: ${OCTO_SEARCH_STANDALONE_PRODUCER_ON:-false}
       BUILTIN_ON: ${OCTO_SEARCH_PRODUCER_ON:-false}
@@ -1320,7 +1331,9 @@ services:
       PRODUCER_KAFKA_DLQ_TOPIC: ${OCTO_SEARCH_KAFKA_DLQ_TOPIC:-octo.message.v1.dlq}
       PRODUCER_TABLES: ${OCTO_SEARCH_SHARD_TABLES:-message,message1,message2,message3,message4}
       PRODUCER_LAG_SECONDS: ${OCTO_SEARCH_STANDALONE_PRODUCER_LAG_SECONDS:-600}
-    # mysql/redis are core; the guard is same-profile so this depends_on is safe.
+    # mysql/redis are core; the guard is now an unprofiled SHARED service (both
+    # this standalone producer and octo-server depend_on it) so this depends_on
+    # resolves to the single guard definition and stays safe.
     # search-kafka is in the `search` profile — NO cross-profile depends_on (see
     # search-backfill note). Operator must bring `search` infra up first; the
     # producer idles cleanly (or, if enabled without brokers, fail-fasts loudly).


### PR DESCRIPTION
## What

Promote `search-producer-guard` to an **unprofiled shared service** so the mutual-exclusion guard covers **both directions**:

- **Before:** the guard had `profiles: ["search-producer"]`, so it only gated the *standalone* producer path. Bringing up octo-server with `OCTO_SEARCH_PRODUCER_ON=true` while the standalone producer was running was **not** blocked → both producers could double-write the shared cursor + Kafka (one-way gap).
- **After:** the guard is unprofiled (single definition) and **both** `octo-server` (built-in producer) and `search-producer` (standalone) `depends_on: service_completed_successfully` it — same pattern octo-server already uses for `preflight`.

The existing fail-closed `is_on()` truth table (`1|t|true|on|yes`) is kept **verbatim** — no second truth parser introduced.

## Files (3)

- `docker/docker-compose.yaml` — drop guard `profiles` line; add `search-producer-guard` to octo-server `depends_on`; update mutual-exclusion comments.
- `docker/.env.example` — describe the guard as a shared bidirectional gate.
- `docker/README.md` — operator notice on the cut-over runbook (down expectation + correct cut-over order + clean recovery path).

## Acceptance (run on real `docker compose`, isolated project, remapped ports)

**1. Direction② blocked + octo-server goes DOWN** — standalone running + `OCTO_SEARCH_STANDALONE_PRODUCER_ON=true`, then bare `OCTO_SEARCH_PRODUCER_ON=true docker compose up -d octo-server`:
```
up rc=1                                  # PASS: up failed (exit code captured directly, no pipe)
guard exit: 1                            # PASS
stderr: "[search-producer-guard] FATAL: both producers enabled —"   # PASS
octo-server ps: (empty running) ; ps -a: Created   # PASS: old running instance torn down, new instance stuck Created
```

**2. Recovery reversibility** — from the case-1 down state, flip the conflicting toggle back and `up`:
```
OCTO_SEARCH_PRODUCER_ON=false docker compose up -d octo-server → rc=0   # PASS
guard re-ran exit 0: "[search-producer-guard] ok: standalone=true builtin=false (not both on)"
octo-server → running healthy          # PASS: clean recovery, no residual/unrecoverable state
```

**3. Default behavior unchanged** (core regression gate):
```
both toggles false  → guard exit 0, octo-server running (healthy)   # PASS
builtin-only (PRODUCER_ON=true)     → guard exit 0, octo-server running (healthy)   # PASS
standalone-only (STANDALONE_ON=true)→ guard exit 0, octo-server running (healthy)   # PASS
```

**4. Single guard definition + no second truth table + valid config:**
```
docker compose config -q             → rc=0          # PASS
grep -c 'is_on()' docker/docker-compose.yaml → 1     # PASS (sole guard body = sole truth table)
search-producer-guard: occurrences   → 1 service def (unprofiled) + 2 depends_on refs
```

## Scope

**No cut-over, default behavior unchanged.** No producer business logic, image, entrypoint, cursor/Kafka/Redis config, or helm/kustomize touched — only compose `depends_on` + env/README docs.
