### PR TITLE
feat(deploy): k8s searchetl-producer + mutex guard manifest (kustomize/search)

### DIFF
--- a/kustomize/search/README.md
+++ b/kustomize/search/README.md
@@ -41,7 +41,84 @@ kubectl apply -k kustomize/search -n <ns>
 - `search-kafka-init.yaml` — one-shot Job creating the body + DLQ topics.
 - `search-opensearch.yaml` — OpenSearch (single node, IK) StatefulSet + headless Service.
 - `es-indexer.yaml` — es-indexer Deployment (DLQ spill on a PVC).
+- `searchetl-producer.yaml` — standalone producer Deployment (opt-in, default OFF; no PVC, no probe).
 - `search-pvc.yaml` — PVCs: OpenSearch data, Kafka data, DLQ spill.
 
 The DLQ-spill PVC is required: without durable spill storage the indexer's
 crash-resumable DLQ accounting is defeated on a pod restart.
+
+## Standalone searchetl-producer (opt-in, default OFF)
+
+`searchetl-producer.yaml` ships a standalone producer that reads MySQL and
+writes the message-search topic (`octo.message.v1`). It is the **replacement
+binary** for octo-server's built-in producer (the `TS_KAFKA_ON` toggle) — they
+share the cursor and Redis lock, so running both double-writes Kafka. It shares
+the `mininglamposs/octo-search-indexer` image with es-indexer (one image, two
+binaries); the Deployment overrides the entrypoint to `searchetl-producer`.
+
+It is shipped **OFF**: `replicas: 0` **and** `PRODUCER_ENABLED=false` (double
+opt-in). Applying this directory creates the Deployment but no pod.
+
+### Enable checklist (owner-gated)
+
+Enabling is a deliberate, owner-gated action with data-layer consequences:
+
+1. Confirm the base Secret `octo-server-secret` already exists in the target
+   namespace — the producer's `PRODUCER_MYSQL_DSN` / `PRODUCER_REDIS_ADDR` are
+   **required** `secretKeyRef`s and the pod will not start without it.
+2. Confirm the producer cursor is seeded to the current high-water mark —
+   otherwise the producer re-streams history (a full reload).
+3. Flip **both** switches together: set `replicas: 1` **and**
+   `PRODUCER_ENABLED=true`. Changing only one leaves you either with a
+   Deployment that is Running but produces nothing, or a guard that passed but
+   a workload idling — neither produces messages.
+
+### Mutual-exclusion guard (and its limits)
+
+The pod runs an init container (`producer-mutex-guard`) that reuses the same
+`is_on()` union truthy logic as the compose `search-producer-guard`
+(`1|t|true|on|yes`, fail-closed). If the built-in producer (`TS_KAFKA_ON` in
+ConfigMap `octo-server-env`) is also truthy, the init container exits 1 and the
+producer pod never reaches Running.
+
+Two limits this guard does **not** cover (operator responsibility):
+
+- **Single-direction**: it only blocks *standalone start-up while the built-in
+  is on*. It does **not** block the reverse — starting/rolling out octo-server
+  with `TS_KAFKA_ON=true` while the standalone is already running. (True
+  bidirectional guarding would require touching `kustomize/base`, out of scope.)
+- **Point-in-time**: the init container runs only at pod start. Flipping
+  `TS_KAFKA_ON` to on **while the producer is already Running** does not
+  re-trigger the check — verify this manually before changing the toggle.
+
+### 🔴 CDC double-write warning
+
+dmwork-test runs `octo-messages-sync` (CDC binlog → Kafka) writing the **same**
+topic `octo.message.v1`. That CDC pipeline is **not** in this kustomize tree, so
+this guard cannot see it and cannot mechanically prevent a standalone↔CDC
+double-write. **Do not enable this standalone producer in an environment where
+CDC is running until you have stopped CDC or decided replace-vs-coexist.**
+
+### 🔴 apply knock-on: es-indexer gets bounced
+
+`kustomization.yaml` pins `mininglamposs/octo-search-indexer` to `yuj5184` for
+the whole directory. Because the override is by image name, applying this
+directory will also bounce any already-running **es-indexer** onto `yuj5184`
+(one image, two binaries — they are meant to stay in lockstep).
+
+### Rollback is data-layer, not k8s-layer
+
+Once the producer has run and advanced the cursor / written Kafka, simply
+scaling down or reverting the manifest does **not** roll back the Kafka / DLQ /
+Redis cursor state. Data-layer rollback is a separate exercise.
+
+### Credentials surface
+
+The producer is the first workload in this directory to consume
+`DM_MYSQL_DSN`, so it gets DB privileges equivalent to octo-server. A
+least-privilege Secret / RBAC narrowing is a follow-up, not done here.
+
+### Not pinned to a digest
+
+`yuj5184` is a tag (mutable), not a digest. A reproducible digest pin belongs
+to the CICD (`v*` tag) work, not this manifest.

--- a/kustomize/search/kustomization.yaml
+++ b/kustomize/search/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - search-kafka-init.yaml
   - search-opensearch.yaml
   - es-indexer.yaml
+  - searchetl-producer.yaml
 
 images:
   - name: apache/kafka
@@ -27,5 +28,10 @@ images:
   # at it. The plugin version MUST match the OpenSearch version.
   - name: octo-search-opensearch-ik
     newTag: "2.17.0"
+  # Shared by es-indexer AND searchetl-producer (one image, two binaries) —
+  # this image-name override pins BOTH to the same tag, which is correct: the
+  # two binaries are built together and must stay in lockstep. yuj5184 is a
+  # manual/temporary build that contains both. NOTE: applying this directory
+  # will also bounce any already-running es-indexer onto this tag.
   - name: mininglamposs/octo-search-indexer
-    newTag: latest
+    newTag: yuj5184

--- a/kustomize/search/searchetl-producer.yaml
+++ b/kustomize/search/searchetl-producer.yaml
@@ -1,0 +1,124 @@
+# searchetl-producer: STANDALONE message-search producer (MySQL -> Kafka
+# octo.message.v1). It is the replacement for octo-server's built-in producer
+# (TS_KAFKA_ON); the two must never run together (shared cursor + Redis lock ->
+# double-write). This is the k8s equivalent of the compose `search-producer`
+# service + `search-producer-guard` (docker/docker-compose.yaml).
+#
+# OPT-IN, DEFAULT OFF. Shipped at replicas:0 and PRODUCER_ENABLED=false (double
+# opt-in). Enabling is owner-gated and has data-layer consequences — see
+# README.md "Standalone searchetl-producer".
+#
+# Shares the image with es-indexer (one image, two binaries) — the entrypoint
+# below selects the producer binary. Pin a real tag in kustomization.yaml.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: searchetl-producer
+  labels:
+    app: searchetl-producer
+spec:
+  # Default OFF: no pod is created. Enabling requires BOTH replicas:1 and
+  # PRODUCER_ENABLED=true (see README enable checklist). The initContainer
+  # mutex guard only runs on scale-up — exactly when it is needed.
+  replicas: 0
+  selector:
+    matchLabels:
+      app: searchetl-producer
+  template:
+    metadata:
+      labels:
+        app: searchetl-producer
+    spec:
+      initContainers:
+        # producer-mutex-guard: fail-closed mutual-exclusion check, the k8s
+        # equivalent of the compose `search-producer-guard`. Reuses the SAME
+        # is_on() union truthy logic (1|t|true|on|yes) — do NOT add a second
+        # truth table. If BOTH the standalone (this pod) and the built-in
+        # producer (octo-server TS_KAFKA_ON) are truthy, exit 1 so the pod
+        # never reaches Running. NOTE: this is single-direction (only blocks
+        # standalone start-up) and point-in-time (start-up only) — see README.
+        - name: producer-mutex-guard
+          image: busybox:1.36
+          env:
+            # Hardcoded true: the pod existing (operator scaled to replicas:1)
+            # is itself the statement of intent to run standalone. Driving this
+            # from PRODUCER_ENABLED would be a two-literal footgun (forget the
+            # guard env -> stale false -> guard bypassed). Hardcoding matches
+            # the compose fail-closed bias (over-block, never under-block).
+            - name: STANDALONE_ON
+              value: "true"
+            # Built-in producer toggle, read from octo-server's ConfigMap.
+            # optional:true covers BOTH "key missing" and "ConfigMap missing"
+            # -> empty -> treated as false.
+            - name: BUILTIN_ON
+              valueFrom:
+                configMapKeyRef:
+                  name: octo-server-env
+                  key: TS_KAFKA_ON
+                  optional: true
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              is_on() {
+                v=$(printf %s "${1:-}" | tr 'A-Z' 'a-z')
+                case "$v" in
+                  1|t|true|on|yes) return 0 ;;
+                  *) return 1 ;;
+                esac
+              }
+              # BUILTIN_ON may be UNSET (not just empty) when the optional
+              # configMapKeyRef's ConfigMap/key is absent — k8s omits the env
+              # var entirely. Under `set -u` a bare "$BUILTIN_ON" would abort;
+              # ${BUILTIN_ON:-} normalizes unset->empty so missing -> false.
+              if is_on "$STANDALONE_ON" && is_on "${BUILTIN_ON:-}"; then
+                echo "[guard] FATAL both producers on" >&2
+                exit 1
+              fi
+              echo "[guard] ok"
+      containers:
+        - name: searchetl-producer
+          image: mininglamposs/octo-search-indexer:latest
+          imagePullPolicy: Always
+          # Select the producer binary from the shared image.
+          command: ["/usr/local/bin/searchetl-producer"]
+          env:
+            # Master switch — OFF by default (defense in depth on top of
+            # replicas:0). Enabling needs this AND replicas:1.
+            - name: PRODUCER_ENABLED
+              value: "false"
+            # Required (no optional): the producer fail-fasts without these.
+            # Implicit prerequisite: the base octo-server-secret must already
+            # exist in the target namespace before scaling up.
+            - name: PRODUCER_MYSQL_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: octo-server-secret
+                  key: DM_MYSQL_DSN
+            - name: PRODUCER_REDIS_ADDR
+              valueFrom:
+                secretKeyRef:
+                  name: octo-server-secret
+                  key: DM_REDIS_ADDR
+            - name: PRODUCER_KAFKA_BROKERS
+              value: "search-kafka:9092"
+            - name: PRODUCER_KAFKA_TOPIC
+              value: "octo.message.v1"
+            - name: PRODUCER_KAFKA_DLQ_TOPIC
+              value: "octo.message.v1.dlq"
+            - name: PRODUCER_TABLES
+              value: "message,message1,message2,message3,message4"
+            - name: PRODUCER_LAG_SECONDS
+              value: "600"
+            - name: TZ
+              value: "UTC"
+          # No liveness/readiness probe — parity with es-indexer (which has
+          # none). No PVC — the producer has no DLQ-spill volume.
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi


### PR DESCRIPTION
## What

Add a standalone `searchetl-producer` Deployment to the opt-in `kustomize/search/` overlay, plus an initContainer mutual-exclusion guard — the k8s equivalent of the existing docker-compose `search-producer` + `search-producer-guard`.

**Manifest only: `replicas:0` default OFF, no apply / no cut-over.** This PR only produces the manifest; it does not deploy, apply, switch traffic, or touch any running deployment.

Scope is confined to `kustomize/search/` (3 files): new `searchetl-producer.yaml`, edited `kustomization.yaml`, edited `README.md`. No changes to `kustomize/base`, overlays, or docker compose.

### Key design points
- **Default OFF (double opt-in)**: `replicas: 0` **and** `PRODUCER_ENABLED=false`. Enabling requires flipping both, on a separate owner-gated action.
- **Mutex guard (initContainer)**: reuses the exact same `is_on()` union truthy logic as compose (`1|t|true|on|yes`, fail-closed, `set -eu`). `STANDALONE_ON` hardcoded `"true"`; `BUILTIN_ON` from optional `configMapKeyRef` `octo-server-env/TS_KAFKA_ON`. Single-direction (blocks standalone startup while built-in is on) and point-in-time (startup only) — both limits documented in the README.
- **Shared image pin**: `octo-search-indexer` pinned to a fixed tag for the whole directory (one image, two binaries — es-indexer and producer kept in lockstep). README notes the apply-time knock-on (es-indexer gets bounced to the same tag).
- **Parity with es-indexer**: no liveness/readiness probe, no PVC.

### Note: one correctness fix beyond the literal spec
The guard call site uses `is_on "${BUILTIN_ON:-}"` (unset-safe) rather than a bare `"$BUILTIN_ON"`. When the optional `configMapKeyRef`'s ConfigMap/key is absent, Kubernetes leaves the env var **unset** (not empty-string), and under `set -u` a bare expansion aborts the init container — which would block the producer in exactly the default state where the key is absent. The `${BUILTIN_ON:-}` form preserves the documented "missing → false" behavior. Independent review caught this; the empty-string truth-table check alone did not surface it.

## Verification (all 6 gates run locally)

**G1 — build + doc count 9→10**
```
$ kubectl kustomize kustomize/search >/dev/null && echo OK
OK
$ kubectl kustomize kustomize/search | grep -c '^kind:'
10
```

**G2/G3/G4 — structured (python3 + yaml) assertions**
```
G2/G3/G4 OK
```
Asserts: producer Deployment count==1, replicas==0, entrypoint `/usr/local/bin/searchetl-producer`, `PRODUCER_ENABLED=false`, `PRODUCER_MYSQL_DSN`/`PRODUCER_REDIS_ADDR` → secretKeyRef `octo-server-secret`, producer image pinned, initContainer `STANDALONE_ON="true"` + `BUILTIN_ON` configMapKeyRef `octo-server-env/TS_KAFKA_ON` optional:true, guard uses unset-safe `${BUILTIN_ON:-}` + `set -eu`, es-indexer on the same pin, no probes on producer.

**G5 — guard truth table in real busybox:1.36**
```
$ docker run --rm busybox:1.36 sh -c '... is_on union ...; g true true; g 1 TRUE; g on yes; g true false; g false false; g "" true'
FAIL FAIL FAIL OK OK OK
```
Plus end-to-end exec of the full guard with `set -eu`: `STANDALONE_ON=true` + unset `BUILTIN_ON` → `[guard] ok` exit 0; both truthy → `[guard] FATAL` exit 1.

**G6 — kubeconform (best-effort)**
```
Summary: 10 resources found parsing stdin - Valid: 10, Invalid: 0, Errors: 0, Skipped: 0
```

## Review status
- Independent model review (GPT-5.5): caught 1 blocking defect (the unset-vs-empty env case above) → fixed → re-reviewed PASS.
- All 6 gates green after the fix.

Closes the k8s searchetl-producer manifest work.
