### PR TITLE
feat(deploy): searchetl-producer Recreate strategy + replicas>1 unsupported note

### DIFF
--- a/kustomize/search/README.md
+++ b/kustomize/search/README.md
@@ -73,6 +73,15 @@ Enabling is a deliberate, owner-gated action with data-layer consequences:
    Deployment that is Running but produces nothing, or a guard that passed but
    a workload idling — neither produces messages.
 
+> **Single-pod design — `replicas > 1` is not supported.** This is a
+> single-active-producer workload: the app-layer Redis run-lock + cursor CAS
+> serialize work to one producer, so a second replica would idle on the lock at
+> best (and any contention is wasted/risk). Keep `replicas: 1` when enabled.
+> The Deployment uses `strategy: Recreate` (not the default RollingUpdate) so an
+> image/env rollout tears the old pod down before starting the new one, instead
+> of briefly running two producer pods — the init mutex guard only blocks the
+> built-in producer, not a same-Deployment overlap.
+
 ### Mutual-exclusion guard (and its limits)
 
 The pod runs an init container (`producer-mutex-guard`) that reuses the same

--- a/kustomize/search/searchetl-producer.yaml
+++ b/kustomize/search/searchetl-producer.yaml
@@ -21,6 +21,16 @@ spec:
   # PRODUCER_ENABLED=true (see README enable checklist). The initContainer
   # mutex guard only runs on scale-up — exactly when it is needed.
   replicas: 0
+  # Recreate (not the default RollingUpdate): this is a single-pod workload by
+  # design (replicas>1 is unsupported — Redis run-lock + cursor CAS serialize
+  # to one active producer). RollingUpdate would briefly run the old and new
+  # pod together during an image/env rollout; the init mutex guard only blocks
+  # the built-in producer, not a same-Deployment overlap. App-layer Redis
+  # run-lock + cursor CAS is the real safety net, so Recreate is defense in
+  # depth — it tears the old pod down before the new one starts, closing the
+  # one overlap window k8s would otherwise introduce.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: searchetl-producer


### PR DESCRIPTION
## What

Follow-up to #126 (k8s `searchetl-producer` + one-way mutex guard manifest), landing the single P2 reviewers flagged.

**P2-3:** the producer `Deployment` had no explicit `strategy`, so it defaulted to `RollingUpdate`. During an image/env rollout that can briefly run the old and new pod together. The init mutex guard only blocks the *built-in* producer (`TS_KAFKA_ON`); it does **not** block a same-`Deployment` overlap. App-layer Redis run-lock + cursor CAS is the real safety net, so this is **defense-in-depth, not a correctness fix** — but it matches the single-pod intent and closes the only overlap window k8s itself introduces.

## Changes (kustomize/search/ only)

1. `searchetl-producer.yaml`: add `strategy: { type: Recreate }` (tears the old pod down before starting the new one).
2. `README.md`: document that `replicas > 1` is unsupported (single-active-producer design, serialized by the Redis run-lock), and explain the Recreate choice.

19 lines, 2 files. **Manifest-only — no traffic cut, no apply.**

## Verification

- `kubectl kustomize kustomize/search` renders clean; `strategy: Recreate` present in output.
- `kubeconform` (v0.7.0, `-strict -ignore-missing-schemas -kubernetes-version 1.31.0 -schema-location default`, matching CI): **10 resources, Valid: 10, Invalid: 0, Errors: 0, Skipped: 0** ✅
- `yamllint` (CI ruleset) on `kustomize/`: clean ✅

## Out of scope (left for separate owner authorization)

- Swapping the hand-built tag `yuj5184` for a real release tag / digest.
- Wiring the `TS_KAFKA_ON` key into the `octo-server-env` ConfigMap (to actually activate the guard).

Part of #126
