### PR TITLE
fix(deploy): add imagePullSecrets to search producer/es-indexer for private TCR

### DIFF
--- a/kustomize/search/README.md
+++ b/kustomize/search/README.md
@@ -22,7 +22,11 @@ kubectl apply -k kustomize/search -n <ns>
    registry the dmwork-test cluster pulls from) — see "Image: pinned to a TCR
    digest" below. Repoint the digest there to roll forward; do not use a
    floating tag for production.
-3. **Topics**: created automatically by the `search-kafka-init` Job (the k8s
+3. **Private TCR pull secret**: the image lives in a **private** Tencent TCR, so
+   the target namespace MUST already hold an image-pull Secret and the manifests
+   MUST reference it (they do — see "Private TCR pull secret" below). Without it
+   both pods `ImagePullBackOff` and never start.
+4. **Topics**: created automatically by the `search-kafka-init` Job (the k8s
    equivalent of the compose init service) — required because broker
    auto-create is off and the indexer's DLQ producer uses
    `AllowAutoTopicCreation=false`. The Job waits for the broker, then creates
@@ -154,6 +158,51 @@ tbj7-xtiao-tcr1.tencentcloudcr.com/xtiao-release/dmwork/octo-search-indexer@sha2
 To roll the image forward, repoint the digest here (and, if needed, push a new
 `:vX.Y.Z` / `:<commit>` tag to TCR) — do not switch back to a floating tag.
 
+### Private TCR pull secret
+
+The image lives in a **private** Tencent TCR
+(`tbj7-xtiao-tcr1.tencentcloudcr.com/...`), so every pod that runs it needs an
+image-pull Secret. Both `es-indexer.yaml` and `searchetl-producer.yaml` declare:
+
+```yaml
+spec:
+  template:
+    spec:
+      imagePullSecrets:
+        - name: tcr-image-xtiao
+```
+
+- **Why it is required**: without a pull secret the kubelet cannot authenticate
+  to the private registry — the pod `ImagePullBackOff`s and never starts. This is
+  exactly the P1 found on dmwork-test: the raw `es-indexer` manifest running there
+  carried `imagePullSecrets` (the `tcr-image-xtiao` secret) while the kustomize
+  render did not, so the kustomize-managed producer would never have come up.
+- **Default `tcr-image-xtiao`**: this is the secret that exists on the
+  dmwork-test (xiaotiao-tke) cluster — the same cluster the digest above is
+  pinned for — so the default is self-consistent.
+- **🔴 Per-cluster override**: the secret name is **cluster-specific**. On any
+  other cluster you MUST (a) create the pull secret in the target namespace and
+  (b) override the name here. Prefer an overlay patch rather than editing this
+  base, e.g.:
+  ```yaml
+  # kustomize/overlays/<cluster>/imagepullsecret-patch.yaml
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: es-indexer          # repeat for searchetl-producer
+  spec:
+    template:
+      spec:
+        imagePullSecrets:
+          - name: <your-cluster-tcr-secret>
+  ```
+  Create the secret with, for example:
+  ```bash
+  kubectl create secret docker-registry <your-cluster-tcr-secret> \
+    --docker-server=tbj7-xtiao-tcr1.tencentcloudcr.com \
+    --docker-username=<user> --docker-password=<token> -n <ns>
+  ```
+
 ## Cut-over runbook (owner-gated; this PR does NOT cut over)
 
 > ⚠️ This directory ships **double-OFF** (`replicas: 0` **and**
@@ -173,6 +222,11 @@ To roll the image forward, repoint the digest here (and, if needed, push a new
    made — see the CDC double-write warning above. The guard cannot see CDC.
 4. The producer cursor is seeded to the current high-water mark, otherwise the
    producer re-streams history (full reload).
+5. The private-TCR image-pull Secret exists in the target namespace and is
+   referenced by the manifests. The default is `tcr-image-xtiao` (present on
+   dmwork-test); on any other cluster create the secret and override the name
+   via an overlay patch — see "Private TCR pull secret" above. Missing this →
+   `ImagePullBackOff`, the pod never starts.
 
 ### Apply (initial, still OFF)
 

--- a/kustomize/search/es-indexer.yaml
+++ b/kustomize/search/es-indexer.yaml
@@ -20,6 +20,15 @@ spec:
       labels:
         app: es-indexer
     spec:
+      # Private-registry pull secret — same private Tencent TCR as the producer
+      # (one image, two binaries). The raw manifest already running on
+      # dmwork-test carries this; once kustomize formally owns es-indexer the
+      # render must carry it too, or the pod ImagePullBackOffs. Default
+      # `tcr-image-xtiao` matches dmwork-test; other clusters MUST override the
+      # name (overlay patch) and ensure the secret exists — see README
+      # "Private TCR pull secret".
+      imagePullSecrets:
+        - name: tcr-image-xtiao
       containers:
         - name: es-indexer
           image: mininglamposs/octo-search-indexer:latest

--- a/kustomize/search/searchetl-producer.yaml
+++ b/kustomize/search/searchetl-producer.yaml
@@ -39,6 +39,17 @@ spec:
       labels:
         app: searchetl-producer
     spec:
+      # Private-registry pull secret. The image above resolves (via the
+      # image-name override in kustomization.yaml) to a private Tencent TCR
+      # (tbj7-xtiao-tcr1.tencentcloudcr.com/...), which needs a pull secret —
+      # without it the pod ImagePullBackOffs and never starts. The default
+      # `tcr-image-xtiao` matches the dmwork-test (xiaotiao-tke) cluster, which
+      # is also the cluster the digest in kustomization.yaml is pinned for.
+      # Other clusters MUST override this name (patch in an overlay) AND ensure
+      # the secret exists in the target namespace — see README "Private TCR
+      # pull secret".
+      imagePullSecrets:
+        - name: tcr-image-xtiao
       initContainers:
         # producer-mutex-guard: fail-closed mutual-exclusion check, the k8s
         # equivalent of the compose `search-producer-guard`. Reuses the SAME


### PR DESCRIPTION
## What

`kubectl kustomize kustomize/search` rendered the `searchetl-producer` and `es-indexer` Deployments **without `imagePullSecrets`**, but the shared image is pinned (in `kustomization.yaml`) to a **private** Tencent TCR (`tbj7-xtiao-tcr1.tencentcloudcr.com/...`). With no pull secret the kubelet can't authenticate → pod `ImagePullBackOff`, never starts.

This is a **P1 found during a real cut-over test on the dmwork-test (xiaotiao-tke) TKE cluster**. The es-indexer already running there works only because it was applied from a raw manifest that carried `imagePullSecrets` (the `tcr-image-xtiao` secret); the kustomize render dropped that line, so the kustomize-managed producer would never have come up. Once kustomize formally owns these workloads, the render must carry the secret itself.

## Changes (manifest + docs only)

- **`searchetl-producer.yaml`** — add `spec.template.spec.imagePullSecrets` (default `tcr-image-xtiao`).
- **`es-indexer.yaml`** — same, so the kustomize-owned es-indexer keeps the pull secret the raw version had.
- **`README.md`** — new "Private TCR pull secret" section + a cut-over precondition, documenting that the secret name is cluster-specific and how to override it per cluster (create the secret + overlay patch).

The default `tcr-image-xtiao` is self-consistent: it's the secret present on dmwork-test, which is the same cluster the pinned digest already targets. Other clusters override the name via an overlay patch (documented in the README).

## Verification

- `kubectl kustomize kustomize/search` now renders `imagePullSecrets` on **both** the producer and es-indexer Deployments.
- `kubeconform -strict` ✅ green (10/10 resources valid).
- Both overlays still validate (17/17 each); `yamllint` clean.

## Scope

Manifest/docs only — no apply, no cut-over. Ships unchanged double-OFF (`replicas: 0` + `PRODUCER_ENABLED=false`).
