### PR TITLE
fix(deploy): searchetl-producer dedicated secret — fix CreateContainerConfigError on octo-server-secret DSN keys

### DIFF
--- a/kustomize/search/README.md
+++ b/kustomize/search/README.md
@@ -69,9 +69,16 @@ opt-in). Applying this directory creates the Deployment but no pod.
 
 Enabling is a deliberate, owner-gated action with data-layer consequences:
 
-1. Confirm the base Secret `octo-server-secret` already exists in the target
-   namespace — the producer's `PRODUCER_MYSQL_DSN` / `PRODUCER_REDIS_ADDR` are
-   **required** `secretKeyRef`s and the pod will not start without it.
+1. Create the dedicated Secret `searchetl-producer-secret` in the target
+   namespace — copy `searchetl-producer-secret.example.yaml` to
+   `searchetl-producer-secret.yaml`, fill in `PRODUCER_MYSQL_DSN` /
+   `PRODUCER_REDIS_ADDR`, then `kubectl apply -f`. These are **required**
+   `secretKeyRef`s and the pod will not start without them
+   (`CreateContainerConfigError`). 🔴 The DSN MUST point at the **live message
+   DB** the IM backend writes to (the DB whose `message` 5-shard tables the
+   producer polls — NOT necessarily the DB octo-server itself points at), and
+   `PRODUCER_REDIS_ADDR` MUST be the **same Redis the built-in producer uses**
+   so the shared run-lock actually achieves mutual exclusion.
 2. Confirm the producer cursor is seeded to the current high-water mark —
    otherwise the producer re-streams history (a full reload).
 3. Flip **both** switches together: set `replicas: 1` **and**
@@ -145,9 +152,12 @@ Redis cursor state. Data-layer rollback is a separate exercise.
 
 ### Credentials surface
 
-The producer is the first workload in this directory to consume
-`DM_MYSQL_DSN`, so it gets DB privileges equivalent to octo-server. A
-least-privilege Secret / RBAC narrowing is a follow-up, not done here.
+The producer reads the live message DB directly, so its DSN
+(`searchetl-producer-secret`) carries DB privileges over that data. It uses its
+own dedicated Secret rather than borrowing octo-server-secret — this keeps the
+producer's DB/Redis target explicit and decoupled from octo-server's own
+connection (which may point at a different DB). A least-privilege DB user / RBAC
+narrowing is a follow-up, not done here.
 
 ### Image: pinned to a TCR digest
 
@@ -228,11 +238,11 @@ spec:
 
 ### Preconditions
 
-1. `octo-server-secret` exists in the target namespace (provides
-   `DM_MYSQL_DSN` / `DM_REDIS_ADDR` the producer needs).
-2. Built-in producer is OFF: `TS_KAFKA_ON=false` in ConfigMap
-   `octo-server-env` (the default shipped here). The init mutex guard reads
-   this key — if it is truthy, the producer pod's init container exits 1.
+1. `searchetl-producer-secret` exists in the target namespace (provides
+   `PRODUCER_MYSQL_DSN` / `PRODUCER_REDIS_ADDR` — the live message DB DSN and
+   the shared-lock Redis addr the producer needs). See the Enable checklist.
+2. Built-in producer is OFF. The init mutex guard reads `TS_KAFKA_ON` from
+   ConfigMap `octo-server-env` (the default shipped here is `false`).
    **The ConfigMap must actually exist in `<ns>`** — this overlay only
    references it (`optional: true`), so a missing `octo-server-env` makes the
    guard a no-op (see "Mutual-exclusion guard" above). Confirm:
@@ -240,6 +250,11 @@ spec:
    kubectl get configmap octo-server-env -n <ns> -o jsonpath='{.data.TS_KAFKA_ON}'
    # expect: false  (empty / NotFound => apply base first; the guard is armed against nothing)
    ```
+   🔴 But `TS_KAFKA_ON` is only the OSS octo-server's toggle. In a fork/dmwork
+   deployment the real running built-in producer may be a different workload
+   (e.g. the IM backend's own `kafka.on` in its `tsdd.yaml`) that the guard
+   CANNOT see — confirm every built-in producer is off before enabling, not
+   just `TS_KAFKA_ON`.
 3. CDC (`octo-messages-sync`) is stopped or a replace-vs-coexist decision is
    made — see the CDC double-write warning above. The guard cannot see CDC.
 4. The producer cursor is seeded to the current high-water mark, otherwise the

--- a/kustomize/search/searchetl-producer-secret.example.yaml
+++ b/kustomize/search/searchetl-producer-secret.example.yaml
@@ -1,0 +1,34 @@
+# searchetl-producer Secret template — the producer's MySQL/Redis connection
+# strings live HERE, in a dedicated Secret, NOT in octo-server-secret.
+#
+# Why a dedicated Secret (and not octo-server-secret):
+#   - The OSS octo-server-secret contract carries DM_MYSQL_DSN / DM_REDIS_ADDR,
+#     but real clusters do not always provision those keys (e.g. dmwork-test's
+#     octo-server-secret has only the 5 *_KEY / *_TOKEN / *_SECRET keys), so a
+#     hard secretKeyRef into it fails the pod with CreateContainerConfigError.
+#   - The producer must read the SAME live message DB as the running IM backend,
+#     which is not necessarily the DB octo-server itself points at. Pinning the
+#     producer's own DSN here keeps it explicit and decoupled.
+#   - This mirrors the sibling same-repo MySQL reader (octo-search-batch), which
+#     already gets its MYSQL_DSN from its own dedicated Secret.
+#
+# Copy to `searchetl-producer-secret.yaml`, replace every CHANGE_ME_* with real
+# values, then apply directly: `kubectl apply -n <ns> -f searchetl-producer-secret.yaml`.
+# Do NOT add the copied file to git — see ../../.gitignore (*-secret.yaml).
+#
+# 🔴 The DSN MUST point at the live message DB that the IM backend writes to
+# (the same DB whose `message` 5-shard tables the producer polls), and
+# PRODUCER_REDIS_ADDR MUST be the SAME Redis the built-in producer uses — the
+# distributed run-lock only achieves mutual exclusion if both sides share it.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: searchetl-producer-secret
+type: Opaque
+stringData:
+  # Full Go-MySQL DSN of the LIVE message DB (user:pass@tcp(host:port)/db?...).
+  # e.g. root:pass@tcp(10.208.14.23:3306)/im_test?charset=utf8mb4&parseTime=true&loc=Local
+  PRODUCER_MYSQL_DSN: "CHANGE_ME_MYSQL_DSN"
+  # host:port of the Redis backing the shared run-lock (same one the built-in
+  # producer uses). e.g. redis-svc.dmwork-test:6379
+  PRODUCER_REDIS_ADDR: "CHANGE_ME_REDIS_ADDR"

--- a/kustomize/search/searchetl-producer.yaml
+++ b/kustomize/search/searchetl-producer.yaml
@@ -110,18 +110,28 @@ spec:
             - name: PRODUCER_ENABLED
               value: "false"
             # Required (no optional): the producer fail-fasts without these.
-            # Implicit prerequisite: the base octo-server-secret must already
-            # exist in the target namespace before scaling up.
+            # Sourced from the producer's OWN dedicated Secret
+            # (searchetl-producer-secret), NOT octo-server-secret. Rationale:
+            # octo-server-secret does not reliably carry DM_MYSQL_DSN /
+            # DM_REDIS_ADDR in real clusters (e.g. dmwork-test's only has the 5
+            # *_KEY/*_TOKEN/*_SECRET keys), so a hard secretKeyRef into it fails
+            # the pod with CreateContainerConfigError; and the producer must read
+            # the LIVE message DB, which is not necessarily the DB octo-server
+            # points at. Mirrors the sibling same-repo MySQL reader
+            # (octo-search-batch), which uses its own dedicated Secret too.
+            # Implicit prerequisite: searchetl-producer-secret must exist in the
+            # target namespace before scaling up — copy
+            # searchetl-producer-secret.example.yaml, fill in real values, apply.
             - name: PRODUCER_MYSQL_DSN
               valueFrom:
                 secretKeyRef:
-                  name: octo-server-secret
-                  key: DM_MYSQL_DSN
+                  name: searchetl-producer-secret
+                  key: PRODUCER_MYSQL_DSN
             - name: PRODUCER_REDIS_ADDR
               valueFrom:
                 secretKeyRef:
-                  name: octo-server-secret
-                  key: DM_REDIS_ADDR
+                  name: searchetl-producer-secret
+                  key: PRODUCER_REDIS_ADDR
             - name: PRODUCER_KAFKA_BROKERS
               value: "search-kafka:9092"
             - name: PRODUCER_KAFKA_TOPIC


### PR DESCRIPTION
## Problem

`searchetl-producer.yaml` wired `PRODUCER_MYSQL_DSN` / `PRODUCER_REDIS_ADDR` as **hard** `secretKeyRef`s into `octo-server-secret` (keys `DM_MYSQL_DSN` / `DM_REDIS_ADDR`). On a real cluster (dmwork-test) `octo-server-secret` carries only 5 keys (`DMWORK_MASTER_KEY` / `NOTIFY_INTERNAL_TOKEN` / `OCTO_INTERNAL_HMAC_SECRET` / `OCTO_JWT_SECRET` / `OCTO_MASTER_KEY`) — those DSN keys do not exist, so the pod fails with `CreateContainerConfigError` and never starts.

Verified live (`kubectl -n dmwork-test`):
- `octo-server-secret` has no `DM_MYSQL_DSN` / `DM_REDIS_ADDR`.
- The **live message DB** the IM backend writes to is `im_test@10.208.14.23:3306` (password-protected), Redis `redis-svc.dmwork-test:6379` — sourced from `dmworkim-develop`'s `tsdd.yaml`, **not** from any secret key, and **not** the cold DB OSS octo-server itself points at (`octo_im_test@10.10.145.87`).
- The sibling same-repo MySQL reader `octo-search-batch` already gets its `MYSQL_DSN` from its **own dedicated Secret** via `envFrom` — the established precedent.

## Fix

Give the producer its own dedicated Secret `searchetl-producer-secret` (keys `PRODUCER_MYSQL_DSN` / `PRODUCER_REDIS_ADDR`), decoupled from `octo-server-secret`:

- Repoint the two `secretKeyRef`s in `searchetl-producer.yaml`.
- Add `searchetl-producer-secret.example.yaml` template (no credentials in git; `*-secret.yaml` is already gitignored).
- Update README enable-checklist / preconditions / credentials-surface, including a 🔴 note that the DSN must target the **live** message DB and Redis must be the **same** instance the built-in producer uses (shared run-lock = real mutual exclusion).
- README also flags that the init mutex guard only sees octo-server's `TS_KAFKA_ON`, not a fork IM backend's own `kafka.on` — relevant at cut-over, tracked separately.

Still ships **double-OFF** (`replicas: 0` + `PRODUCER_ENABLED=false`). No cut-over performed.

## Validation
- `kubectl kustomize kustomize/search` renders clean; `.example` Secret is **not** a kustomization resource (0 Secret objects rendered).
- `kubeconform -strict`: 10/10 valid.
- `/codex review`: PASS — no blocking findings; confirmed `.gitignore` covers `searchetl-producer-secret.yaml`.

Part of #5206
