### PR TITLE
chore(deployment): pin TS_KAFKA_ON=false and document its guard role

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -475,14 +475,17 @@ OCTO_SEARCH_BACKEND=disabled
 # any real search deployment: openssl rand -hex 32
 # OCTO_SEARCH_CURSOR_HMAC=
 # Built-in producer (searchetl -> Kafka) master switch — maps to octo-server's
-# TS_KAFKA_ON. PINNED false: the built-in (in-octo-server) producer is being
-# retired in favor of the standalone search-producer service below, so leave
-# this false permanently. It is still read back as BUILTIN_ON by the
-# `search-producer-guard` to keep the standalone and built-in producers from
-# ever running together (shared cursor + Redis lock -> double-write if both on),
-# so do not remove it. (Historically it also had to stay false until the upgrade
-# flow seeded the extraction cursor to the message high-watermark; a zero cursor
-# re-streams the entire message history.)
+# TS_KAFKA_ON. Default false (off). In Docker the built-in producer is still the
+# supported real-time path: the "Turn search on" flow (scripted by
+# scripts/search-upgrade.sh, see docker/README.md) flips this to true AFTER
+# seeding the extraction cursor to the message high-watermark — turning it on
+# with a zero cursor re-streams the entire message history. A standalone
+# search-producer profile also exists below as an alternative producer.
+# Whichever you run, do NOT remove this key: it is read back as BUILTIN_ON by
+# the `search-producer-guard`, which blocks the built-in and standalone
+# producers from ever running together (they share the cursor + a Redis lock ->
+# double-write if both on). A missing key reads as false and silently neuters
+# that guard.
 OCTO_SEARCH_PRODUCER_ON=false
 # Broker list octo-server's producer connects to (in-network DNS name).
 # OCTO_SEARCH_KAFKA_BROKERS=search-kafka:9092

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -484,9 +484,11 @@ OCTO_SEARCH_BACKEND=disabled
 # profile also exists below as an alternative producer; the standalone-producer
 # cut-over currently applies to the Kubernetes path only.
 # Do NOT remove this key: it is read back as BUILTIN_ON by the
-# `search-producer-guard`, which blocks the built-in and standalone producers
-# from ever running together (they share the cursor + a Redis lock ->
-# double-write if both on). A missing key reads as false and silently neuters
+# `search-producer-guard`. At container start/recreate that guard blocks the
+# both-on state in both directions (octo-server and the standalone
+# search-producer both depend_on it), but it does NOT catch a runtime toggle
+# flip on an already-running producer. They share the cursor + a Redis lock ->
+# double-write if both on. A missing key reads as false and silently neuters
 # that guard.
 OCTO_SEARCH_PRODUCER_ON=false
 # Broker list octo-server's producer connects to (in-network DNS name).

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -474,9 +474,15 @@ OCTO_SEARCH_BACKEND=disabled
 # back to a published (forgeable, authz-free) constant; set a random value for
 # any real search deployment: openssl rand -hex 32
 # OCTO_SEARCH_CURSOR_HMAC=
-# Real-time producer (searchetl -> Kafka) master switch. Keep false until the
-# upgrade flow has seeded the extraction cursor to the message high-watermark;
-# turning it on with a zero cursor re-streams the entire message history.
+# Built-in producer (searchetl -> Kafka) master switch — maps to octo-server's
+# TS_KAFKA_ON. PINNED false: the built-in (in-octo-server) producer is being
+# retired in favor of the standalone search-producer service below, so leave
+# this false permanently. It is still read back as BUILTIN_ON by the
+# `search-producer-guard` to keep the standalone and built-in producers from
+# ever running together (shared cursor + Redis lock -> double-write if both on),
+# so do not remove it. (Historically it also had to stay false until the upgrade
+# flow seeded the extraction cursor to the message high-watermark; a zero cursor
+# re-streams the entire message history.)
 OCTO_SEARCH_PRODUCER_ON=false
 # Broker list octo-server's producer connects to (in-network DNS name).
 # OCTO_SEARCH_KAFKA_BROKERS=search-kafka:9092

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -475,15 +475,17 @@ OCTO_SEARCH_BACKEND=disabled
 # any real search deployment: openssl rand -hex 32
 # OCTO_SEARCH_CURSOR_HMAC=
 # Built-in producer (searchetl -> Kafka) master switch — maps to octo-server's
-# TS_KAFKA_ON. Default false (off). In Docker the built-in producer is still the
-# supported real-time path: the "Turn search on" flow (scripted by
-# scripts/search-upgrade.sh, see docker/README.md) flips this to true AFTER
-# seeding the extraction cursor to the message high-watermark — turning it on
-# with a zero cursor re-streams the entire message history. A standalone
-# search-producer profile also exists below as an alternative producer.
-# Whichever you run, do NOT remove this key: it is read back as BUILTIN_ON by
-# the `search-producer-guard`, which blocks the built-in and standalone
-# producers from ever running together (they share the cursor + a Redis lock ->
+# TS_KAFKA_ON. This Docker compose path still uses the built-in producer; the
+# "Turn search on" flow (scripted by scripts/search-upgrade.sh, see
+# docker/README.md) turns it on as the supported flow, flipping this to true
+# AFTER seeding the extraction cursor to the message high-watermark (turning it
+# on with a zero cursor re-streams the entire message history). Keep this
+# default false for a fresh / non-upgraded deploy. A standalone search-producer
+# profile also exists below as an alternative producer; the standalone-producer
+# cut-over currently applies to the Kubernetes path only.
+# Do NOT remove this key: it is read back as BUILTIN_ON by the
+# `search-producer-guard`, which blocks the built-in and standalone producers
+# from ever running together (they share the cursor + a Redis lock ->
 # double-write if both on). A missing key reads as false and silently neuters
 # that guard.
 OCTO_SEARCH_PRODUCER_ON=false

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -764,14 +764,16 @@ services:
       # OFF means the scheduler never starts (zero overhead) and is the correct
       # state for a no-search deployment.
       #
-      # In Docker the built-in producer is still the supported real-time path:
-      # the `search` profile "Turn search on" flow (scripted by
-      # scripts/search-upgrade.sh, see docker/README.md) turns this ON only
-      # AFTER the extraction cursor has been seeded to each message shard's
-      # high-watermark — otherwise the cursor starts at 0 and the producer
-      # re-streams the entire message history (a full double-ingest on top of
-      # the one-shot backfill). A standalone search-producer profile also exists
-      # below as an alternative producer.
+      # This Docker compose path still uses the built-in producer as the
+      # supported real-time flow: the `search` profile "Turn search on" runbook
+      # (scripted by scripts/search-upgrade.sh, see docker/README.md) turns this
+      # ON only AFTER the extraction cursor has been seeded to each message
+      # shard's high-watermark — otherwise the cursor starts at 0 and the
+      # producer re-streams the entire message history (a full double-ingest on
+      # top of the one-shot backfill). Keep this default OFF for a fresh /
+      # non-upgraded deploy. A standalone search-producer profile also exists
+      # below as an alternative producer; the standalone-producer cut-over
+      # currently applies to the Kubernetes path only.
       #
       # NOTE: do NOT delete this line. The key is read back as BUILTIN_ON by the
       # `search-producer-guard` service to enforce that the standalone and

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -757,25 +757,27 @@ services:
       # set a random value in .env for any real search deployment.
       OCTO_SEARCH_CURSOR_HMAC: ${OCTO_SEARCH_CURSOR_HMAC:-}
       # -----------------------------------------------------------------
-      # Real-time search producer (searchetl → Kafka) — PINNED OFF
+      # Real-time search producer (searchetl → Kafka) — OFF by default
       # -----------------------------------------------------------------
       # The searchetl module streams new messages into Kafka for the indexer
       # to consume. It is gated by Kafka.On (Viper key kafka.on ← TS_KAFKA_ON);
       # OFF means the scheduler never starts (zero overhead) and is the correct
       # state for a no-search deployment.
       #
-      # NOTE: the built-in (in-octo-server) producer is being retired in favor
-      # of the standalone search-producer service, so TS_KAFKA_ON is expected to
-      # stay OFF here permanently — keep OCTO_SEARCH_PRODUCER_ON=false. The key
-      # is NOT dead: it is read back as BUILTIN_ON by the `search-producer-guard`
-      # service to enforce that the standalone and built-in producers never run
-      # together (they share the cursor table octo_etl_es_cursor + a Redis lock;
-      # running both double-writes/reorders Kafka). Do not delete this line.
-      # (Historically the `search` profile turned this on only AFTER the
-      # extraction cursor was seeded to each message shard's high-watermark,
-      # otherwise the cursor started at 0 and the producer re-streamed the entire
-      # message history. The standalone path now carries that cut-over; see
-      # docker/README.md "Turn search on".)
+      # In Docker the built-in producer is still the supported real-time path:
+      # the `search` profile "Turn search on" flow (scripted by
+      # scripts/search-upgrade.sh, see docker/README.md) turns this ON only
+      # AFTER the extraction cursor has been seeded to each message shard's
+      # high-watermark — otherwise the cursor starts at 0 and the producer
+      # re-streams the entire message history (a full double-ingest on top of
+      # the one-shot backfill). A standalone search-producer profile also exists
+      # below as an alternative producer.
+      #
+      # NOTE: do NOT delete this line. The key is read back as BUILTIN_ON by the
+      # `search-producer-guard` service to enforce that the standalone and
+      # built-in producers never run together (they share the cursor table
+      # octo_etl_es_cursor + a Redis lock; running both double-writes/reorders
+      # Kafka). A missing key reads as false and silently neuters that guard.
       TS_KAFKA_ON: ${OCTO_SEARCH_PRODUCER_ON:-false}
       TS_KAFKA_BROKERS: ${OCTO_SEARCH_KAFKA_BROKERS:-search-kafka:9092}
       TS_KAFKA_TOPIC: ${OCTO_SEARCH_KAFKA_TOPIC:-octo.message.v1}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -757,16 +757,25 @@ services:
       # set a random value in .env for any real search deployment.
       OCTO_SEARCH_CURSOR_HMAC: ${OCTO_SEARCH_CURSOR_HMAC:-}
       # -----------------------------------------------------------------
-      # Real-time search producer (searchetl → Kafka) — OFF by default
+      # Real-time search producer (searchetl → Kafka) — PINNED OFF
       # -----------------------------------------------------------------
       # The searchetl module streams new messages into Kafka for the indexer
       # to consume. It is gated by Kafka.On (Viper key kafka.on ← TS_KAFKA_ON);
       # OFF means the scheduler never starts (zero overhead) and is the correct
-      # state for a no-search deployment. The `search` profile upgrade turns it
-      # on ONLY AFTER the extraction cursor has been seeded to each message
-      # shard's high-watermark — otherwise the cursor starts at 0 and the
-      # producer re-streams the entire message history (a full double-ingest on
-      # top of the one-shot backfill). See docker/README.md "Turn search on".
+      # state for a no-search deployment.
+      #
+      # NOTE: the built-in (in-octo-server) producer is being retired in favor
+      # of the standalone search-producer service, so TS_KAFKA_ON is expected to
+      # stay OFF here permanently — keep OCTO_SEARCH_PRODUCER_ON=false. The key
+      # is NOT dead: it is read back as BUILTIN_ON by the `search-producer-guard`
+      # service to enforce that the standalone and built-in producers never run
+      # together (they share the cursor table octo_etl_es_cursor + a Redis lock;
+      # running both double-writes/reorders Kafka). Do not delete this line.
+      # (Historically the `search` profile turned this on only AFTER the
+      # extraction cursor was seeded to each message shard's high-watermark,
+      # otherwise the cursor started at 0 and the producer re-streamed the entire
+      # message history. The standalone path now carries that cut-over; see
+      # docker/README.md "Turn search on".)
       TS_KAFKA_ON: ${OCTO_SEARCH_PRODUCER_ON:-false}
       TS_KAFKA_BROKERS: ${OCTO_SEARCH_KAFKA_BROKERS:-search-kafka:9092}
       TS_KAFKA_TOPIC: ${OCTO_SEARCH_KAFKA_TOPIC:-octo.message.v1}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -776,10 +776,13 @@ services:
       # currently applies to the Kubernetes path only.
       #
       # NOTE: do NOT delete this line. The key is read back as BUILTIN_ON by the
-      # `search-producer-guard` service to enforce that the standalone and
-      # built-in producers never run together (they share the cursor table
-      # octo_etl_es_cursor + a Redis lock; running both double-writes/reorders
-      # Kafka). A missing key reads as false and silently neuters that guard.
+      # `search-producer-guard` service. At container start/recreate that guard
+      # blocks the both-on state in both directions (both octo-server and the
+      # standalone search-producer depend_on it), but it does NOT catch a
+      # runtime toggle flip on an already-running producer. Both producers share
+      # the cursor table octo_etl_es_cursor + a Redis lock; running both
+      # double-writes/reorders Kafka. A missing key reads as false and silently
+      # neuters that guard.
       TS_KAFKA_ON: ${OCTO_SEARCH_PRODUCER_ON:-false}
       TS_KAFKA_BROKERS: ${OCTO_SEARCH_KAFKA_BROKERS:-search-kafka:9092}
       TS_KAFKA_TOPIC: ${OCTO_SEARCH_KAFKA_TOPIC:-octo.message.v1}

--- a/kustomize/base/octo-server-env-config.yaml
+++ b/kustomize/base/octo-server-env-config.yaml
@@ -34,13 +34,18 @@ data:
   DM_SPACE_DISABLE_USER_CREATE: "true"
   DM_THREAD_ON: "true"
 
-  # Built-in searchetl producer toggle. "false" = OFF (current behavior:
-  # octo-server does NOT run its built-in message-search producer). This key is
-  # also read by the kustomize/search standalone searchetl-producer's
-  # init mutex guard (`producer-mutex-guard`, BUILTIN_ON via configMapKeyRef);
-  # defining it here arms that guard — with the key present, starting the
-  # standalone producer while this is truthy makes the init container exit 1.
-  # Keep "false" unless deliberately cutting over to the built-in producer.
+  # Built-in searchetl producer toggle — PINNED "false" (OFF). DO NOT DELETE.
+  # The built-in (in-octo-server) message-search producer is being retired in
+  # favor of the standalone searchetl-producer (kustomize/search), so this key
+  # no longer arms a live producer here and is expected to stay "false"
+  # permanently. Its remaining purpose is to feed the standalone producer's
+  # init mutex guard (`producer-mutex-guard`), which reads this value as
+  # BUILTIN_ON via configMapKeyRef to enforce that the standalone and built-in
+  # producers never run at the same time (they share the cursor table
+  # octo_etl_es_cursor + a Redis lock; running both double-writes/reorders
+  # Kafka). Keep the key present and "false": deleting it silently neuters the
+  # guard (missing key -> treated as false -> no-op, weakening the both-on
+  # protection), and flipping it truthy makes the standalone guard exit 1.
   TS_KAFKA_ON: "false"
 
   # WukongIM endpoints (public TCP/WS addresses — adjust to your deploy)

--- a/kustomize/base/octo-server-env-config.yaml
+++ b/kustomize/base/octo-server-env-config.yaml
@@ -37,15 +37,21 @@ data:
   # Built-in searchetl producer toggle — PINNED "false" (OFF). DO NOT DELETE.
   # The built-in (in-octo-server) message-search producer is being retired in
   # favor of the standalone searchetl-producer (kustomize/search), so this key
-  # no longer arms a live producer here and is expected to stay "false"
-  # permanently. Its remaining purpose is to feed the standalone producer's
-  # init mutex guard (`producer-mutex-guard`), which reads this value as
-  # BUILTIN_ON via configMapKeyRef to enforce that the standalone and built-in
-  # producers never run at the same time (they share the cursor table
-  # octo_etl_es_cursor + a Redis lock; running both double-writes/reorders
-  # Kafka). Keep the key present and "false": deleting it silently neuters the
-  # guard (missing key -> treated as false -> no-op, weakening the both-on
-  # protection), and flipping it truthy makes the standalone guard exit 1.
+  # is no longer intended to be used to arm the built-in producer here and is
+  # expected to stay "false". Its remaining purpose is to feed the standalone
+  # producer's init mutex guard (`producer-mutex-guard`), which reads this value
+  # as BUILTIN_ON via configMapKeyRef. That guard blocks the both-on state only
+  # at container start, and only in one direction: it refuses to start the
+  # standalone producer while the built-in is truthy, but does NOT block the
+  # reverse (rolling out octo-server with TS_KAFKA_ON=true while the standalone
+  # is already Running), and does NOT catch a runtime toggle flip on an
+  # already-running producer. See kustomize/search/README.md ("Mutual-exclusion
+  # guard (and its limits)") for the full guard scope. Both producers share the
+  # cursor table octo_etl_es_cursor + a Redis lock; running both
+  # double-writes/reorders Kafka. Keep the key present and "false": deleting it
+  # silently neuters the guard (missing key -> treated as false -> no-op,
+  # weakening the protection), and flipping it truthy makes the standalone guard
+  # exit 1.
   TS_KAFKA_ON: "false"
 
   # WukongIM endpoints (public TCP/WS addresses — adjust to your deploy)


### PR DESCRIPTION
## What

Comments-only change that pins `TS_KAFKA_ON` / `OCTO_SEARCH_PRODUCER_ON` to `false` and documents why the key must stay present and false.

The built-in (in-octo-server) search producer is being retired in favor of the standalone `search-producer` service. `TS_KAFKA_ON` is now expected to stay `false` permanently. It is **not** dead config: it is read back as `BUILTIN_ON` by the producer mutex guard — `producer-mutex-guard` (init container in `kustomize/search/searchetl-producer.yaml`, via `configMapKeyRef`) and the `search-producer-guard` service in `docker-compose.yaml`. The guard enforces that the standalone and built-in producers never run together; they share the `octo_etl_es_cursor` cursor table + a Redis lock, so running both double-writes/reorders Kafka.

Deleting the key would silently neuter the guard (missing key → treated as false → no-op), weakening the both-on protection. The updated comments make that contract explicit.

## Changes

- `kustomize/base/octo-server-env-config.yaml` — clarify `TS_KAFKA_ON` is pinned false and feeds the standalone guard; do not delete.
- `docker/docker-compose.yaml` — same note on the `octo-server` `TS_KAFKA_ON` env block.
- `docker/.env.example` — same note on `OCTO_SEARCH_PRODUCER_ON`.

## Risk

None. Comments only — no values, no behavior, no code, no DB changes.

## Verification

- `kubectl kustomize kustomize/overlays/prod | grep TS_KAFKA_ON` → `TS_KAFKA_ON: "false"` ✅
- `kubectl kustomize kustomize/overlays/dev  | grep TS_KAFKA_ON` → `TS_KAFKA_ON: "false"` ✅
- `kubectl kustomize kustomize/search` → `producer-mutex-guard` still wires `BUILTIN_ON` via `configMapKeyRef` → `TS_KAFKA_ON` ✅
- `git diff` touches only the 3 files above, comments only ✅
