### PR TITLE
feat: search opt-in parity across deployment entry points (Fixes #134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,24 @@ Whichever you pick, three things must line up between WuKongIM and `octo-server`
 | `webhook.grpcAddr` (the address WuKongIM dials back into) | `<octo-server-svc>:6979` so message events reach OCTO |
 | `external.ip` / `external.wsAddr` / `external.wssAddr` (the public endpoints WuKongIM advertises to clients) | should match how end-user clients reach WuKongIM via your ingress / LB |
 
+## Optional message search
+
+Message search (Kafka + OpenSearch[analysis-ik] + es-indexer) is an **optional**
+component and is **default OFF on every entry point**. Each entry point opts in
+explicitly; the default install path renders **zero** search resources.
+
+| Entry point | Opt-in | Default |
+|---|---|---|
+| Docker Compose | `./setup.sh --search` (or `COMPOSE_PROFILES=search`) | off |
+| Helm | `--set search.enabled=true` | off |
+| Kustomize | `kubectl apply -k kustomize/search` (standalone, not referenced by base/overlays) | off |
+
+All three deploy the search **infrastructure** only; wiring octo-server onto
+OpenSearch is a separate, owner-gated step. See
+[`docker/README.md`](./docker/README.md) "Search profile",
+[`helm/octo/README.md`](./helm/octo/README.md) "Search (optional)", and
+[`kustomize/search/README.md`](./kustomize/search/README.md).
+
 ## Layout
 
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -139,6 +139,23 @@ OCTO 不内置 IM 引擎，通过 HTTP API + webhook gRPC 调用 [WuKongIM](http
 | `webhook.grpcAddr`（WuKongIM 回调地址） | `<octo-server-svc>:6979`，让 IM 消息事件能回到 OCTO |
 | `external.ip` / `external.wsAddr` / `external.wssAddr`（WuKongIM 对客户端暴露的公网地址） | 与终端客户端经 ingress / LB 访问 WuKongIM 的实际地址一致 |
 
+## 可选消息搜索
+
+消息搜索（Kafka + OpenSearch[analysis-ik] + es-indexer）是**可选**组件，
+**在每个部署入口都默认关闭**。每个入口都需显式 opt-in；默认安装路径渲染**零**个
+搜索资源。
+
+| 部署入口 | 开启方式 | 默认 |
+|---|---|---|
+| Docker Compose | `./setup.sh --search`（或 `COMPOSE_PROFILES=search`） | 关 |
+| Helm | `--set search.enabled=true` | 关 |
+| Kustomize | `kubectl apply -k kustomize/search`（独立，不被 base/overlays 引用） | 关 |
+
+三者都只部署搜索**基础设施**；将 octo-server 接到 OpenSearch 是独立的、需 owner
+把关的步骤。详见 [`docker/README.zh.md`](./docker/README.zh.md) "Search profile"、
+[`helm/octo/README.zh.md`](./helm/octo/README.zh.md) "搜索（可选）" 和
+[`kustomize/search/README.md`](./kustomize/search/README.md)。
+
 ## 目录结构
 
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -244,6 +244,21 @@ To enable the optional LLM summary services, add `--summary`:
 sudo ./setup.sh --up
 ```
 
+To enable the optional message-search pipeline (Kafka + OpenSearch +
+es-indexer), add `--search` (it writes `COMPOSE_PROFILES=search` and merges
+with `--summary` when both are given):
+
+```bash
+./setup.sh --search --domain octo.example.com --ip 1.2.3.4
+# or both: ./setup.sh --summary --search ...
+sudo ./setup.sh --up
+```
+
+`--search` only provisions the search **infrastructure**. To index history and
+flip the reader onto OpenSearch, run the zero-downtime upgrade after the stack
+is up: `cd docker && scripts/search-upgrade.sh` (see "Search profile" /
+"Turn search on" below).
+
 `setup.sh` writes `docker/.env` with rotated random secrets and a
 generated `OCTO_ADMIN_PWD`, then **prints the admin URL + password at
 the end of the run** so you do not have to grep `.env` for them. It is
@@ -1189,6 +1204,12 @@ profile. With no profile set it is completely inert:
 > Merging these manifests deploys nothing. Bringing the profile up is an
 > explicit operator action and, in any shared/staging/production environment,
 > is gated on owner sign-off.
+
+> **Shortcut:** `./setup.sh --search` writes `COMPOSE_PROFILES=search` into
+> `docker/.env` for you (and merges with `--summary` when both are passed), so
+> you do not have to hand-edit `COMPOSE_PROFILES`. It provisions infra only; run
+> `scripts/search-upgrade.sh` afterwards to index history and flip the reader
+> (see "Turn search on" below).
 
 ### Build the es-indexer image for local validation
 

--- a/docker/README.zh.md
+++ b/docker/README.zh.md
@@ -138,6 +138,19 @@ sudo ./setup.sh --non-interactive --ip 1.2.3.4 --up --force   # 显式 one-shot 
 sudo ./setup.sh --up
 ```
 
+启用可选的消息搜索流水线（Kafka + OpenSearch + es-indexer）加 `--search`
+（它会写入 `COMPOSE_PROFILES=search`，与 `--summary` 同时给出时自动合并）：
+
+```bash
+./setup.sh --search --domain octo.example.com --ip 1.2.3.4
+# 或同时：./setup.sh --summary --search ...
+sudo ./setup.sh --up
+```
+
+`--search` 只部署搜索**基础设施**。要索引历史数据并把 reader 切到 OpenSearch，
+请在栈起来后运行零停机升级：`cd docker && scripts/search-upgrade.sh`
+（见下文 "Search profile" / "Turn search on"）。
+
 `setup.sh` 写出含轮换随机密钥的 `docker/.env` 和自动生成的 `OCTO_ADMIN_PWD`，并**在最后打印 admin URL + 密码**，免得你回头去 grep `.env`。这是从空 checkout 到 `(healthy)` 栈无需手改任何东西的唯一路径。
 
 栈起来后，通过 nginx 访问：`http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}`（默认 `http://localhost:28080`）。默认 `localhost` 在运行栈的主机上不需要任何额外的 DNS / `/etc/hosts` 配置。如果你把 `OCTO_DOMAIN` 改成真实域名，则每台访问 UI 的客户端机器都要能解析这个域名（真实 DNS，或者 `/etc/hosts` 里指向本机 IP）。

--- a/helm/octo/Chart.yaml
+++ b/helm/octo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: octo
 description: OCTO Server — self-hosted enterprise messaging platform (IM + AI)
 type: application
-version: 0.2.4
+version: 0.3.0
 appVersion: "latest"
 keywords:
   - octo

--- a/helm/octo/README.md
+++ b/helm/octo/README.md
@@ -53,7 +53,7 @@ server:
 To see all available options:
 
 ```bash
-helm show values oci://ghcr.io/mininglamp-oss/octo --version 0.2.4
+helm show values oci://ghcr.io/mininglamp-oss/octo --version 0.3.0
 ```
 
 ### 2. Install
@@ -70,7 +70,7 @@ helm install octo ./helm/octo \
 For overseas users, omit `-f values-china.yaml` — defaults pull from Docker Hub.
 
 ```bash
-helm install octo oci://ghcr.io/mininglamp-oss/octo --version 0.2.4 \
+helm install octo oci://ghcr.io/mininglamp-oss/octo --version 0.3.0 \
   --namespace octo --create-namespace \
   -f my-values.yaml \
   --set secrets.mysqlRootPassword="$(openssl rand -hex 16)" \
@@ -122,7 +122,7 @@ kubectl port-forward -n octo svc/octo-nginx 8080:80
 ## Upgrade
 
 ```bash
-helm upgrade octo oci://ghcr.io/mininglamp-oss/octo --version 0.2.4 \
+helm upgrade octo oci://ghcr.io/mininglamp-oss/octo --version 0.3.0 \
   --namespace octo \
   --reuse-values \
   -f my-values.yaml
@@ -256,6 +256,83 @@ ingress:
     enabled: false
     secretName: ""       # existing TLS secret name
 ```
+
+---
+
+## Search (optional)
+
+Message search (Kafka + OpenSearch[analysis-ik] + es-indexer) is an **opt-in**
+component, **default OFF**. With `search.enabled=false` (the default) the chart
+renders **zero** search resources — parity with `docker` (`--search` /
+`COMPOSE_PROFILES=search`) and `kustomize/search`.
+
+```yaml
+search:
+  enabled: true        # default false → no search resources rendered
+```
+
+Enabling deploys search **infrastructure only**. It does **not** wire
+octo-server onto OpenSearch (reader backend / producer cut-over). That is a
+separate, owner-gated step and is **out of scope** for this chart — parity with
+`kustomize/search`, which is also infra-only. `deployment-octo-server` and its
+ConfigMap are untouched by this toggle.
+
+### Enable checklist
+
+1. **Build & push the OpenSearch image.** `search.opensearch.image` defaults to
+   `octo-search-opensearch-ik:2.17.0`, which is a **local build name and will
+   NOT pull as-is**. Build `docker/opensearch/Dockerfile` (analysis-ik baked in;
+   plugin version MUST match the OpenSearch version), push to your registry, and
+   set `search.opensearch.image.repository`/`tag` (or `global.imageRegistry`).
+2. **Pin the indexer image.** `search.indexer.image` is published only on `v*`
+   tags / manual dispatch; pin a real tag/digest for prod.
+3. **Pull secrets** for private registries go through `global.imagePullSecrets`
+   (chart-wide), not a per-pod secret.
+
+### `clusterId` is immutable
+
+`search.kafka.clusterId` formats the KRaft metadata on the Kafka PVC on first
+install. **Changing it on an existing PVC crash-loops the broker.** Regenerate
+(`kafka-storage.sh random-uuid`) ONLY for a fresh deploy / fresh PVC.
+
+### Standalone producer is a disabled artifact
+
+`search.producer` is shipped **disabled-artifact-only**: `enabled: false` +
+`replicas: 0`. Actually running it (`replicas>0`) is **owner-gated and out of
+scope for this chart revision** — the chart **fail-fasts at render time** on any
+`replicas>0`. This chart is **deliberately stricter than `kustomize/search`**:
+kustomize relies on **runtime** mutual exclusion (Redis run-lock + cursor CAS +
+the `producer-mutex-guard` initContainer), which a template-time render guard
+cannot replace; this chart additionally blocks `replicas>0` at render. The
+`producer-mutex-guard` initContainer is preserved as the runtime backstop. When
+a future ticket opens this path, reference credentials via
+`search.producer.existingSecret` (a pre-created Secret) rather than inlining the
+DSN with `--set` (which would leak it into the release Secret, values history,
+and shell history).
+
+### Production hardening
+
+The OpenSearch security plugin is **disabled by default**
+(`search.opensearch.disableSecurityPlugin: true`) and the chart ships **no
+NetworkPolicy**. For production, run search on a network-isolated namespace,
+enable the OpenSearch security plugin (set `disableSecurityPlugin: false` and
+wire `ES_USERNAME`/`ES_PASSWORD` on the es-indexer), and restrict access to the
+OpenSearch/Kafka Services.
+
+### Verify readiness
+
+```bash
+# OpenSearch health
+kubectl exec -n <ns> sts/octo-search-opensearch -- \
+  curl -s localhost:9200/_cluster/health
+# Kafka topics created by the post-install hook
+kubectl exec -n <ns> sts/octo-search-kafka -- \
+  /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
+```
+
+> **china overlay note:** the new search images (self-built opensearch-ik +
+> private indexer) are not yet mirrored for `values-china.yaml`; wiring the
+> china overlay's search image overrides is a separate follow-up.
 
 ---
 

--- a/helm/octo/README.zh.md
+++ b/helm/octo/README.zh.md
@@ -53,7 +53,7 @@ server:
 查看所有可用配置项：
 
 ```bash
-helm show values oci://ghcr.io/mininglamp-oss/octo --version 0.2.4
+helm show values oci://ghcr.io/mininglamp-oss/octo --version 0.3.0
 ```
 
 ### 2. 安装
@@ -70,7 +70,7 @@ helm install octo ./helm/octo \
 海外用户不加 `-f values-china.yaml`，默认从 Docker Hub 拉取。
 
 ```bash
-helm install octo oci://ghcr.io/mininglamp-oss/octo --version 0.2.4 \
+helm install octo oci://ghcr.io/mininglamp-oss/octo --version 0.3.0 \
   --namespace octo --create-namespace \
   -f my-values.yaml \
   --set secrets.mysqlRootPassword="$(openssl rand -hex 16)" \
@@ -122,7 +122,7 @@ kubectl port-forward -n octo svc/octo-nginx 8080:80
 ## 升级
 
 ```bash
-helm upgrade octo oci://ghcr.io/mininglamp-oss/octo --version 0.2.4 \
+helm upgrade octo oci://ghcr.io/mininglamp-oss/octo --version 0.3.0 \
   --namespace octo \
   --reuse-values \
   -f my-values.yaml
@@ -265,6 +265,74 @@ ingress:
     enabled: false
     secretName: ""       # 已存在的 TLS Secret 名称
 ```
+
+---
+
+## 搜索（可选）
+
+消息搜索（Kafka + OpenSearch[analysis-ik] + es-indexer）是**可选**组件，**默认关闭**。
+当 `search.enabled=false`（默认）时，chart 渲染**零**个搜索资源——与 `docker`
+（`--search` / `COMPOSE_PROFILES=search`）和 `kustomize/search` 对齐。
+
+```yaml
+search:
+  enabled: true        # 默认 false → 不渲染任何搜索资源
+```
+
+开启后只部署搜索**基础设施**，**不会**将 octo-server 接到 OpenSearch（reader 后端 /
+producer 切换）。后者是独立的、需 owner 把关的步骤，**不在本 chart 范围内**——与
+`kustomize/search` 一致（同样只装基础设施）。本开关**不改动**
+`deployment-octo-server` 及其 ConfigMap。
+
+### 开启清单
+
+1. **构建并推送 OpenSearch 镜像。** `search.opensearch.image` 默认为
+   `octo-search-opensearch-ik:2.17.0`，这是**本地构建名，直接拉取会失败**。请构建
+   `docker/opensearch/Dockerfile`（内置 analysis-ik，插件版本必须与 OpenSearch 版本一致），
+   推送到你的 registry，并设置 `search.opensearch.image.repository`/`tag`
+   （或 `global.imageRegistry`）。
+2. **固定 indexer 镜像。** `search.indexer.image` 仅在 `v*` tag / 手动触发时发布；
+   生产环境请固定到真实 tag/digest。
+3. 私有 registry 的**拉取凭据**通过 `global.imagePullSecrets`（chart 级）统一配置，
+   而非每个 pod 单独配置。
+
+### `clusterId` 不可变
+
+`search.kafka.clusterId` 在首次安装时会在 Kafka PVC 上格式化 KRaft 元数据。
+**在已有 PVC 上修改它会导致 broker 崩溃循环。** 只有在全新部署 / 全新 PVC 时才重新
+生成（`kafka-storage.sh random-uuid`）。
+
+### 独立 producer 为禁用产物
+
+`search.producer` 以**禁用产物**形式发布：`enabled: false` + `replicas: 0`。
+实际运行它（`replicas>0`）**需 owner 把关，且超出本 chart 版本范围**——chart 会在
+**渲染期对任何 `replicas>0` fail-fast**。本 chart **比 `kustomize/search` 收紧**：
+kustomize 依赖**运行时**互斥（Redis run-lock + cursor CAS + `producer-mutex-guard`
+initContainer），渲染期守卫无法替代；本 chart 额外在渲染期挡掉 `replicas>0`。
+`producer-mutex-guard` initContainer 作为运行时兜底保留。后续票放开此路径时，请通过
+`search.producer.existingSecret`（预建 Secret）引用凭据，不要用 `--set` 内联 DSN
+（会泄漏到 release Secret、values 历史和 shell 历史）。
+
+### 生产加固
+
+OpenSearch 安全插件**默认关闭**（`search.opensearch.disableSecurityPlugin: true`），
+且 chart**不附带 NetworkPolicy**。生产环境请将搜索运行在网络隔离的 namespace，
+开启 OpenSearch 安全插件（设 `disableSecurityPlugin: false` 并在 es-indexer 上配置
+`ES_USERNAME`/`ES_PASSWORD`），并限制对 OpenSearch/Kafka Service 的访问。
+
+### 验证就绪
+
+```bash
+# OpenSearch 健康
+kubectl exec -n <ns> sts/octo-search-opensearch -- \
+  curl -s localhost:9200/_cluster/health
+# 验证 post-install hook 创建的 Kafka topic
+kubectl exec -n <ns> sts/octo-search-kafka -- \
+  /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
+```
+
+> **china overlay 说明：** 新增的搜索镜像（自建 opensearch-ik + 私有 indexer）
+> 尚未为 `values-china.yaml` 镜像化；接通 china overlay 的搜索镜像覆盖是后续票。
 
 ---
 

--- a/helm/octo/templates/NOTES.txt
+++ b/helm/octo/templates/NOTES.txt
@@ -10,6 +10,19 @@ Service endpoints (internal cluster):
 {{- if .Values.summary.enabled }}
   Summary: http://{{ include "octo.summaryApi.fullname" . }}:8080
 {{- end }}
+{{- if .Values.search.enabled }}
+  Search:  http://{{ include "octo.searchOpensearch.fullname" . }}:9200 (OpenSearch)
+           {{ include "octo.searchKafka.fullname" . }}:9092 (Kafka)
+
+Search INFRASTRUCTURE is deployed (OpenSearch + Kafka + es-indexer). Notes:
+  - This deploys infra ONLY; it does NOT wire octo-server onto OpenSearch
+    (reader/producer cut-over is a separate owner-gated step).
+  - The standalone searchetl-producer is a DISABLED ARTIFACT in this revision
+    (replicas:0); enabling it (replicas>0) is owner-gated and fails the render.
+  - The opensearch image MUST have analysis-ik baked in and be pushed to your
+    registry (the default name is a LOCAL build name and will not pull as-is).
+  See helm/octo/README.md "Search (optional)".
+{{- end }}
 
 Get the public nginx address:
 {{- if eq .Values.nginx.service.type "LoadBalancer" }}

--- a/helm/octo/templates/_helpers.tpl
+++ b/helm/octo/templates/_helpers.tpl
@@ -115,6 +115,26 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s-summary-worker" (include "octo.fullname" .) }}
 {{- end }}
 
+{{- define "octo.searchOpensearch.fullname" -}}
+{{- printf "%s-search-opensearch" (include "octo.fullname" .) }}
+{{- end }}
+
+{{- define "octo.searchKafka.fullname" -}}
+{{- printf "%s-search-kafka" (include "octo.fullname" .) }}
+{{- end }}
+
+{{- define "octo.searchKafkaInit.fullname" -}}
+{{- printf "%s-search-kafka-init" (include "octo.fullname" .) }}
+{{- end }}
+
+{{- define "octo.esIndexer.fullname" -}}
+{{- printf "%s-es-indexer" (include "octo.fullname" .) }}
+{{- end }}
+
+{{- define "octo.searchetlProducer.fullname" -}}
+{{- printf "%s-searchetl-producer" (include "octo.fullname" .) }}
+{{- end }}
+
 {{- define "octo.nginx.fullname" -}}
 {{- printf "%s-nginx" (include "octo.fullname" .) }}
 {{- end }}

--- a/helm/octo/templates/es-indexer.yaml
+++ b/helm/octo/templates/es-indexer.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.search.enabled }}
+# es-indexer: consumes Kafka octo.message.v1 and bulk-indexes into OpenSearch
+# (idempotent _id=message_id upsert; IK analyzers via the embedded mapping). The
+# DLQ spill mounts a PVC so DLQ-write outages survive a pod restart.
+#
+# NOTE: the indexer image is published only on v* tags / manual dispatch — pin a
+# real tag/digest in values (search.indexer.image) before enabling for prod.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "octo.esIndexer.fullname" . }}-dlq-spill
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: es-indexer
+spec:
+  accessModes: ["ReadWriteOnce"]
+  {{- if .Values.search.indexer.dlqSpill.storageClass }}
+  storageClassName: {{ .Values.search.indexer.dlqSpill.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.search.indexer.dlqSpill.size | default "1Gi" }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "octo.esIndexer.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: es-indexer
+spec:
+  replicas: 1
+  # Recreate (NOT the default RollingUpdate): single-pod workload bound to an
+  # RWO DLQ-spill PVC. RollingUpdate would start the new pod before the old one
+  # terminates; both would try to mount the same ReadWriteOnce PVC and the new
+  # pod would wedge on a Multi-Attach error. Recreate tears the old pod down
+  # first, so the single RWO volume is free when the replacement starts.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: es-indexer
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: es-indexer
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: es-indexer
+          image: {{ include "octo.image" (dict "repo" .Values.search.indexer.image.repository "tag" .Values.search.indexer.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.search.indexer.image.pullPolicy }}
+          env:
+            - name: ES_INDEXER_ENABLED
+              value: "true"
+            - name: KAFKA_BROKERS
+              value: "{{ include "octo.searchKafka.fullname" . }}:9092"
+            - name: KAFKA_TOPIC
+              value: "octo.message.v1"
+            - name: KAFKA_DLQ_TOPIC
+              value: "octo.message.v1.dlq"
+            - name: KAFKA_GROUP_ID
+              value: "octo-search-indexer"
+            - name: ES_ADDRESSES
+              value: "http://{{ include "octo.searchOpensearch.fullname" . }}:9200"
+            - name: ES_INDEX
+              value: "octo-message"
+            - name: INDEXER_BATCH_SIZE
+              value: {{ .Values.search.indexer.batchSize | quote }}
+            - name: INDEXER_DLQ_SPILL_DIR
+              value: "/var/lib/es-indexer/dlq-spill"
+          volumeMounts:
+            - name: dlq-spill
+              mountPath: /var/lib/es-indexer/dlq-spill
+          {{- with .Values.search.indexer.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: dlq-spill
+          persistentVolumeClaim:
+            claimName: {{ include "octo.esIndexer.fullname" . }}-dlq-spill
+{{- end }}

--- a/helm/octo/templates/search-kafka-init.yaml
+++ b/helm/octo/templates/search-kafka-init.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.search.enabled }}
+# One-shot topic creation for the search pipeline, run as a Helm hook. REQUIRED
+# because broker auto-create is off and the es-indexer DLQ producer runs with
+# AllowAutoTopicCreation=false — the body + DLQ topics must pre-exist. This is
+# the chart equivalent of the compose/kustomize search-kafka-init step. The
+# topic script is idempotent (--if-not-exists), so re-running on every upgrade
+# is safe.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "octo.searchKafkaInit.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: search-kafka-init
+  annotations:
+    # post-install,post-upgrade: create topics after the broker StatefulSet is
+    # (re)applied. hook-failed is REQUIRED — without it a failed hook Job is
+    # left as an orphan. before-hook-creation avoids the Job-immutable conflict
+    # when a prior hook Job with the same name still exists.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+spec:
+  backoffLimit: 30
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: search-kafka-init
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      restartPolicy: OnFailure
+      containers:
+        - name: kafka-init
+          image: {{ include "octo.image" (dict "repo" .Values.search.kafka.image.repository "tag" .Values.search.kafka.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.search.kafka.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              BOOT={{ include "octo.searchKafka.fullname" . }}:9092
+              # Wait for the broker to accept API calls (cross-object readiness
+              # is not visible to a Job, so poll here).
+              i=0
+              until /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server "$BOOT" >/dev/null 2>&1; do
+                i=$((i+1))
+                if [ "$i" -gt 60 ]; then echo "[init] broker not ready after 5m" >&2; exit 1; fi
+                echo "[init] waiting for $BOOT ..."; sleep 5
+              done
+              for t in octo.message.v1 octo.message.v1.dlq; do
+                /opt/kafka/bin/kafka-topics.sh --bootstrap-server "$BOOT" \
+                  --create --if-not-exists --topic "$t" \
+                  --partitions 1 --replication-factor 1
+              done
+              echo "[init] topics ready"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+{{- end }}

--- a/helm/octo/templates/search-kafka.yaml
+++ b/helm/octo/templates/search-kafka.yaml
@@ -1,0 +1,124 @@
+{{- if .Values.search.enabled }}
+# Kafka (KRaft single broker) for the message-search pipeline. Single-node,
+# in-cluster only. Topics are created by the search-kafka-init hook Job (broker
+# auto-create is off; the es-indexer DLQ producer runs AllowAutoTopicCreation=
+# false, so the body + DLQ topics must pre-exist).
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octo.searchKafka.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: search-kafka
+spec:
+  clusterIP: None
+  # Publish the broker's DNS A record before it is Ready. KRaft resolves the
+  # broker name for KAFKA_CONTROLLER_QUORUM_VOTERS during startup, which happens
+  # before the readiness probe passes — without this the name can be
+  # unresolvable and the single broker deadlocks unready.
+  publishNotReadyAddresses: true
+  ports:
+    - name: broker
+      port: 9092
+      targetPort: broker
+  selector:
+    {{- include "octo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: search-kafka
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "octo.searchKafka.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: search-kafka
+spec:
+  serviceName: {{ include "octo.searchKafka.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: search-kafka
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: search-kafka
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      # apache/kafka runs as a non-root user (uid/gid 1000). Freshly provisioned
+      # PVCs are often root-owned, so set fsGroup to make the data mount
+      # group-writable — otherwise the broker cannot format/write KRaft metadata
+      # under KAFKA_LOG_DIRS and the pod crash-loops before readiness.
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: kafka
+          image: {{ include "octo.image" (dict "repo" .Values.search.kafka.image.repository "tag" .Values.search.kafka.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.search.kafka.image.pullPolicy }}
+          ports:
+            - name: broker
+              containerPort: 9092
+          env:
+            - name: KAFKA_NODE_ID
+              value: "1"
+            - name: KAFKA_PROCESS_ROLES
+              value: "broker,controller"
+            - name: KAFKA_LISTENERS
+              value: "PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093"
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: "PLAINTEXT://{{ include "octo.searchKafka.fullname" . }}:9092"
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT"
+            - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+              value: "1@{{ include "octo.searchKafka.fullname" . }}:9093"
+            - name: KAFKA_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: "PLAINTEXT"
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+              value: "false"
+            # Valid Kafka UUID (22-char URL-safe Base64). IMMUTABLE on an
+            # existing PVC — see search.kafka.clusterId in values.yaml.
+            - name: CLUSTER_ID
+              value: {{ .Values.search.kafka.clusterId | quote }}
+            # apache/kafka defaults log.dirs to /tmp/kraft-combined-logs (NOT
+            # the PVC mount) — set it to the mounted path so topics + KRaft
+            # metadata survive a pod replacement/reschedule.
+            - name: KAFKA_LOG_DIRS
+              value: "/var/lib/kafka/data"
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/kafka/data
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 12
+          {{- with .Values.search.kafka.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.search.kafka.storage.storageClass }}
+        storageClassName: {{ .Values.search.kafka.storage.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.search.kafka.storage.size | default "10Gi" }}
+{{- end }}

--- a/helm/octo/templates/search-opensearch.yaml
+++ b/helm/octo/templates/search-opensearch.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.search.enabled }}
+# OpenSearch (single node, analysis-ik) for the message-search pipeline.
+# The image MUST have the analysis-ik plugin baked in and the plugin version
+# MUST match the OpenSearch version (build docker/opensearch/Dockerfile, push to
+# your registry, then set search.opensearch.image below). Infra only — this does
+# NOT wire octo-server onto OpenSearch (separate owner-gated step).
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octo.searchOpensearch.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: search-opensearch
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: 9200
+      targetPort: http
+  selector:
+    {{- include "octo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: search-opensearch
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "octo.searchOpensearch.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: search-opensearch
+spec:
+  serviceName: {{ include "octo.searchOpensearch.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: search-opensearch
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: search-opensearch
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      # OpenSearch runs as a non-root user (uid/gid 1000). Freshly provisioned
+      # PVCs are often root-owned, so set fsGroup to make the data mount
+      # group-writable — otherwise OpenSearch cannot create files under
+      # /usr/share/opensearch/data and the pod exits before readiness.
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: opensearch
+          image: {{ include "octo.image" (dict "repo" .Values.search.opensearch.image.repository "tag" .Values.search.opensearch.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.search.opensearch.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 9200
+          env:
+            - name: discovery.type
+              value: single-node
+            # Memory locking is OFF for k8s: bootstrap.memory_lock=true requires
+            # the IPC_LOCK capability + an unlimited memlock rlimit on the pod,
+            # which a plain StatefulSet does not have — with it on, OpenSearch
+            # fails its memory-lock bootstrap check and stays unready.
+            - name: bootstrap.memory_lock
+              value: "false"
+            - name: OPENSEARCH_JAVA_OPTS
+              value: {{ .Values.search.opensearch.javaOpts | quote }}
+            # Local/in-cluster default disables the security plugin. For a
+            # hardened deployment set this to false and wire ES_USERNAME /
+            # ES_PASSWORD on the es-indexer (see README "Search (optional)").
+            - name: DISABLE_SECURITY_PLUGIN
+              value: {{ .Values.search.opensearch.disableSecurityPlugin | quote }}
+            - name: DISABLE_INSTALL_DEMO_CONFIG
+              value: "true"
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/opensearch/data
+          readinessProbe:
+            httpGet:
+              path: /_cluster/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 18
+          {{- with .Values.search.opensearch.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.search.opensearch.storage.storageClass }}
+        storageClassName: {{ .Values.search.opensearch.storage.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.search.opensearch.storage.size | default "20Gi" }}
+{{- end }}

--- a/helm/octo/templates/searchetl-producer.yaml
+++ b/helm/octo/templates/searchetl-producer.yaml
@@ -1,0 +1,138 @@
+{{- if .Values.search.enabled }}
+# searchetl-producer: STANDALONE message-search producer (MySQL -> Kafka
+# octo.message.v1). DISABLED-ARTIFACT-ONLY in this chart revision: it is
+# rendered as a Deployment with replicas:0 + PRODUCER_ENABLED=false so the
+# resource exists for review but no pod ever starts.
+#
+# Fail-fast state matrix (producer.enabled x producer.replicas). This chart is
+# DELIBERATELY STRICTER than kustomize/search: kustomize relies on RUNTIME
+# mutual exclusion (Redis run-lock + cursor CAS + the producer-mutex-guard
+# initContainer), which a template-time render guard cannot replace; here we ALSO
+# block any replicas>0 at render time so a standalone producer cannot be brought
+# up by this revision at all. Actually running the producer is owner-gated and
+# out of scope — see README "Search (optional)".
+{{- if gt (int .Values.search.producer.replicas) 0 }}
+{{- if not .Values.search.producer.enabled }}
+{{- fail "search.producer.replicas>0 requires producer.enabled=true" }}
+{{- else }}
+{{- fail "running the standalone producer is owner-gated and out of scope for this chart revision; see README" }}
+{{- end }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "octo.searchetlProducer.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: searchetl-producer
+spec:
+  # Default OFF: replicas 0 → no pod. Per the fail-fast matrix above, any
+  # replicas>0 fails the render in this revision (disabled artifact only).
+  replicas: {{ .Values.search.producer.replicas }}
+  # Recreate (not the default RollingUpdate): single-pod workload by design
+  # (replicas>1 is unsupported — Redis run-lock + cursor CAS serialize to one
+  # active producer). Recreate tears the old pod down before the new one starts,
+  # closing the one overlap window k8s would otherwise introduce. Defense in
+  # depth on top of the app-layer run-lock.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: searchetl-producer
+  template:
+    metadata:
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: searchetl-producer
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      initContainers:
+        # producer-mutex-guard: fail-closed mutual-exclusion check, the chart
+        # equivalent of the compose/kustomize search-producer-guard. This
+        # initContainer is REQUIRED and must NOT be removed: a template-time
+        # render guard only blocks at render, it cannot stop a producer that is
+        # later enabled at runtime, so the guard stays as the runtime backstop.
+        # Reuses the SAME is_on() union truthy logic (1|t|true|on|yes).
+        - name: producer-mutex-guard
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          env:
+            # Hardcoded true: the pod existing (operator scaled to replicas>=1)
+            # is itself the statement of intent to run standalone.
+            - name: STANDALONE_ON
+              value: "true"
+            # Built-in producer toggle. Hardcoded "false" here because this helm
+            # chart has NO built-in producer leg at all — octo-server in this
+            # chart ships zero producer/kafka wiring (no TS_KAFKA_ON env, no
+            # producer ConfigMap), so there is nothing to read.
+            #
+            # 🔴 FORWARD-NOTE: a future owner-gated ticket that actually enables
+            # octo-server's built-in producer MUST change BUILTIN_ON back to read
+            # the octo-server ConfigMap (configMapKeyRef TS_KAFKA_ON, optional:
+            # true — aligning with kustomize/search). Leaving it hardcoded false
+            # once a built-in producer exists would silently DISABLE the
+            # double-producer mutex on the helm side (both producers could run).
+            - name: BUILTIN_ON
+              value: "false"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              is_on() {
+                v=$(printf %s "${1:-}" | tr 'A-Z' 'a-z')
+                case "$v" in
+                  1|t|true|on|yes) return 0 ;;
+                  *) return 1 ;;
+                esac
+              }
+              if is_on "$STANDALONE_ON" && is_on "${BUILTIN_ON:-}"; then
+                echo "[guard] FATAL both producers on" >&2
+                exit 1
+              fi
+              echo "[guard] ok"
+      containers:
+        - name: searchetl-producer
+          image: {{ include "octo.image" (dict "repo" .Values.search.indexer.image.repository "tag" .Values.search.indexer.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.search.indexer.image.pullPolicy }}
+          # Select the producer binary from the shared image (one image, two
+          # binaries — es-indexer + searchetl-producer built in lockstep).
+          command: ["/usr/local/bin/searchetl-producer"]
+          env:
+            # Master switch — OFF by default (defense in depth on top of
+            # replicas:0).
+            - name: PRODUCER_ENABLED
+              value: {{ .Values.search.producer.enabled | quote }}
+            {{- if .Values.search.producer.existingSecret }}
+            # DSN + Redis addr sourced from a PRE-CREATED Secret rather than
+            # inlined via --set (inline leaks the DSN into the release Secret,
+            # values history, and shell history). Mirrors kustomize/search's
+            # dedicated searchetl-producer-secret.
+            - name: PRODUCER_MYSQL_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.search.producer.existingSecret }}
+                  key: {{ .Values.search.producer.mysqlDsnKey }}
+            - name: PRODUCER_REDIS_ADDR
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.search.producer.existingSecret }}
+                  key: {{ .Values.search.producer.redisAddrKey }}
+            {{- end }}
+            - name: PRODUCER_KAFKA_BROKERS
+              value: "{{ include "octo.searchKafka.fullname" . }}:9092"
+            - name: PRODUCER_KAFKA_TOPIC
+              value: "octo.message.v1"
+            - name: PRODUCER_KAFKA_DLQ_TOPIC
+              value: "octo.message.v1.dlq"
+            - name: PRODUCER_TABLES
+              value: {{ .Values.search.producer.tables | quote }}
+            - name: PRODUCER_LAG_SECONDS
+              value: {{ .Values.search.producer.lagSeconds | quote }}
+            - name: TZ
+              value: "UTC"
+          {{- with .Values.search.producer.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/helm/octo/values.yaml
+++ b/helm/octo/values.yaml
@@ -346,6 +346,72 @@ summary:
     resources: {}
 
 # =============================================================================
+# Search pipeline (Kafka + OpenSearch[analysis-ik] + es-indexer) — OPT-IN.
+# Default OFF: with search.enabled=false NO search resources are rendered.
+# Enabling deploys search INFRASTRUCTURE ONLY; it does NOT wire octo-server onto
+# OpenSearch (reader/producer cut-over is a separate owner-gated step — parity
+# with kustomize/search, which is also infra-only).
+#
+# 🔴 PREREQUISITE before search.enabled=true is actually installable:
+#   - opensearch.image MUST be a registry image with analysis-ik baked in
+#     (build docker/opensearch/Dockerfile, push, set repository/tag below).
+#     The default name below is a LOCAL build name and will NOT pull as-is.
+#   - indexer.image is published only on v* tags; pin a real tag/digest for prod.
+#
+# NOTE (china overlay): the new search images (self-built opensearch-ik +
+# private indexer) are NOT yet mirrored for values-china.yaml; wiring the china
+# overlay's search image overrides is a separate follow-up, out of scope here.
+# =============================================================================
+search:
+  enabled: false
+  opensearch:
+    image: { repository: octo-search-opensearch-ik, tag: "2.17.0", pullPolicy: IfNotPresent }
+    javaOpts: "-Xms512m -Xmx512m"
+    disableSecurityPlugin: true
+    storage: { size: 20Gi, storageClass: "" }
+    resources:
+      requests: { cpu: 500m, memory: 1Gi }
+      limits:   { cpu: "2", memory: 2Gi }
+  kafka:
+    image: { repository: apache/kafka, tag: "3.8.0", pullPolicy: IfNotPresent }
+    # 🔴 IMMUTABLE after first install: this UUID formats the KRaft metadata on
+    # the PVC. Changing it on an existing PVC crash-loops the broker. Regenerate
+    # (kafka-storage.sh random-uuid) ONLY for a fresh deploy / fresh PVC.
+    clusterId: "3kNqlPkyT16sjDguh9qqKA"
+    storage: { size: 10Gi, storageClass: "" }
+    resources:
+      requests: { cpu: 250m, memory: 512Mi }
+      limits:   { cpu: "1", memory: 1Gi }
+  indexer:
+    image: { repository: mininglamposs/octo-search-indexer, tag: "latest", pullPolicy: Always }
+    batchSize: 500
+    dlqSpill: { size: 1Gi, storageClass: "" }
+    resources:
+      requests: { cpu: 100m, memory: 128Mi }
+      limits:   { cpu: 500m, memory: 512Mi }
+  # Standalone searchetl-producer — DISABLED-ARTIFACT-ONLY in this chart.
+  # Double-OFF (enabled:false AND replicas:0), parity with kustomize/search.
+  # 🔴 ACTUALLY ENABLING the producer (replicas>0) is OUT OF SCOPE for this
+  # chart revision — it reads the LIVE message DB + shares cursor/Redis lock
+  # with octo-server's built-in producer (double-write risk) and is owner-gated.
+  # The template fail-fasts on illegal enable states (see helm README).
+  producer:
+    enabled: false
+    replicas: 0
+    # When (later) enabled, reference a PRE-CREATED Secret rather than inlining
+    # the DSN — inline --set leaks the DSN into the release Secret, values
+    # history, and shell history. existingSecret keeps the credential out of the
+    # chart, mirroring kustomize/search's dedicated searchetl-producer-secret.
+    existingSecret: ""            # name of a Secret holding the two keys below
+    mysqlDsnKey: "PRODUCER_MYSQL_DSN"
+    redisAddrKey: "PRODUCER_REDIS_ADDR"
+    tables: "message,message1,message2,message3,message4"
+    lagSeconds: 600
+    resources:
+      requests: { cpu: 100m, memory: 128Mi }
+      limits:   { cpu: 500m, memory: 512Mi }
+
+# =============================================================================
 # Nginx reverse proxy
 # =============================================================================
 nginx:

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -61,6 +61,15 @@ kustomize/
     └── prod/                   Multi-replica production overlay
 ```
 
+`kustomize/search/` (Kafka + OpenSearch + es-indexer) is an **optional**,
+standalone search overlay, **default OFF**: it is intentionally **not**
+referenced by `base` or any overlay, so `kubectl apply -k base|overlays/dev|
+overlays/prod` renders **zero** search resources. Opt in explicitly with
+`kubectl apply -k kustomize/search`. See
+[`kustomize/search/README.md`](./search/README.md). This mirrors the optional
+search toggles on the other entry points (docker `--search`, helm
+`search.enabled`).
+
 ## Open items
 
 - [ ] Ingress / Gateway example for `octo-web` + `octo-admin`

--- a/kustomize/README.zh.md
+++ b/kustomize/README.zh.md
@@ -53,6 +53,13 @@ kustomize/
     └── prod/                   多副本生产 overlay
 ```
 
+`kustomize/search/`（Kafka + OpenSearch + es-indexer）是**可选**的独立搜索
+overlay，**默认关闭**：它故意**不**被 `base` 或任何 overlay 引用，所以
+`kubectl apply -k base|overlays/dev|overlays/prod` 渲染**零**个搜索资源。需显式
+opt-in：`kubectl apply -k kustomize/search`，详见
+[`kustomize/search/README.md`](./search/README.md)。这与其他部署入口的可选搜索
+开关一致（docker `--search`、helm `search.enabled`）。
+
 ## 待补
 
 - [ ] `octo-web` + `octo-admin` 的 Ingress / Gateway 示例

--- a/kustomize/search/README.md
+++ b/kustomize/search/README.md
@@ -283,6 +283,13 @@ tbj7-xtiao-tcr1.tencentcloudcr.com/xtiao-release/dmwork/octo-search-indexer@sha2
 To roll the image forward, repoint the digest here (and, if needed, push a new
 `:vX.Y.Z` / `:<commit>` tag to TCR) — do not switch back to a floating tag.
 
+**OSS / non-dmwork users**: the TCR digest above is a **private** image and will
+`ImagePullBackOff` without TCR pull credentials. To pull from public Docker Hub
+instead, replace the `newName`/`digest` pair for `mininglamposs/octo-search-indexer`
+in `kustomization.yaml` with a floating/pinned tag, e.g. `newTag: "latest"` (or a
+pinned `:vX.Y.Z` for reproducibility) and drop the `newName` override. See the
+escape-hatch comment in `kustomization.yaml`. The TCR digest stays the default.
+
 ### Private TCR pull secret
 
 The image lives in a **private** Tencent TCR

--- a/kustomize/search/kustomization.yaml
+++ b/kustomize/search/kustomization.yaml
@@ -33,7 +33,7 @@ images:
   # two binaries are built together and must stay in lockstep.
   #
   # Tencent TCR + digest pin (immutable, reproducible) — this is the registry
-  # the dmwork-test (xiaotiao-tke) cluster actually pulls from, NOT Docker Hub.
+  # the maintainers' reference cluster actually pulls from, NOT Docker Hub.
   # The es-indexer already running there is pinned by digest the same way, so
   # both binaries resolve to the same byte-identical build. The digest below is
   # the image built from octo-search-indexer origin/main 94864fc (git tag
@@ -47,8 +47,8 @@ images:
   # Docker Hub instead, REPLACE the newName/digest pair below with a floating/pinned tag:
   #   - name: mininglamposs/octo-search-indexer
   #     newTag: "latest"     # or a pinned :vX.Y.Z for reproducibility
-  # The TCR digest stays the DEFAULT (dmwork-test reproducibility); this is the
-  # documented escape hatch, not a behavior change.
+  # The TCR digest stays the DEFAULT (reproducibility on the reference cluster);
+  # this is the documented escape hatch, not a behavior change.
   - name: mininglamposs/octo-search-indexer
     newName: tbj7-xtiao-tcr1.tencentcloudcr.com/xtiao-release/dmwork/octo-search-indexer
     digest: sha256:97c781154e1c9588deab7af29d6b7cb041188a072621122821391ac90272c7a0

--- a/kustomize/search/kustomization.yaml
+++ b/kustomize/search/kustomization.yaml
@@ -41,6 +41,14 @@ images:
   # tags pointing at this same digest.
   # NOTE: applying this directory will also bounce any already-running
   # es-indexer onto this digest (see README "apply knock-on").
+  #
+  # OSS / non-dmwork users: the digest below is a PRIVATE Tencent TCR image and
+  # will ImagePullBackOff without TCR pull credentials. To pull from public
+  # Docker Hub instead, REPLACE the newName/digest pair below with a floating/pinned tag:
+  #   - name: mininglamposs/octo-search-indexer
+  #     newTag: "latest"     # or a pinned :vX.Y.Z for reproducibility
+  # The TCR digest stays the DEFAULT (dmwork-test reproducibility); this is the
+  # documented escape hatch, not a behavior change.
   - name: mininglamposs/octo-search-indexer
     newName: tbj7-xtiao-tcr1.tencentcloudcr.com/xtiao-release/dmwork/octo-search-indexer
     digest: sha256:97c781154e1c9588deab7af29d6b7cb041188a072621122821391ac90272c7a0

--- a/setup.sh
+++ b/setup.sh
@@ -59,6 +59,20 @@ ENV_EXAMPLE="${SCRIPT_DIR}/docker/.env.example"
 ENV_OUT="${SCRIPT_DIR}/docker/.env"
 DOCKER_DIR="${SCRIPT_DIR}/docker"
 
+# One-shot init services: jobs that run to completion and whose PASS state
+# is a clean `Exited (0)` (every OTHER service is long-running and must stay
+# `Up`). This single pipe-delimited alternation is the ONLY place the set is
+# named — both the health contract checker
+# (`verify_all_services_running_or_healthy`) and the `--verify` failure
+# classifier consume it, so the two allowlists can never drift apart, and any
+# future profile-activated one-shot only has to be added here once.
+#   - preflight          : token/secret validation gate (always on)
+#   - minio-init         : MinIO user/policy/bucket bootstrap (always on)
+#   - search-kafka-init  : Kafka topic creation, activated by --search
+#                          (COMPOSE_PROFILES=search). `restart: "no"`, so it
+#                          legitimately ends at `Exited (0)` once topics exist.
+ONESHOT_SERVICES_RE='preflight|minio-init|search-kafka-init'
+
 # YUJ-1084 / GH#46: root's primary group differs by OS — Linux uses `root`,
 # macOS (BSD) uses `wheel`. Hard-coding `chown root:root` aborts on macOS
 # with `chown: root: illegal group name`, which leaves docker/.env half-
@@ -214,7 +228,8 @@ compose_supports_wait() {
 #               long-running svcs must never exit), `Restarting (…)`,
 #               `Dead`, `Paused`, `Removing`, or missing container row.
 #
-#   one-shot service (preflight, minio-init):
+#   one-shot service (preflight, minio-init, search-kafka-init — the
+#   ${ONESHOT_SERVICES_RE} set):
 #     PASS   →  `Exited (0)` (job ran and finished cleanly).
 #     WAIT   →  still `Up …` / `Created` (job has not finished yet).
 #     FATAL  →  `Exited (n>0)`, `Restarting (…)`, `Dead`, or missing
@@ -246,37 +261,34 @@ verify_all_services_running_or_healthy() {
       continue
     fi
     status="${row#*	}"
-    case "${svc}" in
-      preflight|minio-init)
-        case "${status}" in
-          "Exited (0)"*)                 : ;;  # PASS — one-shot finished
-          Exited*|Restarting*|Dead*)     out="${out}FATAL	${row}
+    if [[ "${svc}" =~ ^(${ONESHOT_SERVICES_RE})$ ]]; then
+      case "${status}" in
+        "Exited (0)"*)                 : ;;  # PASS — one-shot finished
+        Exited*|Restarting*|Dead*)     out="${out}FATAL	${row}
 " ;;
-          *)                             out="${out}WAIT	${row}
+        *)                             out="${out}WAIT	${row}
 " ;;
-        esac
-        ;;
-      *)
-        case "${status}" in
-          Up*"(unhealthy)"*|Up*"(health: starting)"*|Created*)
-            # `Created` on a long-running svc is the cold-boot race
-            # window: `compose up -d` ordered it after a depends_on
-            # gate (e.g. preflight exit 0, mysql health) and Compose
-            # has not yet `Start`-ed it. From `compose_poll_healthy`
-            # this is WAIT (poll again — `Created` will flip to `Up`
-            # once the gate clears); from `--verify` (stack already
-            # steady) WAIT is treated as a failure by the caller,
-            # which is what we want — a `Created` row at that point
-            # means the gate never cleared.
-            out="${out}WAIT	${row}
+      esac
+    else
+      case "${status}" in
+        Up*"(unhealthy)"*|Up*"(health: starting)"*|Created*)
+          # `Created` on a long-running svc is the cold-boot race
+          # window: `compose up -d` ordered it after a depends_on
+          # gate (e.g. preflight exit 0, mysql health) and Compose
+          # has not yet `Start`-ed it. From `compose_poll_healthy`
+          # this is WAIT (poll again — `Created` will flip to `Up`
+          # once the gate clears); from `--verify` (stack already
+          # steady) WAIT is treated as a failure by the caller,
+          # which is what we want — a `Created` row at that point
+          # means the gate never cleared.
+          out="${out}WAIT	${row}
 "
-            ;;
-          Up*)                           : ;;  # PASS — healthy or no healthcheck
-          *)                             out="${out}FATAL	${row}
+          ;;
+        Up*)                           : ;;  # PASS — healthy or no healthcheck
+        *)                             out="${out}FATAL	${row}
 " ;;
-        esac
-        ;;
-    esac
+      esac
+    fi
   done <<< "${expected}"
   if [[ -n "${out}" ]]; then
     printf '%s' "${out}"
@@ -517,14 +529,15 @@ _compose_up_and_wait_once() {
     # Extract concrete failing service names from
     # `ps --format '{{.Service}}\t{{.Status}}'`. We flag anything that
     # is (unhealthy), Restarting, Dead, or Exited(non-zero). One-shot
-    # services (preflight / minio-init) are normally expected to be
+    # services (preflight / minio-init / search-kafka-init — the
+    # ${ONESHOT_SERVICES_RE} set) are normally expected to be
     # `Exited (0)` and so are NOT a fail in that state — but if they
     # crash with `Exited (1)` / `Restarting` / `Dead` they MUST surface,
     # because they gate the rest of the stack. So instead of stripping
     # them by name, we strip the specific benign one-shot status
     # (`Exited (0)`) and let everything else flow into the fail grep.
     failing_svcs="$(cd "${DOCKER_DIR}" && ${cc} ps --all --format '{{.Service}}	{{.Status}}' 2>/dev/null \
-                      | grep -vE '^(preflight|minio-init)	Exited \(0\)' \
+                      | grep -vE "^(${ONESHOT_SERVICES_RE})	Exited \(0\)" \
                       | grep -E '	.*(\(unhealthy\)|Restarting|Dead|Exited \([1-9])' \
                       | awk -F'	' '{print $1}' | sort -u || true)"
     err ""
@@ -847,7 +860,8 @@ Generation:
                       runs `docker compose up -d --wait --wait-timeout
                       240`, blocking until every long-running service is
                       healthy AND every one-shot init job (preflight /
-                      minio-init) exited 0. On a cold-boot soft timeout
+                      minio-init, plus search-kafka-init under --search)
+                      exited 0. On a cold-boot soft timeout
                       the wait retries ONCE on the warm mysql / image
                       cache (typically <10s). NEVER regenerates secrets
                       — run `./setup.sh` first to create docker/.env, or

--- a/setup.sh
+++ b/setup.sh
@@ -31,6 +31,7 @@ DOMAIN="localhost"
 EXTERNAL_IP=""
 ENABLE_HTTPS=false
 ENABLE_SUMMARY=false
+ENABLE_SEARCH=false
 NON_INTERACTIVE=false
 FORCE_OVERWRITE=false
 RUN_UP=false
@@ -51,6 +52,7 @@ DOMAIN_SET_VIA_CLI=false
 IP_SET_VIA_CLI=false
 HTTPS_SET_VIA_CLI=false
 SUMMARY_SET_VIA_CLI=false
+SEARCH_SET_VIA_CLI=false
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_EXAMPLE="${SCRIPT_DIR}/docker/.env.example"
@@ -121,6 +123,42 @@ sed_inplace() {
     sed -i "$@"
   else
     sed -i '' "$@"
+  fi
+}
+
+# Merge a compose profile into COMPOSE_PROFILES in ${ENV_OUT} without
+# clobbering already-enabled profiles (summary + search must coexist).
+# Pure-bash membership test (mirrors the intent of search-upgrade.sh
+# persist_profile union, but operates on the .env file only — setup.sh
+# does NOT read the shell COMPOSE_PROFILES env var).
+#
+# The CURRENT value is read ONLY from an uncommented `COMPOSE_PROFILES=`
+# line. The shipped .env.example carries a COMMENTED template hint
+# (`# COMPOSE_PROFILES=summary`), and .env is re-copied from it on every
+# run, so a live .env normally has NO uncommented line — the commented hint
+# must NEVER be read as the current value (that would resurrect `summary`
+# for a bare `--search`). When no uncommented line exists `current` is "",
+# and an empty current concatenates with no leading comma.
+add_compose_profile() {
+  local add="$1" line current merged
+  if line="$(grep -m1 '^COMPOSE_PROFILES=' "${ENV_OUT}")"; then
+    current="${line#COMPOSE_PROFILES=}"
+  else
+    current=""
+  fi
+  if [[ -z "${current}" ]]; then
+    merged="${add}"
+  elif [[ ",${current}," != *",${add},"* ]]; then
+    merged="${current},${add}"
+  else
+    merged="${current}"
+  fi
+  if grep -q '^COMPOSE_PROFILES=' "${ENV_OUT}"; then
+    sed_inplace "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=${merged}|" "${ENV_OUT}"
+  elif grep -q '^# *COMPOSE_PROFILES=' "${ENV_OUT}"; then
+    sed_inplace "s|^# *COMPOSE_PROFILES=.*|COMPOSE_PROFILES=${merged}|" "${ENV_OUT}"
+  else
+    printf '\n# Activate optional compose profiles\nCOMPOSE_PROFILES=%s\n' "${merged}" >> "${ENV_OUT}"
   fi
 }
 
@@ -764,6 +802,7 @@ while [[ $# -gt 0 ]]; do
     --ip)       EXTERNAL_IP="${2:?--ip requires a value}";  IP_SET_VIA_CLI=true;      shift 2 ;;
     --https)    ENABLE_HTTPS=true;   HTTPS_SET_VIA_CLI=true;   shift ;;
     --summary)  ENABLE_SUMMARY=true; SUMMARY_SET_VIA_CLI=true; shift ;;
+    --search)   ENABLE_SEARCH=true;  SEARCH_SET_VIA_CLI=true;  shift ;;
     --up)         RUN_UP=true; shift ;;
     --smoke-test) RUN_VERIFY=true; shift ;;
     # `--verify` is the original spelling, retained as a deprecated alias
@@ -778,7 +817,7 @@ while [[ $# -gt 0 ]]; do
     -h|--help)
       cat <<'USAGE'
 Usage: setup.sh [--non-interactive] [--force] [--domain <d>] [--ip <ip>]
-                [--https] [--summary] [--up]
+                [--https] [--summary] [--search] [--up]
        setup.sh --smoke-test (or --verify, deprecated alias)
        setup.sh --uninstall
 
@@ -795,6 +834,14 @@ Generation:
                       See docker/certs/README.md for the full procedure.
   --summary           Enable the optional LLM summary services
                       (COMPOSE_PROFILES=summary).
+  --search            Enable the optional message-search pipeline
+                      (COMPOSE_PROFILES=search): Kafka + OpenSearch +
+                      es-indexer. Merges with --summary if both are given.
+                      This only provisions the search INFRASTRUCTURE; to
+                      index history and flip the reader onto OpenSearch,
+                      run `cd docker && scripts/search-upgrade.sh` after
+                      the stack is up (see docker/README.md "Search
+                      profile" / "Turn search on").
   --up                START-ONLY subcommand (peer of --smoke-test /
                       --uninstall): requires an existing docker/.env and
                       runs `docker compose up -d --wait --wait-timeout
@@ -847,11 +894,12 @@ Smoke test / tear-down (work against an already-existing docker/.env):
   --uninstall         Tear down the stack. Interactively offers three
                       granularity levels (full / data-only / containers-only).
 
-When any of --domain / --ip / --https / --summary is given without
---non-interactive, setup.sh treats the flags as your decisions and runs
-non-interactively so the documented one-liner forms (see docker/README.md)
-work as written. --up is a start-only subcommand (peer of --smoke-test
-/ --uninstall) and never participates in the decision-flag handling.
+When any of --domain / --ip / --https / --summary / --search is given
+without --non-interactive, setup.sh treats the flags as your decisions
+and runs non-interactively so the documented one-liner forms (see
+docker/README.md) work as written. --up is a start-only subcommand
+(peer of --smoke-test / --uninstall) and never participates in the
+decision-flag handling.
 USAGE
       exit 0
       ;;
@@ -1486,14 +1534,15 @@ if [[ "${RUN_UNINSTALL}" == "true" ]]; then
 fi
 
 # If the operator supplied any "decision" flag (--domain / --ip / --https
-# / --summary) but did not pass --non-interactive, treat those flags as
-# the decision and skip the prompts. (--up no longer participates: R6
+# / --summary / --search) but did not pass --non-interactive, treat those
+# flags as the decision and skip the prompts. (--up no longer participates: R6
 # made it a start-only subcommand that exits before the prompts.)
 if [[ "${NON_INTERACTIVE}" == "false" ]]; then
   if [[ "${DOMAIN_SET_VIA_CLI}" == "true" \
      || "${IP_SET_VIA_CLI}" == "true" \
      || "${HTTPS_SET_VIA_CLI}" == "true" \
-     || "${SUMMARY_SET_VIA_CLI}" == "true" ]]; then
+     || "${SUMMARY_SET_VIA_CLI}" == "true" \
+     || "${SEARCH_SET_VIA_CLI}" == "true" ]]; then
     info "CLI flags supplied; switching to non-interactive mode."
     info "(Pass no flags, or only --force, to get the interactive prompts.)"
     NON_INTERACTIVE=true
@@ -1884,6 +1933,13 @@ if [[ "${NON_INTERACTIVE}" == "false" ]]; then
     [yY]|[yY][eE][sS]) ENABLE_SUMMARY=true ;;
     *) ENABLE_SUMMARY=false ;;
   esac
+
+  # Search (message-search pipeline)
+  read -rp "Enable message-search pipeline (Kafka + OpenSearch + es-indexer)? [y/N]: " user_search
+  case "${user_search}" in
+    [yY]|[yY][eE][sS]) ENABLE_SEARCH=true ;;
+    *) ENABLE_SEARCH=false ;;
+  esac
 else
   # Non-interactive: auto-detect IP if not provided via --ip
   if [[ -z "${EXTERNAL_IP}" ]]; then
@@ -1896,6 +1952,7 @@ info "Domain:     ${DOMAIN}"
 info "External IP: ${EXTERNAL_IP}"
 info "HTTPS:      ${ENABLE_HTTPS}"
 info "Summary:    ${ENABLE_SUMMARY}"
+info "Search:     ${ENABLE_SEARCH}"
 
 # ── Generate secrets ────────────────────────────────────────────────────────
 info "Generating random secrets…"
@@ -1969,16 +2026,9 @@ sed_inplace "s|^# *OCTO_ADMIN_PWD=.*|OCTO_ADMIN_PWD=${OCTO_ADMIN_PWD}|" "${ENV_O
 # diffing against R6 sees the intentional removal.
 # (was: sed_inplace "s|^OCTO_TLS_ENABLED=.*|OCTO_TLS_ENABLED=...|" ...)
 
-# Summary setting
-if [[ "${ENABLE_SUMMARY}" == "true" ]]; then
-  if grep -q '^COMPOSE_PROFILES=' "${ENV_OUT}"; then
-    sed_inplace "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=summary|" "${ENV_OUT}"
-  elif grep -q '^# *COMPOSE_PROFILES=' "${ENV_OUT}"; then
-    sed_inplace "s|^# *COMPOSE_PROFILES=.*|COMPOSE_PROFILES=summary|" "${ENV_OUT}"
-  else
-    printf '\n# Activate summary services (summary-api + summary-worker)\nCOMPOSE_PROFILES=summary\n' >> "${ENV_OUT}"
-  fi
-fi
+# Optional compose profiles (merge, not clobber — summary + search coexist).
+if [[ "${ENABLE_SUMMARY}" == "true" ]]; then add_compose_profile summary; fi
+if [[ "${ENABLE_SEARCH}"  == "true" ]]; then add_compose_profile search;  fi
 
 # ── Persist COMPOSE_PROJECT_NAME into .env ─────────────────────────────────
 # INCIDENT-2026-05-16-001 follow-up: the interactive preflight may
@@ -2174,6 +2224,13 @@ fi
 
 if [[ "${ENABLE_SUMMARY}" == "true" ]]; then
   info "Summary service enabled. Set LLM_API_KEY in docker/.env before using."
+fi
+
+if [[ "${ENABLE_SEARCH}" == "true" ]]; then
+  info "Search profile enabled (infra only). To index history + flip the reader"
+  info "onto OpenSearch, run the zero-downtime upgrade after the stack is up:"
+  info "  cd docker && scripts/search-upgrade.sh"
+  info "See docker/README.md \"Search profile\" / \"Turn search on\"."
 fi
 
 # R6 (YUJ-1020): we are always on the generation path here (--up exits


### PR DESCRIPTION
## Summary

Brings the **optional message-search component** to parity across all deployment entry points so both Docker and Kubernetes modes can opt into search (default **OFF everywhere**). Closes the two automation-entry gaps and the consistency nit from the issue.

Fixes #134

## What changed (commit order: kustomize → setup.sh → helm → docs)

1. **`kustomize/search`** — document a Docker Hub fallback for OSS users. The indexer image override now carries an escape-hatch comment (swap the private TCR digest for a public `newTag`), with a matching README note. **Default pin unchanged.**
2. **`setup.sh --search`** — new flag mirroring `--summary`, writes `COMPOSE_PROFILES=search`. Reworks the profile write from **clobber → merge** semantics (`add_compose_profile`) so `summary` + `search` coexist. The helper reads the current value only from an *uncommented* `COMPOSE_PROFILES=` line (the shipped `.env.example` hint is commented and must not be treated as live) and strips any leading comma for empty values. `--search` provisions infra only and guides the operator to `scripts/search-upgrade.sh` for the data cut-over.
3. **`helm/octo` search subsystem** — `search.enabled=false` (default) opt-in pipeline at parity with `kustomize/search`: opensearch + kafka + kafka-init (post-install/post-upgrade **hook** with `hook-failed` cleanup) + es-indexer + disabled-artifact searchetl-producer. All gated by `{{- if .Values.search.enabled }}`.
   - **es-indexer uses `strategy: { type: Recreate }`** — it binds an RWO DLQ-spill PVC, so the default RollingUpdate would Multi-Attach deadlock on `helm upgrade`.
   - **searchetl-producer is disabled-artifact-only** (`replicas:0` + `PRODUCER_ENABLED=false`). A render-time guard **fail-fasts any `replicas>0`** — stricter than kustomize, which relies on runtime Redis run-lock + cursor CAS + the `producer-mutex-guard` initContainer. That initContainer is **preserved** as the runtime backstop.
   - Credentials via a pre-created `existingSecret` (`secretKeyRef`), never inline `--set`.
   - `BUILTIN_ON` hardcoded `false` (this chart has no built-in producer leg) **with a forward-note** to re-wire it to the octo-server ConfigMap if that leg is ever added.
4. **Docs + version bump** — main/docker/helm/kustomize READMEs (+ all `.zh.md`) document the optional search toggle per entry point. `Chart.yaml` `0.2.4 → 0.3.0` (new feature = MINOR); `appVersion` unchanged. All three `0.2.4` `--version` refs in **both** `helm/octo/README.md` and `README.zh.md` bumped to `0.3.0`.

## Hard invariants held
- **Default zero search**: `./setup.sh` / `helm install` / `kubectl apply -k kustomize/{base,overlays/dev,overlays/prod}` all render **0** search resources (verified below).
- **octo-server base manifests untouched** — this branch is rebased onto current `main`, and `git diff origin/main HEAD -- kustomize/base/octo-server-env-config.yaml` is empty: the `TS_KAFKA_ON` guard ConfigMap (including its full qualified comment landed by a prior PR) is preserved verbatim, and `octo-server.yaml` / `octo-server-config.yaml` are not modified either.
- **Info hygiene** — diff-scoped scan of added lines: no ticket IDs; internal cluster names scrubbed from `kustomize/search/kustomization.yaml` comments.

## ⚠️ CI blind-spot: helm/ is NOT covered by CI

`.github/workflows/ci.yml` lints only `.github/` + `kustomize/`. The helm changes have **no CI safety net**, so local evidence is attached as the substitute gate (a follow-up to add a helm CI job is tracked separately).

### `helm lint` → `1 chart(s) linted, 0 chart(s) failed`

### Default render — zero search resources
```
helm template octo helm/octo $DUMMY | grep -ciE 'search-opensearch|search-kafka|es-indexer|searchetl-producer'
0
```

### `--set search.enabled=true` — all resources render
```
search-opensearch=2   (Service + StatefulSet)
search-kafka=3        (Service + StatefulSet + advertised listener ref)
search-kafka-init=1   (hook Job)
es-indexer=2          (PVC + Deployment)
searchetl-producer=1  (Deployment)
```

### es-indexer strategy = `Recreate` (RWO PVC Multi-Attach guard) ✓

### Producer fail-fast
```
--set search.producer.replicas=1                          → fail "owner-gated ... out of scope"
--set search.producer.enabled=false --set ...replicas=1   → fail "requires producer.enabled=true"
```

### `kubeconform -strict` → `Valid: 31, Invalid: 0, Errors: 0`

### setup.sh — `bash -n` OK, `shellcheck -S error` exit 0; `--search`/`--summary --search` merge verified (empty-value case has no leading comma).

### kustomize overlays — `dev` / `prod` both render `0` search resources.

## Not in scope (follow-ups)
- Wiring octo-server onto OpenSearch (reader/producer cut-over) — separate owner-gated ticket.
- `values-china.yaml` search image overrides — noted in helm values/README.
- Adding a helm CI job — separate follow-up.

## Manual verification still pending
Lifecycle test (install → upgrade enable→disable → uninstall; PVC retention + no orphan hook Jobs) requires a real cluster; no usable cluster in this environment, so it is left as the documented `[manual]` matrix item.