### PR TITLE
ci: add helm lint/template job + scrub internal cluster names (Fixes #136)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - '**/*.yaml'
       - '**/*.yml'
       - 'kustomize/**'
+      - 'helm/**'
       - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
@@ -114,6 +115,145 @@ jobs:
           done
           exit "${status}"
 
+  helm-validate:
+    name: helm lint + template
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    env:
+      HELM_VERSION: '3.16.4'
+      KUBECONFORM_VERSION: '0.7.0'
+      # Pin the schema target so a runner-image bump cannot silently change
+      # what counts as valid. Keep in sync with kustomize-validate above.
+      KUBERNETES_VERSION: '1.31.0'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install helm
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+          curl -fsSL -o "$tmp/helm.tar.gz" \
+            "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+          tar -xzf "$tmp/helm.tar.gz" -C "$tmp"
+          sudo install -m 0755 "$tmp/linux-amd64/helm" /usr/local/bin/helm
+          helm version
+
+      - name: Install kubeconform
+        run: |
+          set -euo pipefail
+          # Extract into a scratch directory to keep the workspace pristine
+          # (the kubeconform tarball ships a LICENSE file that would otherwise
+          # overwrite the repo's own LICENSE).
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+          curl -fsSL -o "$tmp/kubeconform.tar.gz" \
+            "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz"
+          tar -xzf "$tmp/kubeconform.tar.gz" -C "$tmp"
+          sudo install -m 0755 "$tmp/kubeconform" /usr/local/bin/kubeconform
+          kubeconform -v
+
+      - name: Lint and render the chart
+        run: |
+          set -euo pipefail
+
+          chart=helm/octo
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+
+          # Dummy secrets so `required` gates pass — these are CI-only throwaway
+          # placeholders, NOT real credentials. The chart only enforces non-empty
+          # (the 32-hex master-key length is a runtime, not template-time, rule),
+          # so low-entropy placeholders keep the secret scanner quiet.
+          dummy_secrets=(
+            --set secrets.mysqlRootPassword=ci-dummy
+            --set secrets.minioRootPassword=ci-dummy-pass
+            --set secrets.minioAppPassword=ci-dummy
+            --set secrets.matterDbPassword=ci-dummy
+            --set secrets.summaryDbPassword=ci-dummy
+            --set secrets.summaryReaderPassword=ci-dummy
+            --set secrets.octoMasterKey=ci-dummy-master-key
+            --set secrets.notifyInternalToken=ci-dummy
+            --set secrets.wukongimManagerToken=ci-dummy
+          )
+
+          echo "::group::helm lint"
+          helm lint "${chart}" "${dummy_secrets[@]}"
+          echo "::endgroup::"
+
+          # The five search templates that must render when search.enabled=true
+          # and must NOT render when search.enabled=false (default-off contract).
+          search_sources=(
+            search-opensearch
+            search-kafka
+            search-kafka-init
+            es-indexer
+            searchetl-producer
+          )
+
+          # Count rendered docs originating from a given template. Reads a file
+          # (not a pipe) so `grep -c` cannot SIGPIPE an upstream producer under
+          # `set -o pipefail` and report a false zero.
+          count_source() {
+            grep -cE "^# Source: octo/templates/${1}\.yaml$" "$2" || true
+          }
+
+          validate() {
+            # Render must be valid Kubernetes. -ignore-missing-schemas tolerates
+            # CRDs/hooks without published schemas, matching kustomize-validate.
+            kubeconform \
+              -strict \
+              -ignore-missing-schemas \
+              -kubernetes-version "${KUBERNETES_VERSION}" \
+              -schema-location default \
+              -summary \
+              -output text < "$1"
+          }
+
+          echo "::group::chart default (default-off: zero search resources)"
+          # Render with NO search override so this exercises the chart's own
+          # default (search.enabled=false in values.yaml). If a later change
+          # flips that default to true, this assertion fails — that is the
+          # point: it guards the documented default-off contract, not a value
+          # we hard-set here.
+          helm template octo "${chart}" "${dummy_secrets[@]}" > "$tmp/off.yaml"
+          validate "$tmp/off.yaml"
+          off_hits=0
+          for s in "${search_sources[@]}"; do
+            n="$(count_source "${s}" "$tmp/off.yaml")"
+            if [ "${n}" -ne 0 ]; then
+              echo "::error::search template '${s}' rendered ${n} doc(s) with search.enabled=false"
+              off_hits=$((off_hits + n))
+            fi
+          done
+          if [ "${off_hits}" -ne 0 ]; then
+            echo "::error::expected 0 search resources with search.enabled=false, found ${off_hits}"
+            exit 1
+          fi
+          echo "OK: no search resources rendered when search.enabled=false"
+          echo "::endgroup::"
+
+          echo "::group::search.enabled=true (all five search templates render)"
+          helm template octo "${chart}" "${dummy_secrets[@]}" \
+            --set search.enabled=true > "$tmp/on.yaml"
+          validate "$tmp/on.yaml"
+          missing=0
+          for s in "${search_sources[@]}"; do
+            n="$(count_source "${s}" "$tmp/on.yaml")"
+            if [ "${n}" -ge 1 ]; then
+              echo "OK: ${s} rendered (${n} doc(s))"
+            else
+              echo "::error::search template '${s}' did NOT render with search.enabled=true"
+              missing=$((missing + 1))
+            fi
+          done
+          if [ "${missing}" -ne 0 ]; then
+            echo "::error::expected all 5 search templates, ${missing} missing"
+            exit 1
+          fi
+          echo "::endgroup::"
+
   ci-gate:
     name: CI Gate
     # Aggregate gate: always runs so the required status check ALWAYS reports.
@@ -124,7 +264,7 @@ jobs:
     # cancelled; 'skipped'/'success' count as passing. Branch protection should
     # require ONLY the "CI Gate" context for this repo.
     if: ${{ always() }}
-    needs: [yaml-lint, kustomize-validate]
+    needs: [yaml-lint, kustomize-validate, helm-validate]
     runs-on: ubuntu-latest
     steps:
       - name: Verify upstream CI results

--- a/kustomize/search/README.md
+++ b/kustomize/search/README.md
@@ -19,7 +19,7 @@ kubectl apply -k kustomize/search -n <ns>
    `kustomization.yaml`.
 2. **es-indexer / searchetl-producer image**: shared one image, two binaries.
    Already pinned in `kustomization.yaml` to a Tencent TCR **digest** (the
-   registry the dmwork-test cluster pulls from) — see "Image: pinned to a TCR
+   registry the reference cluster pulls from) — see "Image: pinned to a TCR
    digest" below. Repoint the digest there to roll forward; do not use a
    floating tag for production.
 3. **Private TCR pull secret**: the image lives in a **private** Tencent TCR, so
@@ -130,7 +130,7 @@ Three limits this guard does **not** cover (operator responsibility):
 
 ### 🔴 CDC double-write warning
 
-dmwork-test runs `octo-messages-sync` (CDC binlog → Kafka) writing the **same**
+Some clusters run `octo-messages-sync` (CDC binlog → Kafka) writing the **same**
 topic `octo.message.v1`. That CDC pipeline is **not** in this kustomize tree, so
 this guard cannot see it and cannot mechanically prevent a standalone↔CDC
 double-write. **Do not enable this standalone producer in an environment where
@@ -268,7 +268,7 @@ digest:
 tbj7-xtiao-tcr1.tencentcloudcr.com/xtiao-release/dmwork/octo-search-indexer@sha256:97c781154e1c9588deab7af29d6b7cb041188a072621122821391ac90272c7a0
 ```
 
-- **Why TCR, not Docker Hub**: the dmwork-test (xiaotiao-tke) cluster pulls from
+- **Why TCR, not Docker Hub**: the reference cluster pulls from
   Tencent TCR; the es-indexer already running there is pinned by digest the same
   way. Docker Hub (`mininglamposs/*`) is the GitHub `docker-publish.yml` track
   and is a *separate* lane the cluster does not pull from.
@@ -306,11 +306,11 @@ spec:
 
 - **Why it is required**: without a pull secret the kubelet cannot authenticate
   to the private registry — the pod `ImagePullBackOff`s and never starts. This is
-  exactly the P1 found on dmwork-test: the raw `es-indexer` manifest running there
+  exactly the P1 found on the reference cluster: the raw `es-indexer` manifest running there
   carried `imagePullSecrets` (the `tcr-image-xtiao` secret) while the kustomize
   render did not, so the kustomize-managed producer would never have come up.
 - **Default `tcr-image-xtiao`**: this is the secret that exists on the
-  dmwork-test (xiaotiao-tke) cluster — the same cluster the digest above is
+  reference cluster — the same cluster the digest above is
   pinned for — so the default is self-consistent.
 - **🔴 Per-cluster override**: the secret name is **cluster-specific**. On any
   other cluster you MUST (a) create the pull secret in the target namespace and
@@ -368,7 +368,7 @@ spec:
    producer re-streams history (full reload).
 5. The private-TCR image-pull Secret exists in the target namespace and is
    referenced by the manifests. The default is `tcr-image-xtiao` (present on
-   dmwork-test); on any other cluster create the secret and override the name
+   the reference cluster); on any other cluster create the secret and override the name
    via an overlay patch — see "Private TCR pull secret" above. Missing this →
    `ImagePullBackOff`, the pod never starts.
 

--- a/kustomize/search/es-indexer.yaml
+++ b/kustomize/search/es-indexer.yaml
@@ -22,9 +22,9 @@ spec:
     spec:
       # Private-registry pull secret — same private Tencent TCR as the producer
       # (one image, two binaries). The raw manifest already running on
-      # dmwork-test carries this; once kustomize formally owns es-indexer the
+      # the reference cluster carries this; once kustomize formally owns es-indexer the
       # render must carry it too, or the pod ImagePullBackOffs. Default
-      # `tcr-image-xtiao` matches dmwork-test; other clusters MUST override the
+      # `tcr-image-xtiao` matches the reference cluster; other clusters MUST override the
       # name (overlay patch) and ensure the secret exists — see README
       # "Private TCR pull secret".
       imagePullSecrets:

--- a/kustomize/search/searchetl-producer-secret.example.yaml
+++ b/kustomize/search/searchetl-producer-secret.example.yaml
@@ -3,7 +3,7 @@
 #
 # Why a dedicated Secret (and not octo-server-secret):
 #   - The OSS octo-server-secret contract carries DM_MYSQL_DSN / DM_REDIS_ADDR,
-#     but real clusters do not always provision those keys (e.g. dmwork-test's
+#     but real clusters do not always provision those keys (on some the
 #     octo-server-secret has only the 5 *_KEY / *_TOKEN / *_SECRET keys), so a
 #     hard secretKeyRef into it fails the pod with CreateContainerConfigError.
 #   - The producer must read the SAME live message DB as the running IM backend,
@@ -47,5 +47,5 @@ stringData:
   # searchetl_prod:pass@tcp(<mysql-host>)/<db-name>?charset=utf8mb4&parseTime=true&loc=Local
   PRODUCER_MYSQL_DSN: "CHANGE_ME_MYSQL_DSN"
   # host:port of the Redis backing the shared run-lock (same one the built-in
-  # producer uses). e.g. redis-svc.dmwork-test:6379
+  # producer uses). e.g. redis-svc.your-namespace:6379
   PRODUCER_REDIS_ADDR: "CHANGE_ME_REDIS_ADDR"

--- a/kustomize/search/searchetl-producer.yaml
+++ b/kustomize/search/searchetl-producer.yaml
@@ -43,7 +43,7 @@ spec:
       # image-name override in kustomization.yaml) to a private Tencent TCR
       # (tbj7-xtiao-tcr1.tencentcloudcr.com/...), which needs a pull secret —
       # without it the pod ImagePullBackOffs and never starts. The default
-      # `tcr-image-xtiao` matches the dmwork-test (xiaotiao-tke) cluster, which
+      # `tcr-image-xtiao` matches the reference cluster, which
       # is also the cluster the digest in kustomization.yaml is pinned for.
       # Other clusters MUST override this name (patch in an overlay) AND ensure
       # the secret exists in the target namespace — see README "Private TCR
@@ -113,7 +113,7 @@ spec:
             # Sourced from the producer's OWN dedicated Secret
             # (searchetl-producer-secret), NOT octo-server-secret. Rationale:
             # octo-server-secret does not reliably carry DM_MYSQL_DSN /
-            # DM_REDIS_ADDR in real clusters (e.g. dmwork-test's only has the 5
+            # DM_REDIS_ADDR in real clusters (on some it only has the 5
             # *_KEY/*_TOKEN/*_SECRET keys), so a hard secretKeyRef into it fails
             # the pod with CreateContainerConfigError; and the producer must read
             # the LIVE message DB, which is not necessarily the DB octo-server


### PR DESCRIPTION
## What

Two CI-hygiene changes to the deployment repo, no manifest behavior change.

### 1. Add a `helm-validate` CI job

`.github/workflows/ci.yml` gained a `helm lint + template` job that mirrors the
existing `kustomize-validate` job's structure (pinned tool versions, scratch-dir
installs, kubeconform `-strict`):

- `helm lint helm/octo` with CI-only dummy secrets (so `required` gates pass).
- `helm template` rendered in **both** search states and validated with
  `kubeconform -strict -ignore-missing-schemas -kubernetes-version 1.31.0`:
  - **chart default** (no override → exercises `search.enabled=false` from
    `values.yaml`): asserts **zero** search resources render — this guards the
    documented default-off contract, so flipping the default later fails CI.
  - **`search.enabled=true`**: asserts all five search templates render
    (`search-opensearch`, `search-kafka`, `search-kafka-init`, `es-indexer`,
    `searchetl-producer`).
- Wired into the `CI Gate` aggregate job; `helm/**` added to the push path filter.

### 2. Scrub internal cluster names

Replaced `dmwork-test` / `xiaotiao-tke` in `kustomize/search` README + manifest
**comments** with generic phrasing (the reference cluster / your namespace).
**Comment text only** — no image, registry, digest, env, or behavior change.

## Verification

- `helm lint` + both `helm template` renders + `kubeconform -strict`: pass locally.
- `git grep -niE 'dmwork-test|xiaotiao-tke' kustomize/ helm/` → 0 hits.
- `kustomize build kustomize/search` output is **byte-identical** to base (comment-only diff).
- `yamllint` on the workflow: pass.

Fixes #136
