### PR TITLE
fix(nginx): add /space → /admin/space redirect for space management page

### DIFF
--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -176,6 +176,12 @@ server {
     # /minio-console/ is intentionally NOT exposed here — see the comment
     # at the top of this file. SSH-forward :29001 for console access.
 
+    # Redirect /space → /admin/space (octo-web navigates to /space
+    # but the route lives inside octo-admin under /admin/space).
+    location ~ ^/space(/.*)?$ {
+        return 301 /admin/space$1$is_args$args;
+    }
+
     location = /admin {
         return 301 /admin/;
     }
@@ -427,6 +433,11 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #         proxy_read_timeout 600s;
 #         proxy_request_buffering off;
 #         proxy_buffering off;
+#     }
+#
+#     # Redirect /space → /admin/space
+#     location ~ ^/space(/.*)?$ {
+#         return 301 /admin/space$1$is_args$args;
 #     }
 #
 #     location = /admin {

--- a/helm/octo/templates/configmap-nginx.yaml
+++ b/helm/octo/templates/configmap-nginx.yaml
@@ -131,6 +131,12 @@ data:
             proxy_buffering off;
         }
 
+        # Redirect /space → /admin/space (octo-web navigates to /space
+        # but the route lives inside octo-admin under /admin/space).
+        location ~ ^/space(/.*)?$ {
+            return 301 /admin/space$1$is_args$args;
+        }
+
         location = /admin {
             return 301 /admin/;
         }


### PR DESCRIPTION
## Summary

- Add `location ~ ^/space(/.*)?$` redirect block to both **Helm** (`configmap-nginx.yaml`) and **Docker Compose** (`octo.conf.template`) nginx configs
- octo-web navigates to `/space` when users click "Space Management" in settings, but the route lives in octo-admin under `/admin/space` — without this redirect, `/space` falls through to the SPA catch-all and renders the wrong page
- Same root cause as #88 (closed as stale before the fix landed in the repo)

## Files changed

| File | Change |
|------|--------|
| `helm/octo/templates/configmap-nginx.yaml` | Added `/space` → `/admin/space` 301 redirect before `location = /admin` |
| `docker/nginx/conf.d/octo.conf.template` | Same redirect in both HTTP and HTTPS (commented) server blocks |

## Test plan

- [ ] Deploy with Helm chart and verify clicking "Space Management" in octo-web redirects to `/admin/space` correctly
- [ ] Deploy with Docker Compose and verify the same
- [ ] Verify `/space/settings` sub-paths also redirect correctly to `/admin/space/settings`
- [ ] Verify query strings are preserved (`/space?tab=members` → `/admin/space?tab=members`)

Closes #88 (re-opened scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)