### PR TITLE
fix(ootb): WuKongIM advertises raw :5200 instead of nginx-proxied /ws when OCTO_WK_WS_ADDR is empty string

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -302,14 +302,21 @@ OCTO_MINIO_APP_PASSWORD=CHANGE_ME_MINIO_APP_PASSWORD
 # debug | release | bench
 WK_MODE=release
 
-# WuKongIM advertised endpoints. LEAVE BLANK for the OOTB default
-# (compose builds ws://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}/ws). Set a literal
-# value if you front the stack with TLS or a different hostname:
+# WuKongIM advertised endpoints. Leave commented-out for the OOTB default
+# (compose builds ws://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}/ws). Uncomment and
+# set a literal value only when you front the stack with TLS or need to
+# override the default hostname — for example:
 #   OCTO_WK_WS_ADDR=ws://192.168.1.42:28080/ws
 #   OCTO_WK_WSS_ADDR=wss://octo.example.com/ws
-OCTO_WK_WS_ADDR=
-OCTO_WK_WSS_ADDR=
-OCTO_WK_TCP_ADDR=
+#
+# WARNING: do NOT set these to empty strings (OCTO_WK_WS_ADDR=). An explicit
+# empty value disables compose's ${VAR:-default} fallback and causes WuKongIM
+# to advertise its raw internal port (ws://<ip>:5200) to clients instead of
+# the nginx-proxied address, breaking IM connectivity. Leave the lines
+# commented out entirely to get the correct default behaviour.
+# OCTO_WK_WS_ADDR=
+# OCTO_WK_WSS_ADDR=
+# OCTO_WK_TCP_ADDR=
 
 # --- OCTO Server ----------------------------------------------------------
 # Must be exactly 32 bytes. Generate with: openssl rand -hex 16

--- a/setup.sh
+++ b/setup.sh
@@ -2162,14 +2162,16 @@ if is_placeholder_domain && [[ -n "${EXTERNAL_IP}" ]] && ! is_loopback_ip "${EXT
   cat >> "${ENV_OUT}" <<URLS
 
 # S1 (R7 / YUJ-1020 / GH#41): Materialised because OCTO_DOMAIN=${DOMAIN}
-# (placeholder) and --ip ${EXTERNAL_IP} was supplied. Without these three
+# (placeholder) and --ip ${EXTERNAL_IP} was supplied. Without these four
 # overrides the compose defaults would sign presigned PUT URLs against
-# http://${DOMAIN}:${HTTP_PORT}, which does not resolve from a client
+# http://${DOMAIN}:${HTTP_PORT} and advertise a WuKongIM WS address of
+# ws://${DOMAIN}:${HTTP_PORT}/ws, neither of which resolves from a client
 # without DNS pointed at this host. Set OCTO_DOMAIN=<real DNS name>
 # and re-run setup.sh --force if you want the DNS-based topology instead.
 MINIO_SERVER_URL=http://${EXTERNAL_IP}:${HTTP_PORT}
 TS_MINIO_DOWNLOADURL=http://${EXTERNAL_IP}:${HTTP_PORT}
 TS_EXTERNAL_BASEURL=http://${EXTERNAL_IP}:${HTTP_PORT}
+OCTO_WK_WS_ADDR=ws://${EXTERNAL_IP}:${HTTP_PORT}/ws
 URLS
 fi
 


### PR DESCRIPTION
## Problem

Every fresh IP-only deployment (`./setup.sh --ip <IP>` without `--domain`) results in WuKongIM advertising `ws://<IP>:5200` to clients via the `/route` API instead of the correct `ws://<IP>:28080/ws` (the nginx-proxied path). IM connectivity breaks immediately.

**Root cause — two compounding bugs:**

**Bug 1 — `.env.example` defines `OCTO_WK_WS_ADDR=` as an explicit empty string.**
After `cp .env.example .env` the variable is _defined_ (set to `""`), so compose's `${OCTO_WK_WS_ADDR:-ws://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}/ws}` fallback never fires. WuKongIM gets an empty `wsAddr`, falls back to its raw internal listener, and advertises `ws://<WK_EXTERNAL_IP>:5200` to clients.

**Bug 2 — `setup.sh` S1 block did not materialise `OCTO_WK_WS_ADDR`.**
The S1 block (IP-mode URL overrides) correctly wrote `MINIO_SERVER_URL`, `TS_MINIO_DOWNLOADURL`, and `TS_EXTERNAL_BASEURL` pointing at the external IP, but left `OCTO_WK_WS_ADDR` unset. Even without Bug 1, an IP-only deployment would have WuKongIM advertising `ws://localhost:28080/ws`, unreachable from any client other than the host itself.

## Fix

**`docker/.env.example`** — comment out `OCTO_WK_WS_ADDR=`, `OCTO_WK_WSS_ADDR=`, `OCTO_WK_TCP_ADDR=` so the `:-` compose defaults are active on a fresh copy. Add a `WARNING` block explaining that setting these to empty strings breaks the fallback and causes the `:5200` symptom.

**`setup.sh` S1 block** — materialise `OCTO_WK_WS_ADDR=ws://${EXTERNAL_IP}:${HTTP_PORT}/ws` alongside the existing three URL overrides.

## Workaround for affected deployments

Add to `docker/.env`:
```
OCTO_WK_WS_ADDR=ws://<your-IP>:<OCTO_HTTP_PORT>/ws
```
Then restart: `sudo ./setup.sh --up`
