### PR TITLE
feat(docker): add speech profile (octo-speech + octo-speech-admin)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -453,11 +453,22 @@ LLM_MODEL=claude-sonnet-4-6
 # SPEECH_ADMIN_PASSWORD=<openssl rand -hex 16>
 # SPEECH_ADMIN_JWT_SECRET=<openssl rand -hex 32>
 
+# MySQL credential for the scoped 'speech' DB user (created by init-extra-dbs.sh
+# on first MySQL volume init, and on existing stacks by speech-setup.sh step 0).
+# Use only [A-Za-z0-9._-] characters — same allowlist as the other DB passwords.
+# Generate with: openssl rand -hex 16
+# SPEECH_DB_PASSWORD=<openssl rand -hex 16>
+
 # After the speech profile is up, create an API key via the speech-admin
 # console (http://<host>/speech-admin/) and paste it here, then restart
 # octo-server so it can call octo-speech for voice transcription.
 # SPEECH_SERVICE_URL=http://octo-speech:8780
 # SPEECH_API_KEY=<key from speech-admin console>
+
+# Host bind / port for the speech-admin container (default: loopback:28088).
+# The admin console is also reachable through nginx at /speech-admin/.
+# OCTO_SPEECH_ADMIN_BIND=127.0.0.1
+# OCTO_SPEECH_ADMIN_PORT=28088
 
 # Speech profile image overrides (only used with COMPOSE_PROFILES=speech):
 # OCTO_SPEECH_IMAGE=mininglamposs/octo-speech:latest

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -428,12 +428,40 @@ LLM_MODEL=claude-sonnet-4-6
 # uncomment COMPOSE_PROFILES below (setup.sh --summary does this for you).
 # COMPOSE_PROFILES=summary
 #
+# The speech pipeline (octo-speech + octo-speech-admin) is gated by the
+# "speech" profile. Enable it with COMPOSE_PROFILES=speech (combine profiles
+# with a comma, e.g. COMPOSE_PROFILES=summary,speech).
+#
 # The message-search pipeline (Kafka + OpenSearch + es-indexer) is gated by
 # the "search" profile. Enable it with COMPOSE_PROFILES=search (combine
 # profiles with a comma, e.g. COMPOSE_PROFILES=summary,search). With no
 # profile set, NONE of the search services start and the lines below are
 # inert — every one has a default, so a default deployment never fails on a
 # missing search variable. See docker/README.md "Search profile".
+
+# --- Speech pipeline (only used when COMPOSE_PROFILES includes "speech") ---
+# LLM engine for voice transcription. "qwen" uses the Qwen omni model via a
+# LiteLLM-compatible gateway (recommended for Chinese); "openai" uses the
+# OpenAI Whisper endpoint.
+# VOICE_ENGINE=qwen
+# VOICE_LITELLM_URL=https://llm-gateway.example.com/v1
+# VOICE_QWEN_KEY=<your-api-key>
+# VOICE_QWEN_MODELS=qwen3.5-omni-plus
+
+# speech-admin console credentials (generate passwords with openssl rand -hex 16)
+# SPEECH_ADMIN_USERNAME=admin
+# SPEECH_ADMIN_PASSWORD=<openssl rand -hex 16>
+# SPEECH_ADMIN_JWT_SECRET=<openssl rand -hex 32>
+
+# After the speech profile is up, create an API key via the speech-admin
+# console (http://<host>/speech-admin/) and paste it here, then restart
+# octo-server so it can call octo-speech for voice transcription.
+# SPEECH_SERVICE_URL=http://octo-speech:8780
+# SPEECH_API_KEY=<key from speech-admin console>
+
+# Speech profile image overrides (only used with COMPOSE_PROFILES=speech):
+# OCTO_SPEECH_IMAGE=mininglamposs/octo-speech:latest
+# OCTO_SPEECH_ADMIN_IMAGE=mininglamposs/octo-speech-admin:latest
 
 # --- Search pipeline (only used when COMPOSE_PROFILES includes "search") ---
 # Host ports for local validation; loopback-bound by default so they never

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1108,7 +1108,7 @@ services:
       mysql:
         condition: service_healthy
     environment:
-      SPEECH_DB_DSN:         "root:${MYSQL_ROOT_PASSWORD}@tcp(mysql:3306)/octo_speech?parseTime=true&loc=Asia%2FShanghai"
+      SPEECH_DB_DSN:         "speech:${SPEECH_DB_PASSWORD:-}@tcp(mysql:3306)/octo_speech?parseTime=true&loc=Asia%2FShanghai"
       SPEECH_SERVICE_PORT:   "8780"
       VOICE_ENGINE:          ${VOICE_ENGINE:-qwen}
       VOICE_LITELLM_URL:     ${VOICE_LITELLM_URL:-}
@@ -1136,12 +1136,12 @@ services:
       mysql:
         condition: service_healthy
       octo-speech:
-        condition: service_started
+        condition: service_healthy
     environment:
-      SPEECH_DB_DSN:       "root:${MYSQL_ROOT_PASSWORD}@tcp(mysql:3306)/octo_speech?parseTime=true&loc=Asia%2FShanghai"
+      SPEECH_DB_DSN:       "speech:${SPEECH_DB_PASSWORD:-}@tcp(mysql:3306)/octo_speech?parseTime=true&loc=Asia%2FShanghai"
       ADMIN_PORT:          "8781"
       ADMIN_USERNAME:      ${SPEECH_ADMIN_USERNAME:-admin}
-      ADMIN_PASSWORD:      ${SPEECH_ADMIN_PASSWORD}
+      ADMIN_PASSWORD:      ${SPEECH_ADMIN_PASSWORD:-}
       ADMIN_JWT_SECRET:    ${SPEECH_ADMIN_JWT_SECRET:-}
       ADMIN_SECURE_COOKIE: "false"
       TZ: Asia/Shanghai

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -745,6 +745,10 @@ services:
       # Leaving it UNSET would make octo-server assume the pre-switch default
       # (ES on) and hammer a non-existent OpenSearch on the first search call.
       OCTO_SEARCH_BACKEND: ${OCTO_SEARCH_BACKEND:-disabled}
+      # octo-speech voice transcription wiring. Empty by default so a non-speech
+      # deployment boots cleanly without these vars set.
+      SPEECH_SERVICE_URL: ${SPEECH_SERVICE_URL:-}
+      SPEECH_API_KEY:     ${SPEECH_API_KEY:-}
       # Where the reader finds OpenSearch + which read alias it queries. Only
       # consulted when OCTO_SEARCH_BACKEND=es; harmless (unread) when disabled.
       # The reader queries the ALIAS, never the physical index — the alias is
@@ -1079,6 +1083,78 @@ services:
       # window does not wedge the worker into `(unhealthy)` while the
       # mysql init script is still finishing.
       start_period: 30s
+
+  # ===========================================================================
+  # Speech infrastructure (voice transcription) — STRICTLY ADDITIVE
+  # ===========================================================================
+  # octo-speech (transcription API) + octo-speech-admin (API-key console).
+  # Both are gated behind `profiles: ["speech"]` — a vanilla `docker compose
+  # up -d` starts neither. Opt in with `COMPOSE_PROFILES=speech` (combine
+  # with other profiles: `COMPOSE_PROFILES=summary,speech`).
+  #
+  # ISOLATION GUARANTEES:
+  #   - No core service definition is touched beyond two optional env vars on
+  #     octo-server (SPEECH_SERVICE_URL / SPEECH_API_KEY), both empty-default.
+  #   - No new REQUIRED env var: every var below has a `:-` default or is
+  #     gated by the profile, so a non-speech deployment never fails preflight.
+  #   - Reuses the existing octo-net network and the existing MySQL instance
+  #     (octo_speech database is created by scripts/init-extra-dbs.sh).
+  # ---------------------------------------------------------------------------
+  octo-speech:
+    image: ${OCTO_SPEECH_IMAGE:-mininglamposs/octo-speech:latest}
+    restart: unless-stopped
+    profiles: ["speech"]
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      SPEECH_DB_DSN:         "root:${MYSQL_ROOT_PASSWORD}@tcp(mysql:3306)/octo_speech?parseTime=true&loc=Asia%2FShanghai"
+      SPEECH_SERVICE_PORT:   "8780"
+      VOICE_ENGINE:          ${VOICE_ENGINE:-qwen}
+      VOICE_LITELLM_URL:     ${VOICE_LITELLM_URL:-}
+      VOICE_QWEN_KEY:        ${VOICE_QWEN_KEY:-}
+      VOICE_QWEN_MODELS:     ${VOICE_QWEN_MODELS:-qwen3.5-omni-plus}
+      VOICE_LITELLM_TIMEOUT: "60"
+      VOICE_TOTAL_TIMEOUT:   "90"
+      VOICE_MAX_DURATION:    "60"
+      VOICE_MAX_FILE_SIZE:   "3145728"
+      TZ: Asia/Shanghai
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/8780' || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    networks:
+      - octo-net
+
+  octo-speech-admin:
+    image: ${OCTO_SPEECH_ADMIN_IMAGE:-mininglamposs/octo-speech-admin:latest}
+    restart: unless-stopped
+    profiles: ["speech"]
+    depends_on:
+      mysql:
+        condition: service_healthy
+      octo-speech:
+        condition: service_started
+    environment:
+      SPEECH_DB_DSN:       "root:${MYSQL_ROOT_PASSWORD}@tcp(mysql:3306)/octo_speech?parseTime=true&loc=Asia%2FShanghai"
+      ADMIN_PORT:          "8781"
+      ADMIN_USERNAME:      ${SPEECH_ADMIN_USERNAME:-admin}
+      ADMIN_PASSWORD:      ${SPEECH_ADMIN_PASSWORD}
+      ADMIN_JWT_SECRET:    ${SPEECH_ADMIN_JWT_SECRET:-}
+      ADMIN_SECURE_COOKIE: "false"
+      TZ: Asia/Shanghai
+    ports:
+      - "${OCTO_SPEECH_ADMIN_BIND:-127.0.0.1}:${OCTO_SPEECH_ADMIN_PORT:-28088}:8781"
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/8781' || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    networks:
+      - octo-net
 
   # ===========================================================================
   # Search infrastructure (message-search pipeline) — STRICTLY ADDITIVE

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -194,6 +194,7 @@ services:
       OCTO_MATTER_DB_PASSWORD: ${OCTO_MATTER_DB_PASSWORD:-matter}
       OCTO_SUMMARY_DB_PASSWORD: ${OCTO_SUMMARY_DB_PASSWORD:-summary}
       OCTO_SUMMARY_READER_PASSWORD: ${OCTO_SUMMARY_READER_PASSWORD:-summary_reader}
+      SPEECH_DB_PASSWORD: ${SPEECH_DB_PASSWORD:-}
     # Backing service: bound to loopback by default so a missed-config moment
     # does not expose MySQL with the placeholder root password to the public
     # internet. Override OCTO_MYSQL_BIND to 0.0.0.0 only when you understand

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -492,6 +492,18 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #         proxy_set_header   X-Forwarded-Proto $scheme;
 #     }
 #
+#     location /speech-admin/ {
+#         limit_req zone=octo_api burst=20 nodelay;
+#         set $upstream_speech_admin octo-speech-admin;
+#         rewrite ^/speech-admin/(.*) /$1 break;
+#         proxy_pass         http://$upstream_speech_admin:8781;
+#         proxy_http_version 1.1;
+#         proxy_set_header   Host              $host;
+#         proxy_set_header   X-Real-IP         $remote_addr;
+#         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+#         proxy_set_header   X-Forwarded-Proto $scheme;
+#     }
+#
 #     location = /_octo_up {
 #         default_type text/html;
 #         return 200 '<!doctype html><html><body><h1>OCTO Server (HTTPS)</h1></body></html>';

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -272,6 +272,21 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
+    location /speech-admin/ {
+        # octo-speech-admin lives in `profiles: [speech]` — variable proxy_pass
+        # defers DNS resolution to request time so nginx starts cleanly even
+        # when the container is absent (returns 502 instead of emerg crash).
+        limit_req zone=octo_api burst=20 nodelay;
+        set $upstream_speech_admin octo-speech-admin;
+        rewrite ^/speech-admin/(.*) /$1 break;
+        proxy_pass         http://$upstream_speech_admin:8781;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
     location = /_octo_up {
         default_type text/html;
         return 200 '<!doctype html>

--- a/docker/scripts/init-extra-dbs.sh
+++ b/docker/scripts/init-extra-dbs.sh
@@ -40,6 +40,7 @@ set -euo pipefail
 : "${OCTO_MATTER_DB_PASSWORD:=matter}"
 : "${OCTO_SUMMARY_DB_PASSWORD:=summary}"
 : "${OCTO_SUMMARY_READER_PASSWORD:=summary_reader}"
+: "${SPEECH_DB_PASSWORD:=}"
 : "${MYSQL_DATABASE:=octo}"
 
 validate_password() {
@@ -167,5 +168,19 @@ GRANT ALL PRIVILEGES ON octo_summary.*     TO 'summary'@'%';
 GRANT SELECT         ON \`${MYSQL_DATABASE}\`.* TO 'summary_reader'@'%';
 FLUSH PRIVILEGES;
 SQL
+
+# If SPEECH_DB_PASSWORD is set, provision the scoped speech DB user.
+# The main SQL block above already created octo_speech; this separate
+# step is conditional so it is safe to skip on a non-speech deployment.
+if [ -n "${SPEECH_DB_PASSWORD:-}" ]; then
+  validate_password SPEECH_DB_PASSWORD "$SPEECH_DB_PASSWORD"
+  MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -u root <<SQL
+CREATE USER IF NOT EXISTS 'speech'@'%' IDENTIFIED BY '${SPEECH_DB_PASSWORD}';
+ALTER USER IF EXISTS      'speech'@'%' IDENTIFIED BY '${SPEECH_DB_PASSWORD}';
+GRANT ALL PRIVILEGES ON octo_speech.* TO 'speech'@'%';
+FLUSH PRIVILEGES;
+SQL
+  echo "[init-extra-dbs] provisioned speech DB user"
+fi
 
 echo "[init-extra-dbs] created octo_matter + octo_summary + service users (scoped to \`${MYSQL_DATABASE}\`)"

--- a/docker/scripts/init-extra-dbs.sh
+++ b/docker/scripts/init-extra-dbs.sh
@@ -142,6 +142,7 @@ MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -u root <<SQL
 -- Schemas ---------------------------------------------------------------------
 CREATE DATABASE IF NOT EXISTS octo_matter  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 CREATE DATABASE IF NOT EXISTS octo_summary CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+CREATE DATABASE IF NOT EXISTS octo_speech  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- Service-scoped read-write accounts -----------------------------------------
 -- CREATE USER IF NOT EXISTS leaves an existing user untouched; the matching

--- a/docker/scripts/speech-setup.sh
+++ b/docker/scripts/speech-setup.sh
@@ -117,7 +117,7 @@ if [ "$FROM_STEP" -le 0 ]; then
   "${DC[@]}" exec -T -e MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql \
     mysql -uroot \
     -e "CREATE DATABASE IF NOT EXISTS octo_speech CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;" \
-    2>/dev/null
+    || fail "Failed to create octo_speech database — check MYSQL_ROOT_PASSWORD and MySQL connectivity."
   ok "octo_speech database ready"
 
   # Create scoped speech DB user (least-privilege, matches matter/summary pattern)
@@ -127,7 +127,7 @@ if [ "$FROM_STEP" -le 0 ]; then
         ALTER USER IF EXISTS 'speech'@'%' IDENTIFIED BY '${SPEECH_DB_PASSWORD}';
         GRANT ALL PRIVILEGES ON octo_speech.* TO 'speech'@'%';
         FLUSH PRIVILEGES;" \
-    2>/dev/null
+    || fail "Failed to provision speech DB user — check MYSQL_ROOT_PASSWORD and MySQL connectivity."
   ok "speech DB user provisioned"
 fi
 

--- a/docker/scripts/speech-setup.sh
+++ b/docker/scripts/speech-setup.sh
@@ -71,7 +71,7 @@ fi
 : "${SPEECH_ADMIN_JWT_SECRET:=$(env_get SPEECH_ADMIN_JWT_SECRET)}"
 : "${SPEECH_API_KEY:=$(env_get SPEECH_API_KEY)}"
 
-HTTP_PORT="${OCTO_HTTP_PORT:-80}"
+HTTP_PORT="${OCTO_HTTP_PORT:-28080}"
 ADMIN_USER="${SPEECH_ADMIN_USERNAME:-admin}"
 BASE_URL="http://127.0.0.1:${HTTP_PORT}/speech-admin"
 
@@ -104,18 +104,25 @@ if [ "$FROM_STEP" -le 0 ]; then
     || fail "MYSQL_ROOT_PASSWORD is not set."
   [ -n "${SPEECH_DB_PASSWORD:-}" ] \
     || fail "SPEECH_DB_PASSWORD is not set. Generate with: openssl rand -hex 16"
+  case "$SPEECH_DB_PASSWORD" in
+    *[!A-Za-z0-9._-]*)
+      fail "SPEECH_DB_PASSWORD contains characters outside [A-Za-z0-9._-]. Use: openssl rand -hex 16" ;;
+  esac
 
   ok "Secrets validated"
 
   # Create DB idempotently against the live MySQL — init-extra-dbs.sh only runs
   # on first volume init, so existing deployments need this explicit step.
-  "${DC[@]}" exec -T mysql mysql -uroot -p"${MYSQL_ROOT_PASSWORD}" \
+  # Pass MYSQL_PWD via -e so the root credential stays out of ps/proc cmdline.
+  "${DC[@]}" exec -T -e MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql \
+    mysql -uroot \
     -e "CREATE DATABASE IF NOT EXISTS octo_speech CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;" \
     2>/dev/null
   ok "octo_speech database ready"
 
   # Create scoped speech DB user (least-privilege, matches matter/summary pattern)
-  "${DC[@]}" exec -T mysql mysql -uroot -p"${MYSQL_ROOT_PASSWORD}" \
+  "${DC[@]}" exec -T -e MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql \
+    mysql -uroot \
     -e "CREATE USER IF NOT EXISTS 'speech'@'%' IDENTIFIED BY '${SPEECH_DB_PASSWORD}';
         ALTER USER IF EXISTS 'speech'@'%' IDENTIFIED BY '${SPEECH_DB_PASSWORD}';
         GRANT ALL PRIVILEGES ON octo_speech.* TO 'speech'@'%';
@@ -140,14 +147,15 @@ fi
 if [ "$FROM_STEP" -le 2 ]; then
   log 2 "Wait for octo-speech-admin to be reachable via nginx"
   RETRIES=30
-  until curl -sf -o /dev/null "${BASE_URL}/api/login" \
-      -X POST -H "Content-Type: application/json" \
-      -d '{"username":"__probe__","password":"__probe__"}' 2>/dev/null; do
+  until [ "$(curl -s -o /dev/null -w '%{http_code}' \
+      -X POST "${BASE_URL}/api/login" \
+      -H "Content-Type: application/json" \
+      -d '{}' 2>/dev/null)" != "000" ]; do
     RETRIES=$((RETRIES - 1))
     [ "$RETRIES" -le 0 ] && fail "octo-speech-admin did not become reachable in time (${BASE_URL})"
     info "waiting for admin console... ($RETRIES attempts left)"
     sleep 5
-  done || true  # 401/422 still means the endpoint is up
+  done
   ok "octo-speech-admin is reachable"
 fi
 

--- a/docker/scripts/speech-setup.sh
+++ b/docker/scripts/speech-setup.sh
@@ -4,16 +4,16 @@
 # already-running stack. Idempotent: every step is safe to re-run.
 # -----------------------------------------------------------------------------
 # Flow:
+#   (0) Validate required secrets; create octo_speech DB if absent
 #   (1) Start speech services (docker compose --profile speech up -d)
-#   (2) Wait for octo-speech to be healthy
+#   (2) Wait for octo-speech-admin to be reachable via nginx
 #   (3) Create an API key via octo-speech-admin
-#   (4) Write SPEECH_API_KEY into docker/.env
+#   (4) Write SPEECH_API_KEY + SPEECH_SERVICE_URL + COMPOSE_PROFILES into .env
 #   (5) Restart octo-server to pick up the key
 #
 # Usage:
-#   docker/scripts/speech-setup.sh                  # full setup
-#   docker/scripts/speech-setup.sh --from 3         # resume at step N (1..5)
-#   SPEECH_ADMIN_PASSWORD=mypass docker/scripts/speech-setup.sh
+#   docker/scripts/speech-setup.sh              # full setup
+#   docker/scripts/speech-setup.sh --from 3     # resume at step N (0..5)
 #
 # Requires: curl, docker (compose v2 plugin or docker-compose binary).
 # -----------------------------------------------------------------------------
@@ -24,9 +24,33 @@ DOCKER_DIR="$(cd "$HERE/.." && pwd)"
 cd "$DOCKER_DIR"
 
 ENV_FILE="${ENV_FILE:-$DOCKER_DIR/.env}"
+
 env_get() {
   [ -f "$ENV_FILE" ] || return 0
   grep -E "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2- | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/"
+}
+
+# portable: rewrite via tmp file, no sed -i flavor issues (matches search-upgrade.sh)
+persist_env() {
+  local key="$1" val="$2"
+  touch "$ENV_FILE"
+  if grep -qE "^${key}=" "$ENV_FILE"; then
+    awk -v k="$key" -v v="$val" \
+      'BEGIN{FS=OFS="="} $1==k{print k"="v; next} {print}' \
+      "$ENV_FILE" > "$ENV_FILE.tmp" && mv "$ENV_FILE.tmp" "$ENV_FILE"
+  else
+    printf '%s=%s\n' "$key" "$val" >> "$ENV_FILE"
+  fi
+}
+
+persist_profile() {
+  local add="$1" current merged
+  current="${COMPOSE_PROFILES:-$(env_get COMPOSE_PROFILES)}"
+  merged="$(printf '%s' "$current" | tr ',' '\n' | sed '/^[[:space:]]*$/d' \
+    | awk -v a="$add" '{print} $0==a{seen=1} END{if(!seen)print a}' \
+    | paste -sd, -)"
+  COMPOSE_PROFILES="$merged"
+  persist_env COMPOSE_PROFILES "$merged"
 }
 
 if docker compose version >/dev/null 2>&1; then
@@ -38,35 +62,67 @@ else
   exit 2
 fi
 
+# resolve vars from .env (env wins, like Compose)
 : "${OCTO_HTTP_PORT:=$(env_get OCTO_HTTP_PORT)}"
+: "${MYSQL_ROOT_PASSWORD:=$(env_get MYSQL_ROOT_PASSWORD)}"
+: "${SPEECH_DB_PASSWORD:=$(env_get SPEECH_DB_PASSWORD)}"
 : "${SPEECH_ADMIN_USERNAME:=$(env_get SPEECH_ADMIN_USERNAME)}"
 : "${SPEECH_ADMIN_PASSWORD:=$(env_get SPEECH_ADMIN_PASSWORD)}"
+: "${SPEECH_ADMIN_JWT_SECRET:=$(env_get SPEECH_ADMIN_JWT_SECRET)}"
+: "${SPEECH_API_KEY:=$(env_get SPEECH_API_KEY)}"
 
 HTTP_PORT="${OCTO_HTTP_PORT:-80}"
 ADMIN_USER="${SPEECH_ADMIN_USERNAME:-admin}"
 BASE_URL="http://127.0.0.1:${HTTP_PORT}/speech-admin"
 
-FROM_STEP=1
-for arg in "$@"; do
-  case "$arg" in
-    --from) shift; FROM_STEP="${1:-1}"; shift ;;
-    --from=*) FROM_STEP="${arg#--from=}" ;;
+# parse --from N
+FROM_STEP=0
+while (($#)); do
+  case "$1" in
+    --from) shift; FROM_STEP="${1:?'--from requires a step number'}"; shift ;;
+    --from=*) FROM_STEP="${1#--from=}"; shift ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
 
-log()     { printf '\n\033[1m=== Step %s: %s ===\033[0m\n' "$1" "$2"; }
-ok()      { printf '\033[32m[OK]\033[0m %s\n' "$*"; }
-info()    { printf '    %s\n' "$*"; }
-fail()    { printf '\033[31m[FAIL]\033[0m %s\n' "$*" >&2; exit 1; }
+log()  { printf '\n\033[1m=== Step %s: %s ===\033[0m\n' "$1" "$2"; }
+ok()   { printf '\033[32m[OK]\033[0m %s\n' "$*"; }
+info() { printf '    %s\n' "$*"; }
+fail() { printf '\033[31m[FAIL]\033[0m %s\n' "$*" >&2; exit 1; }
 
-persist_env() {
-  local key="$1" val="$2"
-  if grep -qE "^${key}=" "$ENV_FILE" 2>/dev/null; then
-    sed -i "s|^${key}=.*|${key}=${val}|" "$ENV_FILE"
-  else
-    printf '\n%s=%s\n' "$key" "$val" >> "$ENV_FILE"
-  fi
-}
+# ---------------------------------------------------------------------------
+# Step 0: validate secrets + create octo_speech DB on existing stack
+# ---------------------------------------------------------------------------
+if [ "$FROM_STEP" -le 0 ]; then
+  log 0 "Validate secrets and provision octo_speech database"
+
+  [ -n "${SPEECH_ADMIN_PASSWORD:-}" ] \
+    || fail "SPEECH_ADMIN_PASSWORD is not set. Add it to docker/.env or export it before running this script."
+  [ -n "${SPEECH_ADMIN_JWT_SECRET:-}" ] \
+    || fail "SPEECH_ADMIN_JWT_SECRET is not set. Generate with: openssl rand -hex 32"
+  [ -n "${MYSQL_ROOT_PASSWORD:-}" ] \
+    || fail "MYSQL_ROOT_PASSWORD is not set."
+  [ -n "${SPEECH_DB_PASSWORD:-}" ] \
+    || fail "SPEECH_DB_PASSWORD is not set. Generate with: openssl rand -hex 16"
+
+  ok "Secrets validated"
+
+  # Create DB idempotently against the live MySQL — init-extra-dbs.sh only runs
+  # on first volume init, so existing deployments need this explicit step.
+  "${DC[@]}" exec -T mysql mysql -uroot -p"${MYSQL_ROOT_PASSWORD}" \
+    -e "CREATE DATABASE IF NOT EXISTS octo_speech CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;" \
+    2>/dev/null
+  ok "octo_speech database ready"
+
+  # Create scoped speech DB user (least-privilege, matches matter/summary pattern)
+  "${DC[@]}" exec -T mysql mysql -uroot -p"${MYSQL_ROOT_PASSWORD}" \
+    -e "CREATE USER IF NOT EXISTS 'speech'@'%' IDENTIFIED BY '${SPEECH_DB_PASSWORD}';
+        ALTER USER IF EXISTS 'speech'@'%' IDENTIFIED BY '${SPEECH_DB_PASSWORD}';
+        GRANT ALL PRIVILEGES ON octo_speech.* TO 'speech'@'%';
+        FLUSH PRIVILEGES;" \
+    2>/dev/null
+  ok "speech DB user provisioned"
+fi
 
 # ---------------------------------------------------------------------------
 # Step 1: start speech services
@@ -74,61 +130,73 @@ persist_env() {
 if [ "$FROM_STEP" -le 1 ]; then
   log 1 "Start speech services"
   "${DC[@]}" --profile speech up -d
-  ok "speech services started"
+  persist_profile "speech"
+  ok "speech services started; COMPOSE_PROFILES updated in .env"
 fi
 
 # ---------------------------------------------------------------------------
-# Step 2: wait for octo-speech healthy
+# Step 2: wait for octo-speech-admin reachable via nginx
 # ---------------------------------------------------------------------------
 if [ "$FROM_STEP" -le 2 ]; then
-  log 2 "Wait for octo-speech to be healthy"
-  RETRIES=20
-  until "${DC[@]}" exec -T octo-speech bash -c 'echo > /dev/tcp/localhost/8780' 2>/dev/null; do
+  log 2 "Wait for octo-speech-admin to be reachable via nginx"
+  RETRIES=30
+  until curl -sf -o /dev/null "${BASE_URL}/api/login" \
+      -X POST -H "Content-Type: application/json" \
+      -d '{"username":"__probe__","password":"__probe__"}' 2>/dev/null; do
     RETRIES=$((RETRIES - 1))
-    [ "$RETRIES" -le 0 ] && fail "octo-speech did not become ready in time"
-    info "waiting... ($RETRIES attempts left)"
+    [ "$RETRIES" -le 0 ] && fail "octo-speech-admin did not become reachable in time (${BASE_URL})"
+    info "waiting for admin console... ($RETRIES attempts left)"
     sleep 5
-  done
-  ok "octo-speech is ready"
+  done || true  # 401/422 still means the endpoint is up
+  ok "octo-speech-admin is reachable"
 fi
 
 # ---------------------------------------------------------------------------
-# Step 3: create API key via speech-admin
+# Step 3: create API key via speech-admin (idempotent: reuse existing app)
 # ---------------------------------------------------------------------------
 if [ "$FROM_STEP" -le 3 ]; then
-  log 3 "Create API key via speech-admin"
+  log 3 "Create (or reuse) API key via speech-admin"
 
-  if [ -z "${SPEECH_ADMIN_PASSWORD:-}" ]; then
-    fail "SPEECH_ADMIN_PASSWORD is not set. Add it to docker/.env or export it before running this script."
-  fi
-
-  # Login and grab token
   LOGIN_RESP=$(curl -sf -X POST "${BASE_URL}/api/login" \
     -H "Content-Type: application/json" \
     -d "{\"username\":\"${ADMIN_USER}\",\"password\":\"${SPEECH_ADMIN_PASSWORD}\"}" 2>&1) \
-    || fail "Login to speech-admin failed. Is the speech profile running and nginx healthy?"
+    || fail "Login to speech-admin failed. Check SPEECH_ADMIN_USERNAME / SPEECH_ADMIN_PASSWORD."
 
   TOKEN=$(printf '%s' "$LOGIN_RESP" | grep -o '"token":"[^"]*"' | cut -d'"' -f4)
-  [ -n "$TOKEN" ] || fail "Could not extract auth token from login response: $LOGIN_RESP"
+  [ -n "$TOKEN" ] || fail "Could not extract auth token from: $LOGIN_RESP"
 
-  # Create application
-  APP_RESP=$(curl -sf -X POST "${BASE_URL}/api/apps" \
-    -H "Content-Type: application/json" \
-    -H "Authorization: Bearer ${TOKEN}" \
-    -d '{"app_name":"octo-docker"}' 2>&1) \
-    || fail "Failed to create speech API key: $APP_RESP"
+  # Try to reuse an existing 'octo-docker' app to stay idempotent
+  LIST_RESP=$(curl -sf "${BASE_URL}/api/apps" \
+    -H "Authorization: Bearer ${TOKEN}" 2>/dev/null || true)
+  EXISTING_KEY=$(printf '%s' "$LIST_RESP" | grep -o '"app_name":"octo-docker"[^}]*"api_key":"[^"]*"' \
+    | grep -o '"api_key":"[^"]*"' | cut -d'"' -f4 || true)
 
-  SPEECH_API_KEY=$(printf '%s' "$APP_RESP" | grep -o '"api_key":"[^"]*"' | cut -d'"' -f4)
-  [ -n "$SPEECH_API_KEY" ] || fail "Could not extract API key from response: $APP_RESP"
-
-  ok "API key created: ${SPEECH_API_KEY:0:12}..."
+  if [ -n "$EXISTING_KEY" ]; then
+    SPEECH_API_KEY="$EXISTING_KEY"
+    ok "Reusing existing 'octo-docker' app key: ${SPEECH_API_KEY:0:12}..."
+  else
+    APP_RESP=$(curl -sf -X POST "${BASE_URL}/api/apps" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${TOKEN}" \
+      -d '{"app_name":"octo-docker"}' 2>&1) \
+      || fail "Failed to create speech API key: $APP_RESP"
+    SPEECH_API_KEY=$(printf '%s' "$APP_RESP" | grep -o '"api_key":"[^"]*"' | cut -d'"' -f4)
+    [ -n "$SPEECH_API_KEY" ] || fail "Could not extract API key from: $APP_RESP"
+    ok "API key created: ${SPEECH_API_KEY:0:12}..."
+  fi
 fi
 
 # ---------------------------------------------------------------------------
-# Step 4: write key into .env
+# Step 4: write key + service URL into .env
 # ---------------------------------------------------------------------------
 if [ "$FROM_STEP" -le 4 ]; then
-  log 4 "Write SPEECH_API_KEY into docker/.env"
+  log 4 "Write SPEECH_API_KEY and SPEECH_SERVICE_URL into docker/.env"
+
+  # When resuming at step 4, load key from .env if not already set by step 3
+  : "${SPEECH_API_KEY:=$(env_get SPEECH_API_KEY)}"
+  [ -n "${SPEECH_API_KEY:-}" ] \
+    || fail "SPEECH_API_KEY is not set and could not be read from .env. Re-run from step 3."
+
   persist_env "SPEECH_SERVICE_URL" "http://octo-speech:8780"
   persist_env "SPEECH_API_KEY" "$SPEECH_API_KEY"
   ok "docker/.env updated"
@@ -145,4 +213,3 @@ fi
 
 printf '\n\033[32m[DONE]\033[0m Speech profile is live.\n'
 printf '  Admin console : %s/\n' "$BASE_URL"
-printf '  API key       : %s\n' "${SPEECH_API_KEY:-<set in .env>}"

--- a/docker/scripts/speech-setup.sh
+++ b/docker/scripts/speech-setup.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Set up the OCTO speech profile (octo-speech + octo-speech-admin) on an
+# already-running stack. Idempotent: every step is safe to re-run.
+# -----------------------------------------------------------------------------
+# Flow:
+#   (1) Start speech services (docker compose --profile speech up -d)
+#   (2) Wait for octo-speech to be healthy
+#   (3) Create an API key via octo-speech-admin
+#   (4) Write SPEECH_API_KEY into docker/.env
+#   (5) Restart octo-server to pick up the key
+#
+# Usage:
+#   docker/scripts/speech-setup.sh                  # full setup
+#   docker/scripts/speech-setup.sh --from 3         # resume at step N (1..5)
+#   SPEECH_ADMIN_PASSWORD=mypass docker/scripts/speech-setup.sh
+#
+# Requires: curl, docker (compose v2 plugin or docker-compose binary).
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKER_DIR="$(cd "$HERE/.." && pwd)"
+cd "$DOCKER_DIR"
+
+ENV_FILE="${ENV_FILE:-$DOCKER_DIR/.env}"
+env_get() {
+  [ -f "$ENV_FILE" ] || return 0
+  grep -E "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2- | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/"
+}
+
+if docker compose version >/dev/null 2>&1; then
+  DC=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  DC=(docker-compose)
+else
+  echo "FATAL: neither 'docker compose' nor 'docker-compose' is available" >&2
+  exit 2
+fi
+
+: "${OCTO_HTTP_PORT:=$(env_get OCTO_HTTP_PORT)}"
+: "${SPEECH_ADMIN_USERNAME:=$(env_get SPEECH_ADMIN_USERNAME)}"
+: "${SPEECH_ADMIN_PASSWORD:=$(env_get SPEECH_ADMIN_PASSWORD)}"
+
+HTTP_PORT="${OCTO_HTTP_PORT:-80}"
+ADMIN_USER="${SPEECH_ADMIN_USERNAME:-admin}"
+BASE_URL="http://127.0.0.1:${HTTP_PORT}/speech-admin"
+
+FROM_STEP=1
+for arg in "$@"; do
+  case "$arg" in
+    --from) shift; FROM_STEP="${1:-1}"; shift ;;
+    --from=*) FROM_STEP="${arg#--from=}" ;;
+  esac
+done
+
+log()     { printf '\n\033[1m=== Step %s: %s ===\033[0m\n' "$1" "$2"; }
+ok()      { printf '\033[32m[OK]\033[0m %s\n' "$*"; }
+info()    { printf '    %s\n' "$*"; }
+fail()    { printf '\033[31m[FAIL]\033[0m %s\n' "$*" >&2; exit 1; }
+
+persist_env() {
+  local key="$1" val="$2"
+  if grep -qE "^${key}=" "$ENV_FILE" 2>/dev/null; then
+    sed -i "s|^${key}=.*|${key}=${val}|" "$ENV_FILE"
+  else
+    printf '\n%s=%s\n' "$key" "$val" >> "$ENV_FILE"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Step 1: start speech services
+# ---------------------------------------------------------------------------
+if [ "$FROM_STEP" -le 1 ]; then
+  log 1 "Start speech services"
+  "${DC[@]}" --profile speech up -d
+  ok "speech services started"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: wait for octo-speech healthy
+# ---------------------------------------------------------------------------
+if [ "$FROM_STEP" -le 2 ]; then
+  log 2 "Wait for octo-speech to be healthy"
+  RETRIES=20
+  until "${DC[@]}" exec -T octo-speech bash -c 'echo > /dev/tcp/localhost/8780' 2>/dev/null; do
+    RETRIES=$((RETRIES - 1))
+    [ "$RETRIES" -le 0 ] && fail "octo-speech did not become ready in time"
+    info "waiting... ($RETRIES attempts left)"
+    sleep 5
+  done
+  ok "octo-speech is ready"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: create API key via speech-admin
+# ---------------------------------------------------------------------------
+if [ "$FROM_STEP" -le 3 ]; then
+  log 3 "Create API key via speech-admin"
+
+  if [ -z "${SPEECH_ADMIN_PASSWORD:-}" ]; then
+    fail "SPEECH_ADMIN_PASSWORD is not set. Add it to docker/.env or export it before running this script."
+  fi
+
+  # Login and grab token
+  LOGIN_RESP=$(curl -sf -X POST "${BASE_URL}/api/login" \
+    -H "Content-Type: application/json" \
+    -d "{\"username\":\"${ADMIN_USER}\",\"password\":\"${SPEECH_ADMIN_PASSWORD}\"}" 2>&1) \
+    || fail "Login to speech-admin failed. Is the speech profile running and nginx healthy?"
+
+  TOKEN=$(printf '%s' "$LOGIN_RESP" | grep -o '"token":"[^"]*"' | cut -d'"' -f4)
+  [ -n "$TOKEN" ] || fail "Could not extract auth token from login response: $LOGIN_RESP"
+
+  # Create application
+  APP_RESP=$(curl -sf -X POST "${BASE_URL}/api/apps" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -d '{"app_name":"octo-docker"}' 2>&1) \
+    || fail "Failed to create speech API key: $APP_RESP"
+
+  SPEECH_API_KEY=$(printf '%s' "$APP_RESP" | grep -o '"api_key":"[^"]*"' | cut -d'"' -f4)
+  [ -n "$SPEECH_API_KEY" ] || fail "Could not extract API key from response: $APP_RESP"
+
+  ok "API key created: ${SPEECH_API_KEY:0:12}..."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: write key into .env
+# ---------------------------------------------------------------------------
+if [ "$FROM_STEP" -le 4 ]; then
+  log 4 "Write SPEECH_API_KEY into docker/.env"
+  persist_env "SPEECH_SERVICE_URL" "http://octo-speech:8780"
+  persist_env "SPEECH_API_KEY" "$SPEECH_API_KEY"
+  ok "docker/.env updated"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5: restart octo-server
+# ---------------------------------------------------------------------------
+if [ "$FROM_STEP" -le 5 ]; then
+  log 5 "Restart octo-server to activate speech"
+  "${DC[@]}" up -d --no-deps octo-server
+  ok "octo-server restarted"
+fi
+
+printf '\n\033[32m[DONE]\033[0m Speech profile is live.\n'
+printf '  Admin console : %s/\n' "$BASE_URL"
+printf '  API key       : %s\n' "${SPEECH_API_KEY:-<set in .env>}"


### PR DESCRIPTION
## Summary

- Adds a `speech` Compose profile that brings up `octo-speech` (voice transcription API) and `octo-speech-admin` (API-key management console) alongside the existing `summary` and `search` profiles
- A vanilla `docker compose up -d` starts nothing new — operators opt in with `COMPOSE_PROFILES=speech`
- Follows the same strictly-additive, profile-gated pattern as the `summary` and `search` profiles

## Changes

| File | What changed |
|------|-------------|
| `docker/docker-compose.yaml` | Add `octo-speech` and `octo-speech-admin` services (`profiles: ["speech"]`); wire `SPEECH_SERVICE_URL` / `SPEECH_API_KEY` into `octo-server` (empty-default, no breakage on non-speech deploys) |
| `docker/nginx/conf.d/octo.conf.template` | Add `/speech-admin/` location block with variable `proxy_pass` so nginx starts cleanly when the speech profile is absent |
| `docker/scripts/init-extra-dbs.sh` | Create `octo_speech` database on first MySQL volume init |
| `docker/scripts/speech-setup.sh` | New guided two-phase setup script: starts services → waits for health → creates API key via admin console → writes it to `.env` → restarts `octo-server` |
| `docker/.env.example` | Document all speech-profile variables with inline guidance on the two-phase key-creation flow |

## Two-phase setup

Voice transcription requires a runtime API key generated by `octo-speech-admin`. The new `speech-setup.sh` script handles this automatically:

```bash
# 1. Set required vars in docker/.env
COMPOSE_PROFILES=summary,speech
SPEECH_ADMIN_USERNAME=admin
SPEECH_ADMIN_PASSWORD=<openssl rand -hex 16>
SPEECH_ADMIN_JWT_SECRET=<openssl rand -hex 32>
VOICE_ENGINE=qwen
VOICE_LITELLM_URL=https://your-llm-gateway/v1
VOICE_QWEN_KEY=<your-api-key>

# 2. Run the setup script
docker/scripts/speech-setup.sh
```

The script starts the speech services, waits for health, creates an API key, writes `SPEECH_API_KEY` into `.env`, and restarts `octo-server`.

## Test plan

- [ ] `docker compose up -d` (no `COMPOSE_PROFILES`) starts cleanly with no speech containers
- [ ] `COMPOSE_PROFILES=speech docker compose up -d` starts `octo-speech` and `octo-speech-admin`
- [ ] `speech-setup.sh` completes all 5 steps without error
- [ ] `http://<host>/speech-admin/` is reachable via nginx
- [ ] Voice message transcription works in the OCTO web client after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)