### PR TITLE
feat(docker): add speech profile (octo-speech + octo-speech-admin)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -431,6 +431,9 @@ LLM_MODEL=claude-sonnet-4-6
 # The speech pipeline (octo-speech + octo-speech-admin) is gated by the
 # "speech" profile. Enable it with COMPOSE_PROFILES=speech (combine profiles
 # with a comma, e.g. COMPOSE_PROFILES=summary,speech).
+# IMPORTANT: run `docker/scripts/speech-setup.sh` to set up the speech profile.
+# Do NOT add "speech" to COMPOSE_PROFILES manually without first setting the
+# required credentials below — the services will fail to start.
 #
 # The message-search pipeline (Kafka + OpenSearch + es-indexer) is gated by
 # the "search" profile. Enable it with COMPOSE_PROFILES=search (combine
@@ -440,13 +443,17 @@ LLM_MODEL=claude-sonnet-4-6
 # missing search variable. See docker/README.md "Search profile".
 
 # --- Speech pipeline (only used when COMPOSE_PROFILES includes "speech") ---
-# LLM engine for voice transcription. "qwen" uses the Qwen omni model via a
-# LiteLLM-compatible gateway (recommended for Chinese); "openai" uses the
-# OpenAI Whisper endpoint.
+# LLM engine for voice transcription. "qwen" uses the Qwen omni model
+# (recommended for Chinese); "openai" uses the OpenAI Whisper endpoint.
 # VOICE_ENGINE=qwen
-# VOICE_LITELLM_URL=https://llm-gateway.example.com/v1
+#
+# Qwen engine (VOICE_ENGINE=qwen):
+# VOICE_QWEN_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 # VOICE_QWEN_KEY=<your-api-key>
 # VOICE_QWEN_MODELS=qwen3.5-omni-plus
+#
+# Non-qwen engines (VOICE_ENGINE=openai / gpt):
+# VOICE_LITELLM_URL=https://llm-gateway.example.com/v1
 
 # speech-admin console credentials (generate passwords with openssl rand -hex 16)
 # SPEECH_ADMIN_USERNAME=admin

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -443,8 +443,8 @@ LLM_MODEL=claude-sonnet-4-6
 # missing search variable. See docker/README.md "Search profile".
 
 # --- Speech pipeline (only used when COMPOSE_PROFILES includes "speech") ---
-# LLM engine for voice transcription. "qwen" uses the Qwen omni model
-# (recommended for Chinese); "openai" uses the OpenAI Whisper endpoint.
+# LLM engine for voice transcription. Supported values: qwen (recommended
+# for Chinese), gpt, gemini. Default: qwen.
 # VOICE_ENGINE=qwen
 #
 # Qwen engine (VOICE_ENGINE=qwen):
@@ -452,7 +452,7 @@ LLM_MODEL=claude-sonnet-4-6
 # VOICE_QWEN_KEY=<your-api-key>
 # VOICE_QWEN_MODELS=qwen3.5-omni-plus
 #
-# Non-qwen engines (VOICE_ENGINE=openai / gpt):
+# Non-qwen engines (VOICE_ENGINE=gpt / gemini):
 # VOICE_LITELLM_URL=https://llm-gateway.example.com/v1
 
 # speech-admin console credentials (generate passwords with openssl rand -hex 16)

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -428,12 +428,51 @@ LLM_MODEL=claude-sonnet-4-6
 # uncomment COMPOSE_PROFILES below (setup.sh --summary does this for you).
 # COMPOSE_PROFILES=summary
 #
+# The speech pipeline (octo-speech + octo-speech-admin) is gated by the
+# "speech" profile. Enable it with COMPOSE_PROFILES=speech (combine profiles
+# with a comma, e.g. COMPOSE_PROFILES=summary,speech).
+#
 # The message-search pipeline (Kafka + OpenSearch + es-indexer) is gated by
 # the "search" profile. Enable it with COMPOSE_PROFILES=search (combine
 # profiles with a comma, e.g. COMPOSE_PROFILES=summary,search). With no
 # profile set, NONE of the search services start and the lines below are
 # inert — every one has a default, so a default deployment never fails on a
 # missing search variable. See docker/README.md "Search profile".
+
+# --- Speech pipeline (only used when COMPOSE_PROFILES includes "speech") ---
+# LLM engine for voice transcription. "qwen" uses the Qwen omni model via a
+# LiteLLM-compatible gateway (recommended for Chinese); "openai" uses the
+# OpenAI Whisper endpoint.
+# VOICE_ENGINE=qwen
+# VOICE_LITELLM_URL=https://llm-gateway.example.com/v1
+# VOICE_QWEN_KEY=<your-api-key>
+# VOICE_QWEN_MODELS=qwen3.5-omni-plus
+
+# speech-admin console credentials (generate passwords with openssl rand -hex 16)
+# SPEECH_ADMIN_USERNAME=admin
+# SPEECH_ADMIN_PASSWORD=<openssl rand -hex 16>
+# SPEECH_ADMIN_JWT_SECRET=<openssl rand -hex 32>
+
+# MySQL credential for the scoped 'speech' DB user (created by init-extra-dbs.sh
+# on first MySQL volume init, and on existing stacks by speech-setup.sh step 0).
+# Use only [A-Za-z0-9._-] characters — same allowlist as the other DB passwords.
+# Generate with: openssl rand -hex 16
+# SPEECH_DB_PASSWORD=<openssl rand -hex 16>
+
+# After the speech profile is up, create an API key via the speech-admin
+# console (http://<host>/speech-admin/) and paste it here, then restart
+# octo-server so it can call octo-speech for voice transcription.
+# SPEECH_SERVICE_URL=http://octo-speech:8780
+# SPEECH_API_KEY=<key from speech-admin console>
+
+# Host bind / port for the speech-admin container (default: loopback:28088).
+# The admin console is also reachable through nginx at /speech-admin/.
+# OCTO_SPEECH_ADMIN_BIND=127.0.0.1
+# OCTO_SPEECH_ADMIN_PORT=28088
+
+# Speech profile image overrides (only used with COMPOSE_PROFILES=speech):
+# OCTO_SPEECH_IMAGE=mininglamposs/octo-speech:latest
+# OCTO_SPEECH_ADMIN_IMAGE=mininglamposs/octo-speech-admin:latest
 
 # --- Search pipeline (only used when COMPOSE_PROFILES includes "search") ---
 # Host ports for local validation; loopback-bound by default so they never

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -194,6 +194,7 @@ services:
       OCTO_MATTER_DB_PASSWORD: ${OCTO_MATTER_DB_PASSWORD:-matter}
       OCTO_SUMMARY_DB_PASSWORD: ${OCTO_SUMMARY_DB_PASSWORD:-summary}
       OCTO_SUMMARY_READER_PASSWORD: ${OCTO_SUMMARY_READER_PASSWORD:-summary_reader}
+      SPEECH_DB_PASSWORD: ${SPEECH_DB_PASSWORD:-}
     # Backing service: bound to loopback by default so a missed-config moment
     # does not expose MySQL with the placeholder root password to the public
     # internet. Override OCTO_MYSQL_BIND to 0.0.0.0 only when you understand
@@ -745,6 +746,10 @@ services:
       # Leaving it UNSET would make octo-server assume the pre-switch default
       # (ES on) and hammer a non-existent OpenSearch on the first search call.
       OCTO_SEARCH_BACKEND: ${OCTO_SEARCH_BACKEND:-disabled}
+      # octo-speech voice transcription wiring. Empty by default so a non-speech
+      # deployment boots cleanly without these vars set.
+      SPEECH_SERVICE_URL: ${SPEECH_SERVICE_URL:-}
+      SPEECH_API_KEY:     ${SPEECH_API_KEY:-}
       # Where the reader finds OpenSearch + which read alias it queries. Only
       # consulted when OCTO_SEARCH_BACKEND=es; harmless (unread) when disabled.
       # The reader queries the ALIAS, never the physical index — the alias is
@@ -1079,6 +1084,78 @@ services:
       # window does not wedge the worker into `(unhealthy)` while the
       # mysql init script is still finishing.
       start_period: 30s
+
+  # ===========================================================================
+  # Speech infrastructure (voice transcription) — STRICTLY ADDITIVE
+  # ===========================================================================
+  # octo-speech (transcription API) + octo-speech-admin (API-key console).
+  # Both are gated behind `profiles: ["speech"]` — a vanilla `docker compose
+  # up -d` starts neither. Opt in with `COMPOSE_PROFILES=speech` (combine
+  # with other profiles: `COMPOSE_PROFILES=summary,speech`).
+  #
+  # ISOLATION GUARANTEES:
+  #   - No core service definition is touched beyond two optional env vars on
+  #     octo-server (SPEECH_SERVICE_URL / SPEECH_API_KEY), both empty-default.
+  #   - No new REQUIRED env var: every var below has a `:-` default or is
+  #     gated by the profile, so a non-speech deployment never fails preflight.
+  #   - Reuses the existing octo-net network and the existing MySQL instance
+  #     (octo_speech database is created by scripts/init-extra-dbs.sh).
+  # ---------------------------------------------------------------------------
+  octo-speech:
+    image: ${OCTO_SPEECH_IMAGE:-mininglamposs/octo-speech:latest}
+    restart: unless-stopped
+    profiles: ["speech"]
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      SPEECH_DB_DSN:         "speech:${SPEECH_DB_PASSWORD:-}@tcp(mysql:3306)/octo_speech?parseTime=true&loc=Asia%2FShanghai"
+      SPEECH_SERVICE_PORT:   "8780"
+      VOICE_ENGINE:          ${VOICE_ENGINE:-qwen}
+      VOICE_LITELLM_URL:     ${VOICE_LITELLM_URL:-}
+      VOICE_QWEN_KEY:        ${VOICE_QWEN_KEY:-}
+      VOICE_QWEN_MODELS:     ${VOICE_QWEN_MODELS:-qwen3.5-omni-plus}
+      VOICE_LITELLM_TIMEOUT: "60"
+      VOICE_TOTAL_TIMEOUT:   "90"
+      VOICE_MAX_DURATION:    "60"
+      VOICE_MAX_FILE_SIZE:   "3145728"
+      TZ: Asia/Shanghai
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/8780' || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    networks:
+      - octo-net
+
+  octo-speech-admin:
+    image: ${OCTO_SPEECH_ADMIN_IMAGE:-mininglamposs/octo-speech-admin:latest}
+    restart: unless-stopped
+    profiles: ["speech"]
+    depends_on:
+      mysql:
+        condition: service_healthy
+      octo-speech:
+        condition: service_healthy
+    environment:
+      SPEECH_DB_DSN:       "speech:${SPEECH_DB_PASSWORD:-}@tcp(mysql:3306)/octo_speech?parseTime=true&loc=Asia%2FShanghai"
+      ADMIN_PORT:          "8781"
+      ADMIN_USERNAME:      ${SPEECH_ADMIN_USERNAME:-admin}
+      ADMIN_PASSWORD:      ${SPEECH_ADMIN_PASSWORD:-}
+      ADMIN_JWT_SECRET:    ${SPEECH_ADMIN_JWT_SECRET:-}
+      ADMIN_SECURE_COOKIE: "false"
+      TZ: Asia/Shanghai
+    ports:
+      - "${OCTO_SPEECH_ADMIN_BIND:-127.0.0.1}:${OCTO_SPEECH_ADMIN_PORT:-28088}:8781"
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/8781' || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    networks:
+      - octo-net
 
   # ===========================================================================
   # Search infrastructure (message-search pipeline) — STRICTLY ADDITIVE

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1121,7 +1121,7 @@ services:
       VOICE_MAX_FILE_SIZE:   "3145728"
       TZ: ${TZ:-UTC}
     healthcheck:
-      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/8780' || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:8780/ || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -1149,7 +1149,7 @@ services:
     ports:
       - "${OCTO_SPEECH_ADMIN_BIND:-127.0.0.1}:${OCTO_SPEECH_ADMIN_PORT:-28088}:8781"
     healthcheck:
-      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/8781' || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:8781/ || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1119,7 +1119,7 @@ services:
       VOICE_TOTAL_TIMEOUT:   "90"
       VOICE_MAX_DURATION:    "60"
       VOICE_MAX_FILE_SIZE:   "3145728"
-      TZ: Asia/Shanghai
+      TZ: ${TZ:-UTC}
     healthcheck:
       test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/8780' || exit 1"]
       interval: 30s
@@ -1145,7 +1145,7 @@ services:
       ADMIN_PASSWORD:      ${SPEECH_ADMIN_PASSWORD:-}
       ADMIN_JWT_SECRET:    ${SPEECH_ADMIN_JWT_SECRET:-}
       ADMIN_SECURE_COOKIE: "false"
-      TZ: Asia/Shanghai
+      TZ: ${TZ:-UTC}
     ports:
       - "${OCTO_SPEECH_ADMIN_BIND:-127.0.0.1}:${OCTO_SPEECH_ADMIN_PORT:-28088}:8781"
     healthcheck:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1112,6 +1112,7 @@ services:
       SPEECH_DB_DSN:         "speech:${SPEECH_DB_PASSWORD:-}@tcp(mysql:3306)/octo_speech?parseTime=true&loc=Asia%2FShanghai"
       SPEECH_SERVICE_PORT:   "8780"
       VOICE_ENGINE:          ${VOICE_ENGINE:-qwen}
+      VOICE_QWEN_URL:        ${VOICE_QWEN_URL:-}
       VOICE_LITELLM_URL:     ${VOICE_LITELLM_URL:-}
       VOICE_QWEN_KEY:        ${VOICE_QWEN_KEY:-}
       VOICE_QWEN_MODELS:     ${VOICE_QWEN_MODELS:-qwen3.5-omni-plus}

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -300,6 +300,7 @@ server {
 <li><a href="/api/v1/health">REST · <code>/api/v1/health</code></a></li>
 <li><a href="/matter/health">Matter · <code>/matter/health</code></a></li>
 <li><a href="/summary/health">Smart-summary · <code>/summary/health</code></a></li>
+<li><a href="/speech-admin/">Speech Admin</a></li>
 </ul>
 <p>MinIO console is loopback-only (port 29001 on the host). SSH-forward
 to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -272,6 +272,21 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
+    location /speech-admin/ {
+        # octo-speech-admin lives in `profiles: [speech]` — variable proxy_pass
+        # defers DNS resolution to request time so nginx starts cleanly even
+        # when the container is absent (returns 502 instead of emerg crash).
+        limit_req zone=octo_api burst=20 nodelay;
+        set $upstream_speech_admin octo-speech-admin;
+        rewrite ^/speech-admin/(.*) /$1 break;
+        proxy_pass         http://$upstream_speech_admin:8781;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
     location = /_octo_up {
         default_type text/html;
         return 200 '<!doctype html>
@@ -470,6 +485,18 @@ to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
 #         set $upstream_summary summary-api;
 #         rewrite ^/summary/(.*) /$1 break;
 #         proxy_pass         http://$upstream_summary:8080;
+#         proxy_http_version 1.1;
+#         proxy_set_header   Host              $host;
+#         proxy_set_header   X-Real-IP         $remote_addr;
+#         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+#         proxy_set_header   X-Forwarded-Proto $scheme;
+#     }
+#
+#     location /speech-admin/ {
+#         limit_req zone=octo_api burst=20 nodelay;
+#         set $upstream_speech_admin octo-speech-admin;
+#         rewrite ^/speech-admin/(.*) /$1 break;
+#         proxy_pass         http://$upstream_speech_admin:8781;
 #         proxy_http_version 1.1;
 #         proxy_set_header   Host              $host;
 #         proxy_set_header   X-Real-IP         $remote_addr;

--- a/docker/scripts/init-extra-dbs.sh
+++ b/docker/scripts/init-extra-dbs.sh
@@ -40,6 +40,7 @@ set -euo pipefail
 : "${OCTO_MATTER_DB_PASSWORD:=matter}"
 : "${OCTO_SUMMARY_DB_PASSWORD:=summary}"
 : "${OCTO_SUMMARY_READER_PASSWORD:=summary_reader}"
+: "${SPEECH_DB_PASSWORD:=}"
 : "${MYSQL_DATABASE:=octo}"
 
 validate_password() {
@@ -142,6 +143,7 @@ MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -u root <<SQL
 -- Schemas ---------------------------------------------------------------------
 CREATE DATABASE IF NOT EXISTS octo_matter  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 CREATE DATABASE IF NOT EXISTS octo_summary CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+CREATE DATABASE IF NOT EXISTS octo_speech  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- Service-scoped read-write accounts -----------------------------------------
 -- CREATE USER IF NOT EXISTS leaves an existing user untouched; the matching
@@ -166,5 +168,19 @@ GRANT ALL PRIVILEGES ON octo_summary.*     TO 'summary'@'%';
 GRANT SELECT         ON \`${MYSQL_DATABASE}\`.* TO 'summary_reader'@'%';
 FLUSH PRIVILEGES;
 SQL
+
+# If SPEECH_DB_PASSWORD is set, provision the scoped speech DB user.
+# The main SQL block above already created octo_speech; this separate
+# step is conditional so it is safe to skip on a non-speech deployment.
+if [ -n "${SPEECH_DB_PASSWORD:-}" ]; then
+  validate_password SPEECH_DB_PASSWORD "$SPEECH_DB_PASSWORD"
+  MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -u root <<SQL
+CREATE USER IF NOT EXISTS 'speech'@'%' IDENTIFIED BY '${SPEECH_DB_PASSWORD}';
+ALTER USER IF EXISTS      'speech'@'%' IDENTIFIED BY '${SPEECH_DB_PASSWORD}';
+GRANT ALL PRIVILEGES ON octo_speech.* TO 'speech'@'%';
+FLUSH PRIVILEGES;
+SQL
+  echo "[init-extra-dbs] provisioned speech DB user"
+fi
 
 echo "[init-extra-dbs] created octo_matter + octo_summary + service users (scoped to \`${MYSQL_DATABASE}\`)"

--- a/docker/scripts/init-extra-dbs.sh
+++ b/docker/scripts/init-extra-dbs.sh
@@ -183,4 +183,4 @@ SQL
   echo "[init-extra-dbs] provisioned speech DB user"
 fi
 
-echo "[init-extra-dbs] created octo_matter + octo_summary + service users (scoped to \`${MYSQL_DATABASE}\`)"
+echo "[init-extra-dbs] created octo_matter + octo_summary + octo_speech + service users (scoped to \`${MYSQL_DATABASE}\`)"

--- a/docker/scripts/speech-setup.sh
+++ b/docker/scripts/speech-setup.sh
@@ -27,7 +27,7 @@ ENV_FILE="${ENV_FILE:-$DOCKER_DIR/.env}"
 
 env_get() {
   [ -f "$ENV_FILE" ] || return 0
-  grep -E "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2- | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/"
+  grep -E "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2- | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/" || true
 }
 
 # portable: rewrite via tmp file, no sed -i flavor issues (matches search-upgrade.sh)
@@ -84,6 +84,10 @@ while (($#)); do
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
+case "$FROM_STEP" in
+  [0-5]) ;;
+  *) echo "Invalid --from value '$FROM_STEP': must be an integer 0..5" >&2; exit 1 ;;
+esac
 
 log()  { printf '\n\033[1m=== Step %s: %s ===\033[0m\n' "$1" "$2"; }
 ok()   { printf '\033[32m[OK]\033[0m %s\n' "$*"; }
@@ -115,6 +119,10 @@ if [ "$FROM_STEP" -le 0 ]; then
   case "$SPEECH_DB_PASSWORD" in
     *[!A-Za-z0-9._-]*)
       fail "SPEECH_DB_PASSWORD contains characters outside [A-Za-z0-9._-]. Use: openssl rand -hex 16" ;;
+  esac
+  case "$(printf %s "$SPEECH_DB_PASSWORD" | tr 'A-Z' 'a-z')" in
+    change_me_*|chg_me*)
+      fail "SPEECH_DB_PASSWORD is still a CHANGE_ME placeholder. Rotate it: openssl rand -hex 16" ;;
   esac
 
   ok "Secrets validated"

--- a/docker/scripts/speech-setup.sh
+++ b/docker/scripts/speech-setup.sh
@@ -98,6 +98,14 @@ if [ "$FROM_STEP" -le 0 ]; then
 
   [ -n "${SPEECH_ADMIN_PASSWORD:-}" ] \
     || fail "SPEECH_ADMIN_PASSWORD is not set. Add it to docker/.env or export it before running this script."
+  case "$SPEECH_ADMIN_PASSWORD" in
+    *[!A-Za-z0-9._-]*)
+      fail "SPEECH_ADMIN_PASSWORD contains characters outside [A-Za-z0-9._-]. Use: openssl rand -hex 16" ;;
+  esac
+  case "$ADMIN_USER" in
+    *[!A-Za-z0-9._-]*)
+      fail "SPEECH_ADMIN_USERNAME contains characters outside [A-Za-z0-9._-]." ;;
+  esac
   [ -n "${SPEECH_ADMIN_JWT_SECRET:-}" ] \
     || fail "SPEECH_ADMIN_JWT_SECRET is not set. Generate with: openssl rand -hex 32"
   [ -n "${MYSQL_ROOT_PASSWORD:-}" ] \
@@ -137,8 +145,12 @@ fi
 if [ "$FROM_STEP" -le 1 ]; then
   log 1 "Start speech services"
   "${DC[@]}" --profile speech up -d
+  # Recreate nginx so it picks up the /speech-admin/ route from the updated
+  # template — Compose does not recreate a running container just because a
+  # bind-mounted file changed.
+  "${DC[@]}" up -d --force-recreate --no-deps nginx
   persist_profile "speech"
-  ok "speech services started; COMPOSE_PROFILES updated in .env"
+  ok "speech services started; nginx recreated; COMPOSE_PROFILES updated in .env"
 fi
 
 # ---------------------------------------------------------------------------
@@ -147,16 +159,21 @@ fi
 if [ "$FROM_STEP" -le 2 ]; then
   log 2 "Wait for octo-speech-admin to be reachable via nginx"
   RETRIES=30
-  until [ "$(curl -s -o /dev/null -w '%{http_code}' \
+  # Accept only HTTP codes that prove the login endpoint itself handled the
+  # request (400 bad-request, 401 unauthorized, 422 validation error).
+  # Intermediate failures (000 no-connection, 404 stale nginx, 502/503 proxy
+  # errors) continue retrying so a normal startup race resolves on its own.
+  until HTTP_CODE="$(curl -s -o /dev/null -w '%{http_code}' \
       -X POST "${BASE_URL}/api/login" \
       -H "Content-Type: application/json" \
-      -d '{}' 2>/dev/null)" != "000" ]; do
+      -d '{}' 2>/dev/null)" \
+    && case "$HTTP_CODE" in 400|401|422) true ;; *) false ;; esac; do
     RETRIES=$((RETRIES - 1))
-    [ "$RETRIES" -le 0 ] && fail "octo-speech-admin did not become reachable in time (${BASE_URL})"
-    info "waiting for admin console... ($RETRIES attempts left)"
+    [ "$RETRIES" -le 0 ] && fail "octo-speech-admin did not become reachable in time (${BASE_URL}, last HTTP $HTTP_CODE)"
+    info "waiting for admin console... ($RETRIES attempts left, HTTP $HTTP_CODE)"
     sleep 5
   done
-  ok "octo-speech-admin is reachable"
+  ok "octo-speech-admin is reachable (HTTP $HTTP_CODE)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/docker/scripts/speech-setup.sh
+++ b/docker/scripts/speech-setup.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Set up the OCTO speech profile (octo-speech + octo-speech-admin) on an
+# already-running stack. Idempotent: every step is safe to re-run.
+# -----------------------------------------------------------------------------
+# Flow:
+#   (0) Validate required secrets; create octo_speech DB if absent
+#   (1) Start speech services (docker compose --profile speech up -d)
+#   (2) Wait for octo-speech-admin to be reachable via nginx
+#   (3) Create an API key via octo-speech-admin
+#   (4) Write SPEECH_API_KEY + SPEECH_SERVICE_URL + COMPOSE_PROFILES into .env
+#   (5) Restart octo-server to pick up the key
+#
+# Usage:
+#   docker/scripts/speech-setup.sh              # full setup
+#   docker/scripts/speech-setup.sh --from 3     # resume at step N (0..5)
+#
+# Requires: curl, docker (compose v2 plugin or docker-compose binary).
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKER_DIR="$(cd "$HERE/.." && pwd)"
+cd "$DOCKER_DIR"
+
+ENV_FILE="${ENV_FILE:-$DOCKER_DIR/.env}"
+
+env_get() {
+  [ -f "$ENV_FILE" ] || return 0
+  grep -E "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2- | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/"
+}
+
+# portable: rewrite via tmp file, no sed -i flavor issues (matches search-upgrade.sh)
+persist_env() {
+  local key="$1" val="$2"
+  touch "$ENV_FILE"
+  if grep -qE "^${key}=" "$ENV_FILE"; then
+    awk -v k="$key" -v v="$val" \
+      'BEGIN{FS=OFS="="} $1==k{print k"="v; next} {print}' \
+      "$ENV_FILE" > "$ENV_FILE.tmp" && mv "$ENV_FILE.tmp" "$ENV_FILE"
+  else
+    printf '%s=%s\n' "$key" "$val" >> "$ENV_FILE"
+  fi
+}
+
+persist_profile() {
+  local add="$1" current merged
+  current="${COMPOSE_PROFILES:-$(env_get COMPOSE_PROFILES)}"
+  merged="$(printf '%s' "$current" | tr ',' '\n' | sed '/^[[:space:]]*$/d' \
+    | awk -v a="$add" '{print} $0==a{seen=1} END{if(!seen)print a}' \
+    | paste -sd, -)"
+  COMPOSE_PROFILES="$merged"
+  persist_env COMPOSE_PROFILES "$merged"
+}
+
+if docker compose version >/dev/null 2>&1; then
+  DC=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  DC=(docker-compose)
+else
+  echo "FATAL: neither 'docker compose' nor 'docker-compose' is available" >&2
+  exit 2
+fi
+
+# resolve vars from .env (env wins, like Compose)
+: "${OCTO_HTTP_PORT:=$(env_get OCTO_HTTP_PORT)}"
+: "${MYSQL_ROOT_PASSWORD:=$(env_get MYSQL_ROOT_PASSWORD)}"
+: "${SPEECH_DB_PASSWORD:=$(env_get SPEECH_DB_PASSWORD)}"
+: "${SPEECH_ADMIN_USERNAME:=$(env_get SPEECH_ADMIN_USERNAME)}"
+: "${SPEECH_ADMIN_PASSWORD:=$(env_get SPEECH_ADMIN_PASSWORD)}"
+: "${SPEECH_ADMIN_JWT_SECRET:=$(env_get SPEECH_ADMIN_JWT_SECRET)}"
+: "${SPEECH_API_KEY:=$(env_get SPEECH_API_KEY)}"
+
+HTTP_PORT="${OCTO_HTTP_PORT:-28080}"
+ADMIN_USER="${SPEECH_ADMIN_USERNAME:-admin}"
+BASE_URL="http://127.0.0.1:${HTTP_PORT}/speech-admin"
+
+# parse --from N
+FROM_STEP=0
+while (($#)); do
+  case "$1" in
+    --from) shift; FROM_STEP="${1:?'--from requires a step number'}"; shift ;;
+    --from=*) FROM_STEP="${1#--from=}"; shift ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+log()  { printf '\n\033[1m=== Step %s: %s ===\033[0m\n' "$1" "$2"; }
+ok()   { printf '\033[32m[OK]\033[0m %s\n' "$*"; }
+info() { printf '    %s\n' "$*"; }
+fail() { printf '\033[31m[FAIL]\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Step 0: validate secrets + create octo_speech DB on existing stack
+# ---------------------------------------------------------------------------
+if [ "$FROM_STEP" -le 0 ]; then
+  log 0 "Validate secrets and provision octo_speech database"
+
+  [ -n "${SPEECH_ADMIN_PASSWORD:-}" ] \
+    || fail "SPEECH_ADMIN_PASSWORD is not set. Add it to docker/.env or export it before running this script."
+  [ -n "${SPEECH_ADMIN_JWT_SECRET:-}" ] \
+    || fail "SPEECH_ADMIN_JWT_SECRET is not set. Generate with: openssl rand -hex 32"
+  [ -n "${MYSQL_ROOT_PASSWORD:-}" ] \
+    || fail "MYSQL_ROOT_PASSWORD is not set."
+  [ -n "${SPEECH_DB_PASSWORD:-}" ] \
+    || fail "SPEECH_DB_PASSWORD is not set. Generate with: openssl rand -hex 16"
+  case "$SPEECH_DB_PASSWORD" in
+    *[!A-Za-z0-9._-]*)
+      fail "SPEECH_DB_PASSWORD contains characters outside [A-Za-z0-9._-]. Use: openssl rand -hex 16" ;;
+  esac
+
+  ok "Secrets validated"
+
+  # Create DB idempotently against the live MySQL — init-extra-dbs.sh only runs
+  # on first volume init, so existing deployments need this explicit step.
+  # Pass MYSQL_PWD via -e so the root credential stays out of ps/proc cmdline.
+  "${DC[@]}" exec -T -e MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql \
+    mysql -uroot \
+    -e "CREATE DATABASE IF NOT EXISTS octo_speech CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;" \
+    || fail "Failed to create octo_speech database — check MYSQL_ROOT_PASSWORD and MySQL connectivity."
+  ok "octo_speech database ready"
+
+  # Create scoped speech DB user (least-privilege, matches matter/summary pattern)
+  "${DC[@]}" exec -T -e MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql \
+    mysql -uroot \
+    -e "CREATE USER IF NOT EXISTS 'speech'@'%' IDENTIFIED BY '${SPEECH_DB_PASSWORD}';
+        ALTER USER IF EXISTS 'speech'@'%' IDENTIFIED BY '${SPEECH_DB_PASSWORD}';
+        GRANT ALL PRIVILEGES ON octo_speech.* TO 'speech'@'%';
+        FLUSH PRIVILEGES;" \
+    || fail "Failed to provision speech DB user — check MYSQL_ROOT_PASSWORD and MySQL connectivity."
+  ok "speech DB user provisioned"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 1: start speech services
+# ---------------------------------------------------------------------------
+if [ "$FROM_STEP" -le 1 ]; then
+  log 1 "Start speech services"
+  "${DC[@]}" --profile speech up -d
+  persist_profile "speech"
+  ok "speech services started; COMPOSE_PROFILES updated in .env"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: wait for octo-speech-admin reachable via nginx
+# ---------------------------------------------------------------------------
+if [ "$FROM_STEP" -le 2 ]; then
+  log 2 "Wait for octo-speech-admin to be reachable via nginx"
+  RETRIES=30
+  until [ "$(curl -s -o /dev/null -w '%{http_code}' \
+      -X POST "${BASE_URL}/api/login" \
+      -H "Content-Type: application/json" \
+      -d '{}' 2>/dev/null)" != "000" ]; do
+    RETRIES=$((RETRIES - 1))
+    [ "$RETRIES" -le 0 ] && fail "octo-speech-admin did not become reachable in time (${BASE_URL})"
+    info "waiting for admin console... ($RETRIES attempts left)"
+    sleep 5
+  done
+  ok "octo-speech-admin is reachable"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: create API key via speech-admin (idempotent: reuse existing app)
+# ---------------------------------------------------------------------------
+if [ "$FROM_STEP" -le 3 ]; then
+  log 3 "Create (or reuse) API key via speech-admin"
+
+  LOGIN_RESP=$(curl -sf -X POST "${BASE_URL}/api/login" \
+    -H "Content-Type: application/json" \
+    -d "{\"username\":\"${ADMIN_USER}\",\"password\":\"${SPEECH_ADMIN_PASSWORD}\"}" 2>&1) \
+    || fail "Login to speech-admin failed. Check SPEECH_ADMIN_USERNAME / SPEECH_ADMIN_PASSWORD."
+
+  TOKEN=$(printf '%s' "$LOGIN_RESP" | grep -o '"token":"[^"]*"' | cut -d'"' -f4)
+  [ -n "$TOKEN" ] || fail "Could not extract auth token from: $LOGIN_RESP"
+
+  # Try to reuse an existing 'octo-docker' app to stay idempotent
+  LIST_RESP=$(curl -sf "${BASE_URL}/api/apps" \
+    -H "Authorization: Bearer ${TOKEN}" 2>/dev/null || true)
+  EXISTING_KEY=$(printf '%s' "$LIST_RESP" | grep -o '"app_name":"octo-docker"[^}]*"api_key":"[^"]*"' \
+    | grep -o '"api_key":"[^"]*"' | cut -d'"' -f4 || true)
+
+  if [ -n "$EXISTING_KEY" ]; then
+    SPEECH_API_KEY="$EXISTING_KEY"
+    ok "Reusing existing 'octo-docker' app key: ${SPEECH_API_KEY:0:12}..."
+  else
+    APP_RESP=$(curl -sf -X POST "${BASE_URL}/api/apps" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${TOKEN}" \
+      -d '{"app_name":"octo-docker"}' 2>&1) \
+      || fail "Failed to create speech API key: $APP_RESP"
+    SPEECH_API_KEY=$(printf '%s' "$APP_RESP" | grep -o '"api_key":"[^"]*"' | cut -d'"' -f4)
+    [ -n "$SPEECH_API_KEY" ] || fail "Could not extract API key from: $APP_RESP"
+    ok "API key created: ${SPEECH_API_KEY:0:12}..."
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: write key + service URL into .env
+# ---------------------------------------------------------------------------
+if [ "$FROM_STEP" -le 4 ]; then
+  log 4 "Write SPEECH_API_KEY and SPEECH_SERVICE_URL into docker/.env"
+
+  # When resuming at step 4, load key from .env if not already set by step 3
+  : "${SPEECH_API_KEY:=$(env_get SPEECH_API_KEY)}"
+  [ -n "${SPEECH_API_KEY:-}" ] \
+    || fail "SPEECH_API_KEY is not set and could not be read from .env. Re-run from step 3."
+
+  persist_env "SPEECH_SERVICE_URL" "http://octo-speech:8780"
+  persist_env "SPEECH_API_KEY" "$SPEECH_API_KEY"
+  ok "docker/.env updated"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5: restart octo-server
+# ---------------------------------------------------------------------------
+if [ "$FROM_STEP" -le 5 ]; then
+  log 5 "Restart octo-server to activate speech"
+  "${DC[@]}" up -d --no-deps octo-server
+  ok "octo-server restarted"
+fi
+
+printf '\n\033[32m[DONE]\033[0m Speech profile is live.\n'
+printf '  Admin console : %s/\n' "$BASE_URL"


### PR DESCRIPTION
## Summary

Add voice transcription as an opt-in Docker Compose profile (`speech`). Two new services — `octo-speech` (transcription API) and `octo-speech-admin` (API-key console) — are gated behind `profiles: ["speech"]` so a vanilla `docker compose up -d` is completely unaffected.

### What's included

- **docker-compose.yaml**: `octo-speech` + `octo-speech-admin` service definitions with health checks, least-privilege `speech` DB user, and two optional env vars on `octo-server` (`SPEECH_SERVICE_URL` / `SPEECH_API_KEY`, both empty-defaulted). `SPEECH_DB_PASSWORD` forwarded to the MySQL service for `init-extra-dbs.sh` provisioning.
- **scripts/speech-setup.sh**: Guided setup script (steps 0–5) that provisions the DB, starts speech services, obtains an API key via the admin console, and wires `octo-server`. Portable patterns throughout:
  - `awk + tmp` for `.env` rewriting (no `sed -i` flavor issues)
  - `MYSQL_PWD` via `docker compose exec -e` (credentials stay out of `ps`/`/proc`)
  - `curl -w '%{http_code}' != "000"` for health probes (correctly treats 401/422 from a healthy admin as "reachable")
  - `case`-based password validation against `[A-Za-z0-9._-]` allowlist
  - `|| fail "diagnostic"` on MySQL commands (no silent `2>/dev/null`)
  - `HTTP_PORT` defaults to `28080` (matches compose default)
- **scripts/init-extra-dbs.sh**: Creates `octo_speech` database unconditionally; conditionally provisions scoped `speech` DB user when `SPEECH_DB_PASSWORD` is set (with `validate_password` guard).
- **nginx/conf.d/octo.conf.template**: `/speech-admin/` location with variable `proxy_pass` for deferred DNS resolution, in both HTTP and commented-out HTTPS server blocks.
- **.env.example**: Documents all speech-related variables with generation instructions.

### Isolation guarantees

- No core service definition is touched beyond two optional env vars on `octo-server`, both empty-defaulted
- No new **required** env var — every variable has a `:-` default or is gated by the profile
- Reuses existing `octo-net` network and MySQL instance

## Test plan

- [ ] `docker compose up -d` with `COMPOSE_PROFILES` unset — verify no speech containers start
- [ ] Set `COMPOSE_PROFILES=speech`, run `speech-setup.sh` — verify all 6 steps complete
- [ ] `speech-setup.sh --from 3` — verify idempotent API key reuse
- [ ] Verify `/speech-admin/` accessible through nginx
- [ ] Verify octo-server voice transcription works end-to-end
- [ ] Fresh volume init: verify `init-extra-dbs.sh` creates `octo_speech` DB and `speech` user

🤖 Generated with [Claude Code](https://claude.com/claude-code)