### PR TITLE
feat(helm): add octo-fleet service as opt-in component

### DIFF
--- a/helm/octo/templates/_helpers.tpl
+++ b/helm/octo/templates/_helpers.tpl
@@ -137,6 +137,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s-speech-admin" (include "octo.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "octo.fleet.fullname" -}}
+{{- printf "%s-fleet" (include "octo.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 {{- define "octo.nginx.fullname" -}}
 {{- printf "%s-nginx" (include "octo.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
@@ -185,6 +189,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "octo.configMap.wukongim" -}}
 {{- printf "%s-wukongim-config" (include "octo.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "octo.configMap.fleet" -}}
+{{- printf "%s-fleet-config" (include "octo.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{- define "octo.speech.pvc" -}}

--- a/helm/octo/templates/configmap-fleet.yaml
+++ b/helm/octo/templates/configmap-fleet.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.fleet.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "octo.configMap.fleet" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fleet
+data:
+  fleet.yaml: |
+    mode: "release"
+    addr: ":{{ .Values.fleet.service.port }}"
+    appName: "octo-fleet"
+    rootDir: "fleetdata"
+    db:
+      # mysqlAddr is injected at runtime via the FLEET_DB_MYSQLADDR env var
+      # (see deployment-fleet.yaml). Keep the DSN password out of this ConfigMap.
+      redisAddr: "{{ include "octo.redis.host" . }}:{{ include "octo.redis.port" . }}"
+      redisPass: ""
+    external:
+      baseURL: {{ .Values.fleet.config.externalBaseURL | quote }}
+    auth:
+      # fleet calls octo-server /v1/auth/verify-* to authenticate callers.
+      octoServerURL: {{ .Values.fleet.config.octoServerURL | default (printf "http://%s:8090" (include "octo.server.fullname" .)) | quote }}
+    logger:
+      level: 1
+      dir: "/home/logs"
+      lineNum: false
+{{- end }}

--- a/helm/octo/templates/configmap-misc.yaml
+++ b/helm/octo/templates/configmap-misc.yaml
@@ -68,6 +68,9 @@ data:
     {{- if .Values.speech.enabled }}
     : "${OCTO_SPEECH_DB_PASSWORD:=speech}"
     {{- end }}
+    {{- if .Values.fleet.enabled }}
+    : "${OCTO_FLEET_DB_PASSWORD:=fleet}"
+    {{- end }}
     : "${MYSQL_DATABASE:=octo}"
 
     validate_password() {
@@ -76,8 +79,8 @@ data:
         echo "[init-extra-dbs] FATAL: $name is empty" >&2; exit 1
       fi
       case "$value" in
-        *[!A-Za-z0-9._-]*)
-          echo "[init-extra-dbs] FATAL: $name contains characters outside [A-Za-z0-9._-]" >&2; exit 1 ;;
+        *[!A-Za-z0-9._+=-]*)
+          echo "[init-extra-dbs] FATAL: $name contains characters outside [A-Za-z0-9._+=-]" >&2; exit 1 ;;
       esac
       local lc; lc=$(printf %s "$value" | tr 'A-Z' 'a-z')
       case "$lc" in
@@ -110,11 +113,17 @@ data:
     {{- if .Values.speech.enabled }}
     validate_password  OCTO_SPEECH_DB_PASSWORD       "$OCTO_SPEECH_DB_PASSWORD"
     {{- end }}
+    {{- if .Values.fleet.enabled }}
+    validate_password  OCTO_FLEET_DB_PASSWORD        "$OCTO_FLEET_DB_PASSWORD"
+    {{- end }}
     reject_literal_default OCTO_MATTER_DB_PASSWORD       "$OCTO_MATTER_DB_PASSWORD"      "matter"
     reject_literal_default OCTO_SUMMARY_DB_PASSWORD      "$OCTO_SUMMARY_DB_PASSWORD"     "summary"
     reject_literal_default OCTO_SUMMARY_READER_PASSWORD  "$OCTO_SUMMARY_READER_PASSWORD" "summary_reader"
     {{- if .Values.speech.enabled }}
     reject_literal_default OCTO_SPEECH_DB_PASSWORD       "$OCTO_SPEECH_DB_PASSWORD"      "speech"
+    {{- end }}
+    {{- if .Values.fleet.enabled }}
+    reject_literal_default OCTO_FLEET_DB_PASSWORD        "$OCTO_FLEET_DB_PASSWORD"       "fleet"
     {{- end }}
     validate_password  MYSQL_ROOT_PASSWORD            "$MYSQL_ROOT_PASSWORD"
     validate_identifier MYSQL_DATABASE               "$MYSQL_DATABASE"
@@ -124,6 +133,9 @@ data:
     CREATE DATABASE IF NOT EXISTS octo_summary CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
     {{- if .Values.speech.enabled }}
     CREATE DATABASE IF NOT EXISTS octo_speech  CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    {{- end }}
+    {{- if .Values.fleet.enabled }}
+    CREATE DATABASE IF NOT EXISTS octo_fleet  CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
     {{- end }}
 
     CREATE USER IF NOT EXISTS 'matter'@'%'  IDENTIFIED BY '${OCTO_MATTER_DB_PASSWORD}';
@@ -138,6 +150,11 @@ data:
     CREATE USER IF NOT EXISTS 'speech'@'%' IDENTIFIED BY '${OCTO_SPEECH_DB_PASSWORD}';
     ALTER USER IF EXISTS      'speech'@'%' IDENTIFIED BY '${OCTO_SPEECH_DB_PASSWORD}';
     {{- end }}
+    {{- if .Values.fleet.enabled }}
+
+    CREATE USER IF NOT EXISTS 'fleet'@'%' IDENTIFIED BY '${OCTO_FLEET_DB_PASSWORD}';
+    ALTER USER IF EXISTS      'fleet'@'%' IDENTIFIED BY '${OCTO_FLEET_DB_PASSWORD}';
+    {{- end }}
 
     GRANT ALL PRIVILEGES ON octo_matter.*       TO 'matter'@'%';
     GRANT ALL PRIVILEGES ON octo_summary.*      TO 'summary'@'%';
@@ -145,11 +162,18 @@ data:
     {{- if .Values.speech.enabled }}
     GRANT ALL PRIVILEGES ON octo_speech.*       TO 'speech'@'%';
     {{- end }}
+    {{- if .Values.fleet.enabled }}
+    GRANT ALL PRIVILEGES ON octo_fleet.*        TO 'fleet'@'%';
+    {{- end }}
     FLUSH PRIVILEGES;
     SQL
 
-    {{- if .Values.speech.enabled }}
+    {{- if and .Values.speech.enabled .Values.fleet.enabled }}
+    echo "[init-extra-dbs] created octo_matter + octo_summary + octo_speech + octo_fleet + service users"
+    {{- else if .Values.speech.enabled }}
     echo "[init-extra-dbs] created octo_matter + octo_summary + octo_speech + service users"
+    {{- else if .Values.fleet.enabled }}
+    echo "[init-extra-dbs] created octo_matter + octo_summary + octo_fleet + service users"
     {{- else }}
     echo "[init-extra-dbs] created octo_matter + octo_summary + service users"
     {{- end }}

--- a/helm/octo/templates/configmap-nginx.yaml
+++ b/helm/octo/templates/configmap-nginx.yaml
@@ -177,6 +177,19 @@ data:
         }
         {{- end }}
 
+        {{- if .Values.fleet.enabled }}
+        location /fleet/ {
+            limit_req zone=octo_api burst=20 nodelay;
+            rewrite ^/fleet/(.*) /$1 break;
+            proxy_pass         http://{{ include "octo.fleet.fullname" . }}:{{ .Values.fleet.service.port }};
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+        }
+        {{- end }}
+
         location = /_octo_up {
             default_type text/html;
             return 200 "OCTO Server is up. Visit /admin/ for the admin console.";

--- a/helm/octo/templates/deployment-fleet.yaml
+++ b/helm/octo/templates/deployment-fleet.yaml
@@ -1,0 +1,133 @@
+{{- if .Values.fleet.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octo.fleet.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fleet
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.fleet.service.port }}
+      targetPort: http
+  selector:
+    {{- include "octo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: fleet
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "octo.fleet.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fleet
+spec:
+  replicas: {{ .Values.fleet.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: fleet
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-fleet.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: fleet
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      initContainers:
+        - name: wait-for-mysql
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command: ['sh', '-c', 'until nc -z {{ include "octo.mysql.host" . }} {{ include "octo.mysql.port" . }}; do echo waiting for mysql; sleep 2; done']
+        - name: wait-for-redis
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command: ['sh', '-c', 'until nc -z {{ include "octo.redis.host" . }} {{ include "octo.redis.port" . }}; do echo waiting for redis; sleep 2; done']
+        - name: init-fleet-db
+          image: {{ include "octo.image" (dict "repo" .Values.mysql.image.repository "tag" .Values.mysql.image.tag "ctx" .) }}
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: MYSQL_ROOT_PASSWORD
+            - name: FLEET_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: FLEET_DB_PASSWORD
+          command:
+            - sh
+            - -c
+            - >
+              until mysql -h {{ include "octo.mysql.host" . }} -P {{ include "octo.mysql.port" . }} -u root -p"${MYSQL_ROOT_PASSWORD}" -e "SELECT 1" >/dev/null 2>&1; do
+                echo "waiting for mysql..."; sleep 2;
+              done;
+              echo "CREATE DATABASE IF NOT EXISTS {{ .Values.fleet.database.name }} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+              CREATE USER IF NOT EXISTS 'fleet'@'%' IDENTIFIED BY '${FLEET_DB_PASSWORD}';
+              ALTER USER IF EXISTS 'fleet'@'%' IDENTIFIED BY '${FLEET_DB_PASSWORD}';
+              GRANT ALL PRIVILEGES ON {{ .Values.fleet.database.name }}.* TO 'fleet'@'%';
+              FLUSH PRIVILEGES;" |
+              mysql -h {{ include "octo.mysql.host" . }} -P {{ include "octo.mysql.port" . }} -u root -p"${MYSQL_ROOT_PASSWORD}" &&
+              echo "fleet database ready."
+      containers:
+        - name: octo-fleet
+          image: {{ include "octo.image" (dict "repo" .Values.fleet.image.repository "tag" .Values.fleet.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.fleet.image.pullPolicy }}
+          args: ["--config", "/home/configs/fleet.yaml"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.fleet.service.port }}
+          env:
+            - name: TZ
+              value: {{ .Values.timezone | default "UTC" | quote }}
+            - name: FLEET_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: FLEET_DB_PASSWORD
+            - name: FLEET_DB_MYSQLADDR
+              value: "fleet:$(FLEET_DB_PASSWORD)@tcp({{ include "octo.mysql.host" . }}:{{ include "octo.mysql.port" . }})/{{ .Values.fleet.database.name }}?charset=utf8mb4&parseTime=true"
+            {{- if .Values.secrets.redisPassword }}
+            - name: FLEET_DB_REDISPASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: REDIS_PASSWORD
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /v1/ping
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /v1/ping
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 3
+          volumeMounts:
+            - name: config
+              mountPath: /home/configs/fleet.yaml
+              subPath: fleet.yaml
+            - name: logs
+              mountPath: /home/logs
+          {{- with .Values.fleet.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "octo.configMap.fleet" . }}
+        - name: logs
+          emptyDir: {}
+{{- end }}

--- a/helm/octo/templates/deployment-speech.yaml
+++ b/helm/octo/templates/deployment-speech.yaml
@@ -72,6 +72,33 @@ spec:
         - name: wait-for-mysql
           image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
           command: ['sh', '-c', 'until nc -z {{ include "octo.mysql.host" . }} {{ include "octo.mysql.port" . }}; do echo waiting for mysql; sleep 2; done']
+        - name: init-speech-db
+          image: {{ include "octo.image" (dict "repo" .Values.mysql.image.repository "tag" .Values.mysql.image.tag "ctx" .) }}
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: MYSQL_ROOT_PASSWORD
+            - name: SPEECH_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: SPEECH_DB_PASSWORD
+          command:
+            - sh
+            - -c
+            - >
+              until mysql -h {{ include "octo.mysql.host" . }} -P {{ include "octo.mysql.port" . }} -u root -p"${MYSQL_ROOT_PASSWORD}" -e "SELECT 1" >/dev/null 2>&1; do
+                echo "waiting for mysql..."; sleep 2;
+              done;
+              echo "CREATE DATABASE IF NOT EXISTS octo_speech CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+              CREATE USER IF NOT EXISTS 'speech'@'%' IDENTIFIED BY '${SPEECH_DB_PASSWORD}';
+              ALTER USER IF EXISTS 'speech'@'%' IDENTIFIED BY '${SPEECH_DB_PASSWORD}';
+              GRANT ALL PRIVILEGES ON octo_speech.* TO 'speech'@'%';
+              FLUSH PRIVILEGES;" |
+              mysql -h {{ include "octo.mysql.host" . }} -P {{ include "octo.mysql.port" . }} -u root -p"${MYSQL_ROOT_PASSWORD}" &&
+              echo "speech database ready."
       containers:
         - name: octo-speech
           image: {{ include "octo.image" (dict "repo" .Values.speech.image.repository "tag" .Values.speech.image.tag "ctx" .) }}

--- a/helm/octo/templates/secret.yaml
+++ b/helm/octo/templates/secret.yaml
@@ -46,6 +46,9 @@ data:
   SPEECH_ADMIN_PASSWORD:        {{ required "secrets.speechAdminPassword must be set when speech.enabled=true" .Values.secrets.speechAdminPassword | b64enc | quote }}
   SPEECH_ADMIN_JWT_SECRET:      {{ required "secrets.speechAdminJwtSecret must be set when speech.enabled=true" .Values.secrets.speechAdminJwtSecret | b64enc | quote }}
   {{- end }}
+  {{- if .Values.fleet.enabled }}
+  FLEET_DB_PASSWORD:            {{ required "secrets.fleetDbPassword must be set when fleet.enabled=true" .Values.secrets.fleetDbPassword | b64enc | quote }}
+  {{- end }}
   {{- if .Values.secrets.redisPassword }}
   REDIS_PASSWORD:               {{ .Values.secrets.redisPassword | b64enc | quote }}
   {{- end }}

--- a/helm/octo/templates/statefulset-mysql.yaml
+++ b/helm/octo/templates/statefulset-mysql.yaml
@@ -82,6 +82,13 @@ spec:
                   name: {{ include "octo.secretName" . }}
                   key: SPEECH_DB_PASSWORD
             {{- end }}
+            {{- if .Values.fleet.enabled }}
+            - name: OCTO_FLEET_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: FLEET_DB_PASSWORD
+            {{- end }}
           readinessProbe:
             exec:
               command:

--- a/helm/octo/values-china.yaml
+++ b/helm/octo/values-china.yaml
@@ -40,3 +40,7 @@ summary:
   worker:
     image:
       repository: tsh8-deepminer-tcr1.tencentcloudcr.com/octo-oss/octo-smart-summary-worker
+
+fleet:
+  image:
+    repository: tsh8-deepminer-tcr1.tencentcloudcr.com/octo-oss/octo-fleet

--- a/helm/octo/values.yaml
+++ b/helm/octo/values.yaml
@@ -120,6 +120,9 @@ secrets:
   speechAdminPassword: ""
   speechAdminJwtSecret: ""
 
+  # Fleet DB password (required when fleet.enabled=true). Characters must be in [A-Za-z0-9._+=-].
+  fleetDbPassword: ""
+
   # Inbound webhook HMAC secret (optional).
   webhookSecretKey: ""
 
@@ -488,6 +491,32 @@ speech:
       repository: curlimages/curl
       tag: "8.10.1"
       pullPolicy: IfNotPresent
+
+# =============================================================================
+# Fleet (runtime & bot orchestration service)
+# =============================================================================
+fleet:
+  enabled: false
+  image:
+    repository: mininglamposs/octo-fleet
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  service:
+    port: 8092
+  config:
+    externalBaseURL: ""
+    # octoServerURL defaults internally to http://<octo-server>:8090; override only if needed.
+    octoServerURL: ""
+  database:
+    name: octo_fleet
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "2"
+      memory: 1Gi
 
 # =============================================================================
 # Search pipeline (Kafka + OpenSearch[analysis-ik] + es-indexer) — OPT-IN.


### PR DESCRIPTION
## Summary

Add octo-fleet (runtime & bot orchestration service, split from octo-server) as an opt-in component to the Helm chart, default off (`fleet.enabled=false`). Also patches speech with an `init-speech-db` initContainer to close the same existing-cluster opt-in gap.

- **values.yaml**: new `fleet:` section (`enabled: false`, `image: latest`, port 8092, resources aligned with speech) + `secrets.fleetDbPassword`
- **values-china.yaml**: TCR image override for fleet
- **_helpers.tpl**: `octo.fleet.fullname` + `octo.configMap.fleet` helpers
- **secret.yaml**: `FLEET_DB_PASSWORD` gated by `fleet.enabled` (required + b64enc)
- **configmap-fleet.yaml** (new): renders `fleet.yaml` (redis addr, `auth.octoServerURL` defaulting to `http://octo-server:8090`, logger); MySQL DSN injected via `FLEET_DB_MYSQLADDR` env at runtime
- **configmap-misc.yaml**: `init-extra-dbs.sh` gains `fleet.enabled` gate for fresh installs (CREATE DATABASE/USER/GRANT for `octo_fleet`)
- **statefulset-mysql.yaml**: passes `OCTO_FLEET_DB_PASSWORD` to `init-extra-dbs.sh`
- **deployment-fleet.yaml** (new): ClusterIP Service + Deployment with wait-for-mysql/wait-for-redis/init-fleet-db initContainers, /v1/ping probes, config + logs volumes
- **configmap-nginx.yaml**: `/fleet/` location block (`fleet.enabled` gated) with rewrite + proxy_pass to fleet service
- **deployment-speech.yaml**: adds `init-speech-db` initContainer (idempotent DDL for existing-cluster opt-in, same pattern as fleet)

## Design notes

- Zero Helm hooks/Jobs; init containers cover both fresh install (`init-extra-dbs.sh` in MySQL docker-entrypoint-initdb.d) and existing-cluster opt-in (`init-fleet-db`/`init-speech-db` initContainers with idempotent DDL)
- Table migrations run automatically on first startup (octo-lib default `db.migration: true`, SQL files embedded in fleet binary)
- Fleet uses a dedicated `fleet` MySQL user with ALL PRIVILEGES on `octo_fleet.*` (not root); root credentials only used by init containers for DDL
- Fleet calls octo-server `/v1/auth/verify-*` for JWT auth (not JWKS); daemon onboarding URLs are auto-derived by octo-server from its own External.BaseURL (nginx `/fleet/` reverse proxy makes the endpoint reachable externally)
- Rollback: set `fleet.enabled=false` to remove fleet resources; server-side `LEGACY_RUNTIME_ROUTES=true` falls back to built-in runtime routes

## Verification

- `helm lint` (enabled/disabled both states)
- `helm template` + `kubectl apply --dry-run=client` (enabled/disabled both states, + values-china.yaml TCR)
- All config keys / env vars verified against octo-fleet source code and octo-lib config structs
- `/v1/ping` probe endpoint confirmed in octo-lib server.New()

Closes #155
