### PR TITLE
feat(docker): add docs profile (octo-docs-backend collaborative documents)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -488,6 +488,50 @@ LLM_MODEL=claude-sonnet-4-6
 # OCTO_SPEECH_IMAGE=mininglamposs/octo-speech:latest
 # OCTO_SPEECH_ADMIN_IMAGE=mininglamposs/octo-speech-admin:latest
 
+# --- Docs pipeline (only used when COMPOSE_PROFILES includes "docs") ---
+# Real-time collaborative document backend (Hocuspocus + Yjs).
+# Enable with COMPOSE_PROFILES=docs (combine profiles with a comma, e.g.
+# COMPOSE_PROFILES=summary,docs).
+#
+# Do NOT add "docs" to COMPOSE_PROFILES without first setting ALL the required
+# credentials below. Missing OCTO_DOCS_DB_PASSWORD causes a startup failure;
+# missing OCTO_DOCS_COLLAB_SECRET or OCTO_DOCS_ATTACHMENT_SECRET causes the
+# service to boot in an insecure state.
+#
+# Generate secrets with: openssl rand -hex 32
+# Generate passwords with: openssl rand -hex 16
+
+# Scoped MySQL user for octo_docs database (allowlist: [A-Za-z0-9._-])
+# OCTO_DOCS_DB_PASSWORD=<openssl rand -hex 16>
+
+# JWT signing secret for short-lived Hocuspocus collab tokens (min 32 chars)
+# OCTO_DOCS_COLLAB_SECRET=<openssl rand -hex 32>
+
+# HMAC signing secret for attachment presigned URLs (min 32 chars)
+# OCTO_DOCS_ATTACHMENT_SECRET=<openssl rand -hex 32>
+
+# Public, browser-reachable WebSocket URL for the Hocuspocus collab WS.
+# nginx reverse-proxies /docs-ws/ → :1234 so the URL uses the same
+# host/port as the main HTTP listener. Set this to the IP/domain your
+# users' browsers can reach. Example:
+# OCTO_DOCS_COLLAB_WS_URL=ws://10.201.0.101:28080/docs-ws/
+
+# Public web origin (the URL users open octo-web from). Used to build
+# shareable doc links returned to callers. Example:
+# OCTO_DOCS_WEB_ORIGIN=http://10.201.0.101:28080
+
+# S3-compatible endpoint for attachment storage (MinIO). Must be the
+# public, browser-reachable URL so the browser can PUT/GET attachments
+# directly via presigned URLs. Example:
+# OCTO_DOCS_S3_ENDPOINT=http://10.201.0.101:28080
+
+# CORS allowed origins for the docs REST API (comma-separated exact origins,
+# or * to allow all). Must include the origin octo-web is served from.
+# OCTO_DOCS_CORS_ORIGINS=http://10.201.0.101:28080
+
+# Docs image override (only used with COMPOSE_PROFILES=docs):
+# OCTO_DOCS_IMAGE=hub2.intra.mlamp.cn/octo/octo-docs-backend:0.2.0
+
 # --- Search pipeline (only used when COMPOSE_PROFILES includes "search") ---
 # Host ports for local validation; loopback-bound by default so they never
 # collide with or expose anything on a shared host. Override the *_BIND vars

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -529,6 +529,11 @@ LLM_MODEL=claude-sonnet-4-6
 # or * to allow all). Must include the origin octo-web is served from.
 # OCTO_DOCS_CORS_ORIGINS=http://10.201.0.101:28080
 
+# In-network URL octo-server uses to call the docs REST API for server-side
+# operations (e.g. permission checks). This is a container-network address,
+# not the public URL. Example:
+# OCTO_DOCS_SERVICE_URL=http://octo-docs-backend:3000
+
 # Docs image override (only used with COMPOSE_PROFILES=docs):
 # OCTO_DOCS_IMAGE=hub2.intra.mlamp.cn/octo/octo-docs-backend:0.2.0
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -494,9 +494,8 @@ LLM_MODEL=claude-sonnet-4-6
 # COMPOSE_PROFILES=summary,docs).
 #
 # Do NOT add "docs" to COMPOSE_PROFILES without first setting ALL the required
-# credentials below. Missing OCTO_DOCS_DB_PASSWORD causes a startup failure;
-# missing OCTO_DOCS_COLLAB_SECRET or OCTO_DOCS_ATTACHMENT_SECRET causes the
-# service to boot in an insecure state.
+# credentials below. Missing docs settings now fail fast in the docs-preflight
+# service; empty signing secrets are never accepted for a docs deployment.
 #
 # Generate secrets with: openssl rand -hex 32
 # Generate passwords with: openssl rand -hex 16
@@ -529,13 +528,13 @@ LLM_MODEL=claude-sonnet-4-6
 # or * to allow all). Must include the origin octo-web is served from.
 # OCTO_DOCS_CORS_ORIGINS=http://10.201.0.101:28080
 
-# In-network URL octo-server uses to call the docs REST API for server-side
-# operations (e.g. permission checks). This is a container-network address,
-# not the public URL. Example:
-# OCTO_DOCS_SERVICE_URL=http://octo-docs-backend:3000
+# Shared secret between octo-server and octo-docs-backend for server→docs
+# notification calls (approval cards, document events). Optional; leave
+# unset if you don't need server-initiated doc notifications.
+# OCTO_DOCS_NOTIFY_TOKEN=<openssl rand -hex 32>
 
 # Docs image override (only used with COMPOSE_PROFILES=docs):
-# OCTO_DOCS_IMAGE=hub2.intra.mlamp.cn/octo/octo-docs-backend:0.2.0
+# OCTO_DOCS_IMAGE=mininglamposs/octo-docs-backend:latest
 
 # --- Search pipeline (only used when COMPOSE_PROFILES includes "search") ---
 # Host ports for local validation; loopback-bound by default so they never

--- a/docker/README.md
+++ b/docker/README.md
@@ -1259,9 +1259,11 @@ details on each.
 
 ```bash
 cd docker
-# Add "docs" to the existing COMPOSE_PROFILES (never overwrite the whole line)
+# Add "docs" to the existing COMPOSE_PROFILES (guard against double-append)
 existing="$(grep -E '^COMPOSE_PROFILES=' .env | tail -1 | cut -d= -f2-)"
-sed -i "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=${existing:+$existing,}docs|" .env
+if ! echo "$existing" | grep -qw "docs"; then
+  sed -i "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=${existing:+$existing,}docs|" .env
+fi
 
 docker compose --profile docs up -d octo-docs-backend
 docker compose up -d --force-recreate nginx
@@ -1269,13 +1271,27 @@ docker compose up -d --force-recreate nginx
 
 ### Database and MinIO setup
 
-The `octo_docs` schema is created automatically by `init-extra-dbs.sh` the
-first time the `mysql` container starts (same mechanism as `octo_matter` and
-`octo_summary`). The `docs` MySQL user is provisioned when
-`OCTO_DOCS_DB_PASSWORD` is non-empty.
+`init-extra-dbs.sh` runs only on the **first** MySQL volume init, so on a
+fresh deployment `octo_docs` and the `docs` user are created automatically.
+
+**On an existing cluster** (the common opt-in-later path) you must create them
+manually against the live MySQL container. Set `OCTO_DOCS_DB_PASSWORD` in
+`.env` first, then run:
+
+```bash
+DOCS_PASS="$(grep -E '^OCTO_DOCS_DB_PASSWORD=' docker/.env | cut -d= -f2-)"
+docker exec -i octo-mysql-1 \
+  mysql -uroot -p"$(grep -E '^MYSQL_ROOT_PASSWORD=' docker/.env | cut -d= -f2-)" <<SQL
+CREATE DATABASE IF NOT EXISTS octo_docs CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+CREATE USER IF NOT EXISTS 'docs'@'%' IDENTIFIED BY '${DOCS_PASS}';
+ALTER USER IF EXISTS      'docs'@'%' IDENTIFIED BY '${DOCS_PASS}';
+GRANT ALL PRIVILEGES ON octo_docs.* TO 'docs'@'%';
+FLUSH PRIVILEGES;
+SQL
+```
 
 `octo-docs-backend` runs its own schema migrations on boot — no manual SQL
-import is needed.
+import is needed beyond the above.
 
 The `octo-docs-attachments` MinIO bucket is created automatically by
 `minio-init` when `OCTO_DOCS_DB_PASSWORD` is non-empty. If `minio-init`

--- a/docker/README.md
+++ b/docker/README.md
@@ -1228,6 +1228,92 @@ See `.env.example` for details.
 
 ---
 
+## Docs profile (collaborative documents)
+
+The collaborative document backend — `octo-docs-backend` (Hocuspocus + Yjs
+real-time sync) — is **opt-in** behind the Docker Compose `docs` profile:
+
+- A default `docker compose up -d` starts **zero** docs services.
+- Every docs variable in `.env` has an empty default, so a non-docs deployment
+  never fails preflight on a missing docs variable.
+- nginx proxies both REST (`/docs-api/` → port 3000) and WebSocket
+  (`/docs-ws/` → port 1234) — no extra host port is required.
+
+### Prerequisites
+
+Before adding `docs` to `COMPOSE_PROFILES`, set the four required secrets in
+`docker/.env`:
+
+| Variable | Purpose | Generate with |
+|---|---|---|
+| `OCTO_DOCS_DB_PASSWORD` | MySQL scoped user for `octo_docs` | `openssl rand -hex 16` |
+| `OCTO_DOCS_COLLAB_SECRET` | JWT signing secret for Hocuspocus collab tokens (≥32 chars) | `openssl rand -hex 32` |
+| `OCTO_DOCS_ATTACHMENT_SECRET` | HMAC signing secret for attachment presigned URLs (≥32 chars) | `openssl rand -hex 32` |
+| `OCTO_DOCS_COLLAB_WS_URL` | Browser-reachable WebSocket URL, e.g. `ws://10.201.0.101:28080/docs-ws/` | set manually |
+
+Also set `OCTO_DOCS_WEB_ORIGIN`, `OCTO_DOCS_S3_ENDPOINT`, and
+`OCTO_DOCS_CORS_ORIGINS` to match your deployment URL. See `.env.example` for
+details on each.
+
+### Bring the docs profile up
+
+```bash
+cd docker
+# Add "docs" to the existing COMPOSE_PROFILES (never overwrite the whole line)
+existing="$(grep -E '^COMPOSE_PROFILES=' .env | tail -1 | cut -d= -f2-)"
+sed -i "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=${existing:+$existing,}docs|" .env
+
+docker compose --profile docs up -d octo-docs-backend
+docker compose up -d --force-recreate nginx
+```
+
+### Database and MinIO setup
+
+The `octo_docs` schema is created automatically by `init-extra-dbs.sh` the
+first time the `mysql` container starts (same mechanism as `octo_matter` and
+`octo_summary`). The `docs` MySQL user is provisioned when
+`OCTO_DOCS_DB_PASSWORD` is non-empty.
+
+`octo-docs-backend` runs its own schema migrations on boot — no manual SQL
+import is needed.
+
+The `octo-docs-attachments` MinIO bucket is created automatically by
+`minio-init` when `OCTO_DOCS_DB_PASSWORD` is non-empty. If `minio-init`
+already ran before you added docs, re-run it:
+
+```bash
+docker compose up --force-recreate minio-init
+```
+
+### Enable the docs feature flag in octo-server
+
+The docs module is gated by a `system_setting` row. Insert it once after
+`octo-server` is running:
+
+```bash
+docker exec -i octo-mysql-1 \
+  mysql -uroot -p"$(grep MYSQL_ROOT_PASSWORD docker/.env | cut -d= -f2-)" octo <<'SQL'
+INSERT INTO system_setting (category, key_name, value, value_type, description)
+VALUES ('docs', 'enabled', '1', 'bool', 'Enable docs module in octo-web')
+ON DUPLICATE KEY UPDATE value = '1';
+SQL
+
+docker compose restart octo-server
+```
+
+### Verify
+
+```bash
+# REST health
+curl http://127.0.0.1:28080/docs-api/healthz
+# → {"ok":true}
+
+# Service status
+docker compose ps octo-docs-backend
+```
+
+---
+
 ## Search profile (message-search pipeline)
 
 The message-search pipeline — Kafka + OpenSearch (with the `analysis-ik`

--- a/docker/README.md
+++ b/docker/README.md
@@ -1250,6 +1250,7 @@ Before adding `docs` to `COMPOSE_PROFILES`, set the four required secrets in
 | `OCTO_DOCS_COLLAB_SECRET` | JWT signing secret for Hocuspocus collab tokens (≥32 chars) | `openssl rand -hex 32` |
 | `OCTO_DOCS_ATTACHMENT_SECRET` | HMAC signing secret for attachment presigned URLs (≥32 chars) | `openssl rand -hex 32` |
 | `OCTO_DOCS_COLLAB_WS_URL` | Browser-reachable WebSocket URL, e.g. `ws://10.201.0.101:28080/docs-ws/` | set manually |
+| `OCTO_DOCS_SERVICE_URL` | Internal URL octo-server uses to call docs REST API | `http://octo-docs-backend:3000` |
 
 Also set `OCTO_DOCS_WEB_ORIGIN`, `OCTO_DOCS_S3_ENDPOINT`, and
 `OCTO_DOCS_CORS_ORIGINS` to match your deployment URL. See `.env.example` for

--- a/docker/README.md
+++ b/docker/README.md
@@ -1241,7 +1241,7 @@ real-time sync) — is **opt-in** behind the Docker Compose `docs` profile:
 
 ### Prerequisites
 
-Before adding `docs` to `COMPOSE_PROFILES`, set the four required secrets in
+Before adding `docs` to `COMPOSE_PROFILES`, set the required docs settings in
 `docker/.env`:
 
 | Variable | Purpose | Generate with |
@@ -1250,7 +1250,6 @@ Before adding `docs` to `COMPOSE_PROFILES`, set the four required secrets in
 | `OCTO_DOCS_COLLAB_SECRET` | JWT signing secret for Hocuspocus collab tokens (≥32 chars) | `openssl rand -hex 32` |
 | `OCTO_DOCS_ATTACHMENT_SECRET` | HMAC signing secret for attachment presigned URLs (≥32 chars) | `openssl rand -hex 32` |
 | `OCTO_DOCS_COLLAB_WS_URL` | Browser-reachable WebSocket URL, e.g. `ws://10.201.0.101:28080/docs-ws/` | set manually |
-| `OCTO_DOCS_SERVICE_URL` | Internal URL octo-server uses to call docs REST API | `http://octo-docs-backend:3000` |
 
 Also set `OCTO_DOCS_WEB_ORIGIN`, `OCTO_DOCS_S3_ENDPOINT`, and
 `OCTO_DOCS_CORS_ORIGINS` to match your deployment URL. See `.env.example` for
@@ -1263,7 +1262,11 @@ cd docker
 # Add "docs" to the existing COMPOSE_PROFILES (guard against double-append)
 existing="$(grep -E '^COMPOSE_PROFILES=' .env | tail -1 | cut -d= -f2-)"
 if ! echo "$existing" | grep -qw "docs"; then
-  sed -i "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=${existing:+$existing,}docs|" .env
+  if [ -n "$existing" ]; then
+    sed -i "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=${existing},docs|" .env
+  else
+    echo "COMPOSE_PROFILES=docs" >> .env
+  fi
 fi
 
 docker compose --profile docs up -d octo-docs-backend
@@ -1280,9 +1283,9 @@ manually against the live MySQL container. Set `OCTO_DOCS_DB_PASSWORD` in
 `.env` first, then run:
 
 ```bash
-DOCS_PASS="$(grep -E '^OCTO_DOCS_DB_PASSWORD=' docker/.env | cut -d= -f2-)"
-docker exec -i octo-mysql-1 \
-  mysql -uroot -p"$(grep -E '^MYSQL_ROOT_PASSWORD=' docker/.env | cut -d= -f2-)" <<SQL
+DOCS_PASS="$(grep -E '^OCTO_DOCS_DB_PASSWORD=' .env | cut -d= -f2-)"
+docker compose exec -T mysql \
+  mysql -uroot -p"$(grep -E '^MYSQL_ROOT_PASSWORD=' .env | cut -d= -f2-)" <<SQL
 CREATE DATABASE IF NOT EXISTS octo_docs CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 CREATE USER IF NOT EXISTS 'docs'@'%' IDENTIFIED BY '${DOCS_PASS}';
 ALTER USER IF EXISTS      'docs'@'%' IDENTIFIED BY '${DOCS_PASS}';
@@ -1308,8 +1311,8 @@ The docs module is gated by a `system_setting` row. Insert it once after
 `octo-server` is running:
 
 ```bash
-docker exec -i octo-mysql-1 \
-  mysql -uroot -p"$(grep MYSQL_ROOT_PASSWORD docker/.env | cut -d= -f2-)" octo <<'SQL'
+docker compose exec -T mysql \
+  mysql -uroot -p"$(grep MYSQL_ROOT_PASSWORD .env | cut -d= -f2-)" octo <<'SQL'
 INSERT INTO system_setting (category, key_name, value, value_type, description)
 VALUES ('docs', 'enabled', '1', 'bool', 'Enable docs module in octo-web')
 ON DUPLICATE KEY UPDATE value = '1';

--- a/docker/README.zh.md
+++ b/docker/README.zh.md
@@ -864,6 +864,85 @@ scripts/speech-setup.sh --from 3   # 从步骤 3 恢复（0..5）
 
 ---
 
+## Docs profile（协同文档）
+
+协同文档后端 — `octo-docs-backend`（Hocuspocus + Yjs 实时同步）— 通过 Docker
+Compose 的 `docs` profile **按需启用**：
+
+- 默认 `docker compose up -d` **不会**启动任何文档服务。
+- 所有文档相关环境变量均有空默认值，非文档部署不会因缺少变量而 preflight 失败。
+- nginx 同时代理 REST（`/docs-api/` → port 3000）和 WebSocket（`/docs-ws/` →
+  port 1234）——无需额外主机端口。
+
+### 前置条件
+
+在将 `docs` 加入 `COMPOSE_PROFILES` 之前，先在 `docker/.env` 中设置四个必填密钥：
+
+| 变量 | 用途 | 生成方式 |
+|---|---|---|
+| `OCTO_DOCS_DB_PASSWORD` | `octo_docs` 数据库专属 MySQL 用户密码 | `openssl rand -hex 16` |
+| `OCTO_DOCS_COLLAB_SECRET` | Hocuspocus collab token 的 JWT 签名密钥（≥32 字符） | `openssl rand -hex 32` |
+| `OCTO_DOCS_ATTACHMENT_SECRET` | 附件预签名 URL 的 HMAC 签名密钥（≥32 字符） | `openssl rand -hex 32` |
+| `OCTO_DOCS_COLLAB_WS_URL` | 浏览器可访问的 WebSocket URL，例如 `ws://10.201.0.101:28080/docs-ws/` | 手动填写 |
+
+同时将 `OCTO_DOCS_WEB_ORIGIN`、`OCTO_DOCS_S3_ENDPOINT`、`OCTO_DOCS_CORS_ORIGINS`
+设置为与你的部署 URL 一致。详见 `.env.example`。
+
+### 启动 docs profile
+
+```bash
+cd docker
+# 将 "docs" 并入已有的 COMPOSE_PROFILES（绝不要覆盖整行）
+existing="$(grep -E '^COMPOSE_PROFILES=' .env | tail -1 | cut -d= -f2-)"
+sed -i "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=${existing:+$existing,}docs|" .env
+
+docker compose --profile docs up -d octo-docs-backend
+docker compose up -d --force-recreate nginx
+```
+
+### 数据库与 MinIO
+
+`octo_docs` schema 由 `init-extra-dbs.sh` 在 `mysql` 容器**首次启动时**自动创建
+（与 `octo_matter`、`octo_summary` 机制相同）。`OCTO_DOCS_DB_PASSWORD` 非空时自动
+创建 `docs` MySQL 用户。
+
+`octo-docs-backend` 启动时会自行运行 schema migration——无需手动导入 SQL。
+
+`octo-docs-attachments` MinIO bucket 由 `minio-init` 在 `OCTO_DOCS_DB_PASSWORD`
+非空时自动创建。若 `minio-init` 已在你添加 docs 之前运行过，重跑一次即可：
+
+```bash
+docker compose up --force-recreate minio-init
+```
+
+### 开启 octo-server 中的文档功能开关
+
+文档模块受 `system_setting` 表控制。`octo-server` 启动后执行一次：
+
+```bash
+docker exec -i octo-mysql-1 \
+  mysql -uroot -p"$(grep MYSQL_ROOT_PASSWORD docker/.env | cut -d= -f2-)" octo <<'SQL'
+INSERT INTO system_setting (category, key_name, value, value_type, description)
+VALUES ('docs', 'enabled', '1', 'bool', 'Enable docs module in octo-web')
+ON DUPLICATE KEY UPDATE value = '1';
+SQL
+
+docker compose restart octo-server
+```
+
+### 验证
+
+```bash
+# REST 健康检查
+curl http://127.0.0.1:28080/docs-api/healthz
+# → {"ok":true}
+
+# 服务状态
+docker compose ps octo-docs-backend
+```
+
+---
+
 ## Search profile（消息搜索流水线）
 
 消息搜索流水线——Kafka + OpenSearch（带 `analysis-ik` 中文分词器）+ `es-indexer` 消费者——通过 Docker Compose 的 `search` profile **按需开启（opt-in）**，和 smart-summary 的 `summary` profile 完全一样。不设 profile 时它完全惰性、零副作用：

--- a/docker/README.zh.md
+++ b/docker/README.zh.md
@@ -892,9 +892,11 @@ Compose 的 `docs` profile **按需启用**：
 
 ```bash
 cd docker
-# 将 "docs" 并入已有的 COMPOSE_PROFILES（绝不要覆盖整行）
+# 将 "docs" 并入已有的 COMPOSE_PROFILES（防止重复追加）
 existing="$(grep -E '^COMPOSE_PROFILES=' .env | tail -1 | cut -d= -f2-)"
-sed -i "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=${existing:+$existing,}docs|" .env
+if ! echo "$existing" | grep -qw "docs"; then
+  sed -i "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=${existing:+$existing,}docs|" .env
+fi
 
 docker compose --profile docs up -d octo-docs-backend
 docker compose up -d --force-recreate nginx
@@ -902,9 +904,23 @@ docker compose up -d --force-recreate nginx
 
 ### 数据库与 MinIO
 
-`octo_docs` schema 由 `init-extra-dbs.sh` 在 `mysql` 容器**首次启动时**自动创建
-（与 `octo_matter`、`octo_summary` 机制相同）。`OCTO_DOCS_DB_PASSWORD` 非空时自动
-创建 `docs` MySQL 用户。
+`init-extra-dbs.sh` 只在 MySQL volume **首次初始化**时运行，因此全新部署时
+`octo_docs` 和 `docs` 用户会自动创建。
+
+**在已运行的集群上**（大多数按需启用的场景）需要手动对在线 MySQL 执行。先在 `.env`
+中设好 `OCTO_DOCS_DB_PASSWORD`，然后运行：
+
+```bash
+DOCS_PASS="$(grep -E '^OCTO_DOCS_DB_PASSWORD=' docker/.env | cut -d= -f2-)"
+docker exec -i octo-mysql-1 \
+  mysql -uroot -p"$(grep -E '^MYSQL_ROOT_PASSWORD=' docker/.env | cut -d= -f2-)" <<SQL
+CREATE DATABASE IF NOT EXISTS octo_docs CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+CREATE USER IF NOT EXISTS 'docs'@'%' IDENTIFIED BY '${DOCS_PASS}';
+ALTER USER IF EXISTS      'docs'@'%' IDENTIFIED BY '${DOCS_PASS}';
+GRANT ALL PRIVILEGES ON octo_docs.* TO 'docs'@'%';
+FLUSH PRIVILEGES;
+SQL
+```
 
 `octo-docs-backend` 启动时会自行运行 schema migration——无需手动导入 SQL。
 

--- a/docker/README.zh.md
+++ b/docker/README.zh.md
@@ -876,7 +876,7 @@ Compose 的 `docs` profile **按需启用**：
 
 ### 前置条件
 
-在将 `docs` 加入 `COMPOSE_PROFILES` 之前，先在 `docker/.env` 中设置四个必填密钥：
+在将 `docs` 加入 `COMPOSE_PROFILES` 之前，先在 `docker/.env` 中设置必填的 docs 配置：
 
 | 变量 | 用途 | 生成方式 |
 |---|---|---|
@@ -884,7 +884,6 @@ Compose 的 `docs` profile **按需启用**：
 | `OCTO_DOCS_COLLAB_SECRET` | Hocuspocus collab token 的 JWT 签名密钥（≥32 字符） | `openssl rand -hex 32` |
 | `OCTO_DOCS_ATTACHMENT_SECRET` | 附件预签名 URL 的 HMAC 签名密钥（≥32 字符） | `openssl rand -hex 32` |
 | `OCTO_DOCS_COLLAB_WS_URL` | 浏览器可访问的 WebSocket URL，例如 `ws://10.201.0.101:28080/docs-ws/` | 手动填写 |
-| `OCTO_DOCS_SERVICE_URL` | octo-server 调用 docs REST API 的内部地址 | `http://octo-docs-backend:3000` |
 
 同时将 `OCTO_DOCS_WEB_ORIGIN`、`OCTO_DOCS_S3_ENDPOINT`、`OCTO_DOCS_CORS_ORIGINS`
 设置为与你的部署 URL 一致。详见 `.env.example`。
@@ -896,7 +895,11 @@ cd docker
 # 将 "docs" 并入已有的 COMPOSE_PROFILES（防止重复追加）
 existing="$(grep -E '^COMPOSE_PROFILES=' .env | tail -1 | cut -d= -f2-)"
 if ! echo "$existing" | grep -qw "docs"; then
-  sed -i "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=${existing:+$existing,}docs|" .env
+  if [ -n "$existing" ]; then
+    sed -i "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=${existing},docs|" .env
+  else
+    echo "COMPOSE_PROFILES=docs" >> .env
+  fi
 fi
 
 docker compose --profile docs up -d octo-docs-backend
@@ -912,9 +915,9 @@ docker compose up -d --force-recreate nginx
 中设好 `OCTO_DOCS_DB_PASSWORD`，然后运行：
 
 ```bash
-DOCS_PASS="$(grep -E '^OCTO_DOCS_DB_PASSWORD=' docker/.env | cut -d= -f2-)"
-docker exec -i octo-mysql-1 \
-  mysql -uroot -p"$(grep -E '^MYSQL_ROOT_PASSWORD=' docker/.env | cut -d= -f2-)" <<SQL
+DOCS_PASS="$(grep -E '^OCTO_DOCS_DB_PASSWORD=' .env | cut -d= -f2-)"
+docker compose exec -T mysql \
+  mysql -uroot -p"$(grep -E '^MYSQL_ROOT_PASSWORD=' .env | cut -d= -f2-)" <<SQL
 CREATE DATABASE IF NOT EXISTS octo_docs CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 CREATE USER IF NOT EXISTS 'docs'@'%' IDENTIFIED BY '${DOCS_PASS}';
 ALTER USER IF EXISTS      'docs'@'%' IDENTIFIED BY '${DOCS_PASS}';
@@ -937,8 +940,8 @@ docker compose up --force-recreate minio-init
 文档模块受 `system_setting` 表控制。`octo-server` 启动后执行一次：
 
 ```bash
-docker exec -i octo-mysql-1 \
-  mysql -uroot -p"$(grep MYSQL_ROOT_PASSWORD docker/.env | cut -d= -f2-)" octo <<'SQL'
+docker compose exec -T mysql \
+  mysql -uroot -p"$(grep MYSQL_ROOT_PASSWORD .env | cut -d= -f2-)" octo <<'SQL'
 INSERT INTO system_setting (category, key_name, value, value_type, description)
 VALUES ('docs', 'enabled', '1', 'bool', 'Enable docs module in octo-web')
 ON DUPLICATE KEY UPDATE value = '1';

--- a/docker/README.zh.md
+++ b/docker/README.zh.md
@@ -884,6 +884,7 @@ Compose 的 `docs` profile **按需启用**：
 | `OCTO_DOCS_COLLAB_SECRET` | Hocuspocus collab token 的 JWT 签名密钥（≥32 字符） | `openssl rand -hex 32` |
 | `OCTO_DOCS_ATTACHMENT_SECRET` | 附件预签名 URL 的 HMAC 签名密钥（≥32 字符） | `openssl rand -hex 32` |
 | `OCTO_DOCS_COLLAB_WS_URL` | 浏览器可访问的 WebSocket URL，例如 `ws://10.201.0.101:28080/docs-ws/` | 手动填写 |
+| `OCTO_DOCS_SERVICE_URL` | octo-server 调用 docs REST API 的内部地址 | `http://octo-docs-backend:3000` |
 
 同时将 `OCTO_DOCS_WEB_ORIGIN`、`OCTO_DOCS_S3_ENDPOINT`、`OCTO_DOCS_CORS_ORIGINS`
 设置为与你的部署 URL 一致。详见 `.env.example`。

--- a/docker/configs/minio-octo-app-policy.json
+++ b/docker/configs/minio-octo-app-policy.json
@@ -19,7 +19,8 @@
         "arn:aws:s3:::common",
         "arn:aws:s3:::download",
         "arn:aws:s3:::group",
-        "arn:aws:s3:::avatar"
+        "arn:aws:s3:::avatar",
+        "arn:aws:s3:::octo-docs-attachments"
       ]
     },
     {
@@ -42,7 +43,8 @@
         "arn:aws:s3:::common/*",
         "arn:aws:s3:::download/*",
         "arn:aws:s3:::group/*",
-        "arn:aws:s3:::avatar/*"
+        "arn:aws:s3:::avatar/*",
+        "arn:aws:s3:::octo-docs-attachments/*"
       ]
     }
   ]

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -195,6 +195,7 @@ services:
       OCTO_SUMMARY_DB_PASSWORD: ${OCTO_SUMMARY_DB_PASSWORD:-summary}
       OCTO_SUMMARY_READER_PASSWORD: ${OCTO_SUMMARY_READER_PASSWORD:-summary_reader}
       SPEECH_DB_PASSWORD: ${SPEECH_DB_PASSWORD:-}
+      OCTO_DOCS_DB_PASSWORD: ${OCTO_DOCS_DB_PASSWORD:-}
     # Backing service: bound to loopback by default so a missed-config moment
     # does not expose MySQL with the placeholder root password to the public
     # internet. Override OCTO_MYSQL_BIND to 0.0.0.0 only when you understand
@@ -343,6 +344,7 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
       OCTO_MINIO_APP_USER: ${OCTO_MINIO_APP_USER:-octo-app}
       OCTO_MINIO_APP_PASSWORD: ${OCTO_MINIO_APP_PASSWORD}
+      OCTO_DOCS_DB_PASSWORD: ${OCTO_DOCS_DB_PASSWORD:-}
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
@@ -423,6 +425,14 @@ services:
         for b in file chat moment sticker report chatbg common download group avatar; do
           mc mb --ignore-existing "local/$$b" >/dev/null
         done
+
+        # Docs profile: create the attachment bucket when the docs DB password
+        # is set (i.e. the operator has opted in to the docs profile).
+        # The bucket is private — octo-docs-backend presigns all URLs.
+        if [ -n "$${OCTO_DOCS_DB_PASSWORD:-}" ]; then
+          mc mb --ignore-existing "local/octo-docs-attachments" >/dev/null
+          echo "[minio-init] created octo-docs-attachments bucket"
+        fi
 
         # OCTO IM semantics: chat/file/moment/sticker/chatbg/common/avatar
         # are content buckets shared among group members. Anonymous GET
@@ -750,6 +760,10 @@ services:
       # deployment boots cleanly without these vars set.
       SPEECH_SERVICE_URL: ${SPEECH_SERVICE_URL:-}
       SPEECH_API_KEY:     ${SPEECH_API_KEY:-}
+      # octo-docs-backend collaborative document wiring. Empty by default so a
+      # non-docs deployment boots cleanly without these vars set.
+      DOCS_SERVICE_URL: ${DOCS_SERVICE_URL:-}
+      DOCS_COLLAB_SECRET: ${OCTO_DOCS_COLLAB_SECRET:-}
       # Where the reader finds OpenSearch + which read alias it queries. Only
       # consulted when OCTO_SEARCH_BACKEND=es; harmless (unread) when disabled.
       # The reader queries the ALIAS, never the physical index — the alias is
@@ -1155,6 +1169,82 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:8781/healthz || exit 1"]
       interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    networks:
+      - octo-net
+
+  # ===========================================================================
+  # Docs infrastructure (collaborative document backend) — STRICTLY ADDITIVE
+  # ===========================================================================
+  # octo-docs-backend: Hocuspocus + Yjs real-time collaborative document sync.
+  # Gated behind `profiles: ["docs"]` — a vanilla `docker compose up -d` starts
+  # nothing. Opt in with `COMPOSE_PROFILES=docs` (combine with other profiles:
+  # `COMPOSE_PROFILES=summary,docs`).
+  #
+  # Two listeners in one process:
+  #   REST API   :3000  — docs CRUD, collab-token issuance, attachments
+  #   Hocuspocus :1234  — real-time Yjs WebSocket sync
+  # Both are reverse-proxied through nginx (/docs-api/ and /docs-ws/) so only
+  # the existing OCTO_HTTP_PORT stays open; no new host ports are required.
+  #
+  # ISOLATION GUARANTEES:
+  #   - No core service definition is touched beyond two optional env vars on
+  #     octo-server (DOCS_SERVICE_URL / DOCS_COLLAB_SECRET), both empty-default.
+  #   - No new REQUIRED env var: every var below has a `:-` default or is
+  #     gated by the profile, so a non-docs deployment never fails preflight.
+  #   - Reuses the existing octo-net network, MySQL instance (octo_docs database
+  #     created by init-extra-dbs.sh), and MinIO instance.
+  # ---------------------------------------------------------------------------
+  octo-docs-backend:
+    image: ${OCTO_DOCS_IMAGE:-hub2.intra.mlamp.cn/octo/octo-docs-backend:0.2.0}
+    restart: unless-stopped
+    profiles: ["docs"]
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    environment:
+      NODE_ENV: production
+      HTTP_PORT: "3000"
+      HOCUSPOCUS_PORT: "1234"
+      TRUST_PROXY: "1"
+      # MySQL
+      MYSQL_HOST: mysql
+      MYSQL_PORT: "3306"
+      MYSQL_USER: docs
+      MYSQL_PASSWORD: ${OCTO_DOCS_DB_PASSWORD:-}
+      MYSQL_DATABASE: octo_docs
+      # Redis (reuse existing instance)
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      REDIS_PREFIX: octo-docs
+      # Collab token (short-lived JWT for Hocuspocus WS handshake)
+      COLLAB_TOKEN_SECRET: ${OCTO_DOCS_COLLAB_SECRET:-}
+      # Browser-reachable WS URL returned to clients. nginx proxies /docs-ws/ →
+      # :1234, so the public URL is ws:// (or wss://) on the same host+port as
+      # the REST API — no extra open port required.
+      COLLAB_TOKEN_PUBLIC_WS_URL: "${OCTO_DOCS_COLLAB_WS_URL:-}"
+      # Identity — delegate auth to octo-server
+      OCTO_IDENTITY_MODE: http
+      OCTO_SERVER_BASE_URL: http://octo-server:8090
+      OCTO_WEB_ORIGIN: "${OCTO_DOCS_WEB_ORIGIN:-}"
+      # Attachments via MinIO (s3 driver)
+      ATTACHMENT_DRIVER: s3
+      ATTACHMENT_BUCKET: octo-docs-attachments
+      ATTACHMENT_S3_ENDPOINT: "${OCTO_DOCS_S3_ENDPOINT:-}"
+      ATTACHMENT_S3_ACCESS_KEY: ${OCTO_MINIO_APP_USER:-octo-app}
+      ATTACHMENT_S3_SECRET_KEY: ${OCTO_MINIO_APP_PASSWORD:-}
+      ATTACHMENT_S3_FORCE_PATH_STYLE: "true"
+      ATTACHMENT_SIGNING_SECRET: ${OCTO_DOCS_ATTACHMENT_SECRET:-}
+      # CORS — allow requests from the web frontend
+      CORS_ALLOWED_ORIGINS: "${OCTO_DOCS_CORS_ORIGINS:-}"
+      TZ: ${TZ:-UTC}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:3000/healthz || exit 1"]
+      interval: 15s
       timeout: 5s
       retries: 3
       start_period: 30s

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -762,7 +762,7 @@ services:
       SPEECH_API_KEY:     ${SPEECH_API_KEY:-}
       # octo-docs-backend collaborative document wiring. Empty by default so a
       # non-docs deployment boots cleanly without these vars set.
-      DOCS_SERVICE_URL: ${DOCS_SERVICE_URL:-}
+      DOCS_SERVICE_URL: ${OCTO_DOCS_SERVICE_URL:-}
       DOCS_COLLAB_SECRET: ${OCTO_DOCS_COLLAB_SECRET:-}
       # Where the reader finds OpenSearch + which read alias it queries. Only
       # consulted when OCTO_SEARCH_BACKEND=es; harmless (unread) when disabled.
@@ -1191,7 +1191,7 @@ services:
   #
   # ISOLATION GUARANTEES:
   #   - No core service definition is touched beyond two optional env vars on
-  #     octo-server (DOCS_SERVICE_URL / DOCS_COLLAB_SECRET), both empty-default.
+  #     octo-server (OCTO_DOCS_SERVICE_URL / OCTO_DOCS_COLLAB_SECRET), both empty-default.
   #   - No new REQUIRED env var: every var below has a `:-` default or is
   #     gated by the profile, so a non-docs deployment never fails preflight.
   #   - Reuses the existing octo-net network, MySQL instance (octo_docs database

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -422,17 +422,13 @@ services:
         # CreateBucket privileges (the policy below intentionally omits
         # bucket admin actions). Each `mb` is `--ignore-existing` so the
         # service stays idempotent.
-        for b in file chat moment sticker report chatbg common download group avatar; do
+        for b in file chat moment sticker report chatbg common download group avatar octo-docs-attachments; do
           mc mb --ignore-existing "local/$$b" >/dev/null
         done
 
-        # Docs profile: create the attachment bucket when the docs DB password
-        # is set (i.e. the operator has opted in to the docs profile).
-        # The bucket is private — octo-docs-backend presigns all URLs.
-        if [ -n "$${OCTO_DOCS_DB_PASSWORD:-}" ]; then
-          mc mb --ignore-existing "local/octo-docs-attachments" >/dev/null
-          echo "[minio-init] created octo-docs-attachments bucket"
-        fi
+        # Docs attachment bucket is created alongside the core bucket list
+        # below (no docs DB-password gate needed — the bucket is free to
+        # pre-create and the docs service is profile-gated).
 
         # OCTO IM semantics: chat/file/moment/sticker/chatbg/common/avatar
         # are content buckets shared among group members. Anonymous GET
@@ -760,10 +756,9 @@ services:
       # deployment boots cleanly without these vars set.
       SPEECH_SERVICE_URL: ${SPEECH_SERVICE_URL:-}
       SPEECH_API_KEY:     ${SPEECH_API_KEY:-}
-      # octo-docs-backend collaborative document wiring. Empty by default so a
-      # non-docs deployment boots cleanly without these vars set.
-      DOCS_SERVICE_URL: ${OCTO_DOCS_SERVICE_URL:-}
-      DOCS_COLLAB_SECRET: ${OCTO_DOCS_COLLAB_SECRET:-}
+      # octo-docs-backend notification token wiring. Empty by default so a
+      # non-docs deployment boots cleanly without this var set.
+      OCTO_DOCS_NOTIFY_TOKEN: ${OCTO_DOCS_NOTIFY_TOKEN:-}
       # Where the reader finds OpenSearch + which read alias it queries. Only
       # consulted when OCTO_SEARCH_BACKEND=es; harmless (unread) when disabled.
       # The reader queries the ALIAS, never the physical index — the alias is
@@ -1178,7 +1173,7 @@ services:
   # ===========================================================================
   # Docs infrastructure (collaborative document backend) — STRICTLY ADDITIVE
   # ===========================================================================
-  # octo-docs-backend: Hocuspocus + Yjs real-time collaborative document sync.
+  # docs-preflight / octo-docs-backend: Hocuspocus + Yjs real-time collaborative document sync.
   # Gated behind `profiles: ["docs"]` — a vanilla `docker compose up -d` starts
   # nothing. Opt in with `COMPOSE_PROFILES=docs` (combine with other profiles:
   # `COMPOSE_PROFILES=summary,docs`).
@@ -1190,18 +1185,73 @@ services:
   # the existing OCTO_HTTP_PORT stays open; no new host ports are required.
   #
   # ISOLATION GUARANTEES:
-  #   - No core service definition is touched beyond two optional env vars on
-  #     octo-server (OCTO_DOCS_SERVICE_URL / OCTO_DOCS_COLLAB_SECRET), both empty-default.
-  #   - No new REQUIRED env var: every var below has a `:-` default or is
-  #     gated by the profile, so a non-docs deployment never fails preflight.
+  #   - No core service definition is touched beyond one optional env var on
+  #     octo-server (OCTO_DOCS_NOTIFY_TOKEN), empty by default.
+  #   - All required docs secrets/URLs are enforced by docs-preflight, which is
+  #     itself gated by the `docs` profile, so non-docs deployments never fail
+  #     preflight on missing docs variables.
   #   - Reuses the existing octo-net network, MySQL instance (octo_docs database
   #     created by init-extra-dbs.sh), and MinIO instance.
   # ---------------------------------------------------------------------------
+  docs-preflight:
+    image: ${OCTO_PREFLIGHT_IMAGE:-busybox:1.36}
+    restart: "no"
+    profiles: ["docs"]
+    environment:
+      OCTO_DOCS_DB_PASSWORD: ${OCTO_DOCS_DB_PASSWORD:-}
+      OCTO_DOCS_COLLAB_SECRET: ${OCTO_DOCS_COLLAB_SECRET:-}
+      OCTO_DOCS_ATTACHMENT_SECRET: ${OCTO_DOCS_ATTACHMENT_SECRET:-}
+      OCTO_DOCS_COLLAB_WS_URL: ${OCTO_DOCS_COLLAB_WS_URL:-}
+      OCTO_DOCS_WEB_ORIGIN: ${OCTO_DOCS_WEB_ORIGIN:-}
+      OCTO_DOCS_S3_ENDPOINT: ${OCTO_DOCS_S3_ENDPOINT:-}
+      OCTO_DOCS_CORS_ORIGINS: ${OCTO_DOCS_CORS_ORIGINS:-}
+      OCTO_DOCS_NOTIFY_TOKEN: ${OCTO_DOCS_NOTIFY_TOKEN:-}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -eu
+        check_required() {
+          name=$$1
+          raw=$$(eval "printf %s \"\$$$$name\"")
+          if [ -z "$$raw" ]; then
+            echo "[docs-preflight] FATAL: $$name is empty — set it in .env before enabling the docs profile" >&2
+            exit 1
+          fi
+        }
+        check_hex_secret() {
+          name=$$1
+          raw=$$(eval "printf %s \"\$$$$name\"")
+          check_required "$$name"
+          if [ "$${#raw}" -lt 32 ]; then
+            echo "[docs-preflight] FATAL: $$name must be at least 32 characters (openssl rand -hex 32)" >&2
+            exit 1
+          fi
+          lc=$$(printf %s "$$raw" | tr 'A-Z' 'a-z')
+          case "$$lc" in
+            change_me_*|chg_me*)
+              echo "[docs-preflight] FATAL: $$name is still a CHANGE_ME / CHG_ME placeholder" >&2
+              exit 1
+              ;;
+          esac
+        }
+        check_required OCTO_DOCS_DB_PASSWORD
+        check_hex_secret OCTO_DOCS_COLLAB_SECRET
+        check_hex_secret OCTO_DOCS_ATTACHMENT_SECRET
+        check_required OCTO_DOCS_COLLAB_WS_URL
+        check_required OCTO_DOCS_WEB_ORIGIN
+        check_required OCTO_DOCS_S3_ENDPOINT
+        check_required OCTO_DOCS_CORS_ORIGINS
+        echo "[docs-preflight] docs settings look valid"
+    networks:
+      - octo-net
+
   octo-docs-backend:
-    image: ${OCTO_DOCS_IMAGE:-hub2.intra.mlamp.cn/octo/octo-docs-backend:0.2.0}
+    image: ${OCTO_DOCS_IMAGE:-mininglamposs/octo-docs-backend:latest}
     restart: unless-stopped
     profiles: ["docs"]
     depends_on:
+      docs-preflight:
+        condition: service_completed_successfully
       mysql:
         condition: service_healthy
       redis:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1206,6 +1206,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
+      minio-init:
+        condition: service_completed_successfully
     environment:
       NODE_ENV: production
       HTTP_PORT: "3000"

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -272,6 +272,41 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
+    location /docs-api/ {
+        # octo-docs-backend REST API lives in `profiles: [docs]` — variable
+        # proxy_pass defers DNS resolution so nginx starts cleanly when the
+        # container is absent (returns 502 instead of emerg crash).
+        limit_req zone=octo_api burst=20 nodelay;
+        set $upstream_docs octo-docs-backend;
+        rewrite ^/docs-api/(.*) /$1 break;
+        proxy_pass         http://$upstream_docs:3000;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location /docs-ws/ {
+        # Hocuspocus WebSocket relay — upgrade semantics must be preserved.
+        # Variable proxy_pass + Docker DNS defers resolution so nginx starts
+        # cleanly when the profile is off. No rate-limiting on WS: the
+        # handshake limit_req on /docs-api/collab-token already bounds new
+        # sessions; persistent WebSocket connections don't produce new requests.
+        set $upstream_docs_ws octo-docs-backend;
+        rewrite ^/docs-ws/(.*) /$1 break;
+        proxy_pass         http://$upstream_docs_ws:1234;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade    $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+    }
+
     location = /_octo_up {
         default_type text/html;
         return 200 '<!doctype html>
@@ -285,6 +320,7 @@ server {
 <li><a href="/api/v1/health">REST · <code>/api/v1/health</code></a></li>
 <li><a href="/matter/health">Matter · <code>/matter/health</code></a></li>
 <li><a href="/summary/health">Smart-summary · <code>/summary/health</code></a></li>
+<li><a href="/docs-api/healthz">Docs · <code>/docs-api/healthz</code></a></li>
 </ul>
 <p>MinIO console is loopback-only (port 29001 on the host). SSH-forward
 to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
@@ -477,6 +513,33 @@ to reach it (<code>ssh -L 28088:127.0.0.1:28088 user@host</code>).</p>
 #         proxy_set_header   X-Real-IP         $remote_addr;
 #         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
 #         proxy_set_header   X-Forwarded-Proto $scheme;
+#     }
+#
+#     location /docs-api/ {
+#         limit_req zone=octo_api burst=20 nodelay;
+#         set $upstream_docs octo-docs-backend;
+#         rewrite ^/docs-api/(.*) /$1 break;
+#         proxy_pass         http://$upstream_docs:3000;
+#         proxy_http_version 1.1;
+#         proxy_set_header   Host              $host;
+#         proxy_set_header   X-Real-IP         $remote_addr;
+#         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+#         proxy_set_header   X-Forwarded-Proto $scheme;
+#     }
+#
+#     location /docs-ws/ {
+#         set $upstream_docs_ws octo-docs-backend;
+#         rewrite ^/docs-ws/(.*) /$1 break;
+#         proxy_pass         http://$upstream_docs_ws:1234;
+#         proxy_http_version 1.1;
+#         proxy_set_header   Upgrade    $http_upgrade;
+#         proxy_set_header   Connection "upgrade";
+#         proxy_set_header   Host              $host;
+#         proxy_set_header   X-Real-IP         $remote_addr;
+#         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+#         proxy_set_header   X-Forwarded-Proto $scheme;
+#         proxy_read_timeout 86400s;
+#         proxy_send_timeout 86400s;
 #     }
 #
 #     location = /_octo_up {

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -287,6 +287,10 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
+    location = /docs-api {
+        return 301 /docs-api/;
+    }
+
     location /docs-ws/ {
         # Hocuspocus WebSocket relay — upgrade semantics must be preserved.
         # Variable proxy_pass + Docker DNS defers resolution so nginx starts
@@ -349,7 +353,7 @@ to reach it (<code>ssh -L 28088:127.0.0.1:28088 user@host</code>).</p>
     # trailing slash) must fall through to the `location /` SPA
     # catch-all instead of being routed at MinIO — otherwise an SPA
     # refresh on `/chat/` would render MinIO's 404 XML.
-    location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)/.+ {
+    location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar|octo-docs-attachments)/.+ {
         proxy_pass         http://octo_minio_api;
         proxy_http_version 1.1;
         proxy_set_header   Host              $http_host;
@@ -527,6 +531,10 @@ to reach it (<code>ssh -L 28088:127.0.0.1:28088 user@host</code>).</p>
 #         proxy_set_header   X-Forwarded-Proto $scheme;
 #     }
 #
+#     location = /docs-api {
+#         return 301 /docs-api/;
+#     }
+#
 #     location /docs-ws/ {
 #         set $upstream_docs_ws octo-docs-backend;
 #         rewrite ^/docs-ws/(.*) /$1 break;
@@ -554,7 +562,7 @@ to reach it (<code>ssh -L 28088:127.0.0.1:28088 user@host</code>).</p>
 #     # `/chat/` must fall through to `location /`). Whitelist must stay
 #     # in sync with the `minio-init` `for b in …` list. Must precede
 #     # `location /`.
-#     location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)/.+ {
+#     location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar|octo-docs-attachments)/.+ {
 #         proxy_pass         http://octo_minio_api;
 #         proxy_http_version 1.1;
 #         proxy_set_header   Host              $http_host;

--- a/docker/scripts/init-extra-dbs.sh
+++ b/docker/scripts/init-extra-dbs.sh
@@ -41,6 +41,7 @@ set -euo pipefail
 : "${OCTO_SUMMARY_DB_PASSWORD:=summary}"
 : "${OCTO_SUMMARY_READER_PASSWORD:=summary_reader}"
 : "${SPEECH_DB_PASSWORD:=}"
+: "${OCTO_DOCS_DB_PASSWORD:=}"
 : "${MYSQL_DATABASE:=octo}"
 
 validate_password() {
@@ -144,6 +145,7 @@ MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -u root <<SQL
 CREATE DATABASE IF NOT EXISTS octo_matter  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 CREATE DATABASE IF NOT EXISTS octo_summary CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 CREATE DATABASE IF NOT EXISTS octo_speech  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+CREATE DATABASE IF NOT EXISTS octo_docs    CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- Service-scoped read-write accounts -----------------------------------------
 -- CREATE USER IF NOT EXISTS leaves an existing user untouched; the matching
@@ -183,4 +185,18 @@ SQL
   echo "[init-extra-dbs] provisioned speech DB user"
 fi
 
-echo "[init-extra-dbs] created octo_matter + octo_summary + octo_speech + service users (scoped to \`${MYSQL_DATABASE}\`)"
+# If OCTO_DOCS_DB_PASSWORD is set, provision the scoped docs DB user.
+# The main SQL block above already created octo_docs; this separate
+# step is conditional so it is safe to skip on a non-docs deployment.
+if [ -n "${OCTO_DOCS_DB_PASSWORD:-}" ]; then
+  validate_password OCTO_DOCS_DB_PASSWORD "$OCTO_DOCS_DB_PASSWORD"
+  MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -u root <<SQL
+CREATE USER IF NOT EXISTS 'docs'@'%' IDENTIFIED BY '${OCTO_DOCS_DB_PASSWORD}';
+ALTER USER IF EXISTS      'docs'@'%' IDENTIFIED BY '${OCTO_DOCS_DB_PASSWORD}';
+GRANT ALL PRIVILEGES ON octo_docs.* TO 'docs'@'%';
+FLUSH PRIVILEGES;
+SQL
+  echo "[init-extra-dbs] provisioned docs DB user"
+fi
+
+echo "[init-extra-dbs] created octo_matter + octo_summary + octo_speech + octo_docs + service users (scoped to \`${MYSQL_DATABASE}\`)"


### PR DESCRIPTION
## Summary

Adds `octo-docs-backend` (Hocuspocus + Yjs real-time collaborative document sync) as an opt-in Docker Compose profile, following the same strictly-additive pattern established by the speech profile (#164).

- **Zero impact on default deployments**: `docker compose up -d` is byte-for-byte unchanged. Every new env var has an empty `:-` default, so preflight never fails on a non-docs deployment.
- **Single-port**: nginx proxies both REST (`/docs-api/` → `:3000`) and WebSocket (`/docs-ws/` → `:1234`), so no new host port is required.
- **Fully opt-in**: gated behind `profiles: ["docs"]` — operators add `docs` to `COMPOSE_PROFILES` only after setting the four required secrets.

## Changes

| File | What changed |
|---|---|
| `docker/docker-compose.yaml` | Add `octo-docs-backend` service (`profiles: ["docs"]`); add `DOCS_SERVICE_URL` / `DOCS_COLLAB_SECRET` to `octo-server` env (empty-default); add `OCTO_DOCS_DB_PASSWORD` to `mysql` and `minio-init`; conditionally create `octo-docs-attachments` MinIO bucket in `minio-init` |
| `docker/nginx/conf.d/octo.conf.template` | Add `/docs-api/` (REST) and `/docs-ws/` (WebSocket + upgrade headers) locations with deferred DNS via `set $upstream_docs`; HTTPS mirrors commented; healthz link on `_octo_up` |
| `docker/scripts/init-extra-dbs.sh` | Create `octo_docs` schema unconditionally; provision `docs` MySQL user when `OCTO_DOCS_DB_PASSWORD` is set |
| `docker/.env.example` | Add "Docs pipeline" section with all vars + generation commands |
| `docker/README.md` | Add "Docs profile" section (EN): prerequisites, startup, DB/MinIO, feature-flag SQL, verify |
| `docker/README.zh.md` | Add "Docs profile" section (ZH): same content in Chinese |

## Test plan

- [ ] `docker compose up -d` (no `docs` profile) starts cleanly — no new errors, nginx healthy
- [ ] Set `OCTO_DOCS_DB_PASSWORD` + other secrets → `COMPOSE_PROFILES=docs docker compose up -d` brings `octo-docs-backend` to `(healthy)`
- [ ] `curl http://127.0.0.1:28080/docs-api/healthz` returns `{"ok":true}`
- [ ] WebSocket connection to `ws://host:port/docs-ws/` completes handshake
- [ ] `minio-init --force-recreate` creates `octo-docs-attachments` bucket when password is set
- [ ] Feature-flag SQL + `octo-server` restart shows docs entry in octo-web

🤖 Generated with [Claude Code](https://claude.com/claude-code)