### PR TITLE
feat(docker): add marketplace profile (octo-marketplace Skill & MCP market)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -534,7 +534,27 @@ LLM_MODEL=claude-sonnet-4-6
 # OCTO_DOCS_NOTIFY_TOKEN=<openssl rand -hex 32>
 
 # Docs image override (only used with COMPOSE_PROFILES=docs):
-# OCTO_DOCS_IMAGE=mininglamposs/octo-docs-backend:latest
+# OCTO_DOCS_IMAGE=mininglamposs/octo-docs-backend:0.4.0
+
+# --- Marketplace (only used when COMPOSE_PROFILES includes "market") ---------
+# Enable with COMPOSE_PROFILES=market (combine: COMPOSE_PROFILES=docs,market).
+# Do NOT add "market" to COMPOSE_PROFILES without setting the required
+# credentials below. market-preflight will fail fast if they are missing.
+#
+# Scoped MySQL user for octo_marketplace database (allowlist: [A-Za-z0-9._-])
+# OCTO_MARKETPLACE_DB_PASSWORD=<openssl rand -hex 16>
+#
+# Public base URL: the full origin the browser uses to reach this stack.
+# Baked into presigned skill-archive and MCP-icon URLs. Must be the same
+# origin the browser navigates to (e.g. https://octo.example.com or
+# http://192.168.1.10:28080 for a LAN deployment).
+# OCTO_PUBLIC_BASE_URL=http://${OCTO_DOMAIN}:${OCTO_HTTP_PORT}
+#
+# Connect octo-web to the marketplace backend (set when profile is active):
+# OCTO_MARKET_API_URL=http://octo-marketplace:8092
+#
+# Marketplace image override:
+# OCTO_MARKETPLACE_IMAGE=mininglamposs/octo-marketplace:latest
 
 # --- Search pipeline (only used when COMPOSE_PROFILES includes "search") ---
 # Host ports for local validation; loopback-bound by default so they never

--- a/docker/README.md
+++ b/docker/README.md
@@ -1334,6 +1334,88 @@ docker compose ps octo-docs-backend
 
 ---
 
+## Marketplace profile (Skill & MCP market)
+
+The marketplace backend — `octo-marketplace` — provides Skill archive
+upload/download and MCP server icon management, accessible through the
+octo-web sidebar "工具" (Tools) entry. It is **opt-in** behind the Docker
+Compose `market` profile:
+
+- A default `docker compose up -d` starts **zero** marketplace services.
+- Every marketplace variable in `.env` has an empty default, so a non-market
+  deployment never fails preflight on a missing marketplace variable.
+- nginx proxies `/market/api/v1/` to the marketplace container (variable
+  `proxy_pass`, so nginx starts cleanly when the profile is inactive).
+
+### Required settings
+
+Before adding `market` to `COMPOSE_PROFILES`, set the required variables in
+`docker/.env`:
+
+| Variable | Purpose | Generate with |
+|---|---|---|
+| `OCTO_MARKETPLACE_DB_PASSWORD` | MySQL scoped user for `octo_marketplace` | `openssl rand -hex 16` |
+| `OCTO_PUBLIC_BASE_URL` | Full browser-reachable origin (baked into presigned URLs) | e.g. `https://octo.example.com` or `http://192.168.1.10:28080` |
+| `OCTO_MARKET_API_URL` | Wires octo-web to the marketplace backend | `http://octo-marketplace:8092` |
+
+### Bring the marketplace profile up
+
+```bash
+# In docker/.env — set the required variables first:
+echo 'OCTO_MARKETPLACE_DB_PASSWORD='$(openssl rand -hex 16) >> .env
+echo 'OCTO_PUBLIC_BASE_URL=http://YOUR_HOST:28080' >> .env
+echo 'OCTO_MARKET_API_URL=http://octo-marketplace:8092' >> .env
+
+# Add "market" to COMPOSE_PROFILES:
+existing="$(grep -E '^COMPOSE_PROFILES=' .env | tail -1 | cut -d= -f2-)"
+if ! echo "$existing" | grep -qw "market"; then
+  [ -n "$existing" ] \
+    && sed -i "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=${existing},market|" .env \
+    || echo 'COMPOSE_PROFILES=market' >> .env
+fi
+
+docker compose up -d
+```
+
+`market-preflight` (a one-shot `mysql:8.0` service) validates the password,
+then idempotently creates `octo_marketplace` and the `marketplace` DB user
+before `octo-marketplace` starts. This covers both fresh installs and
+**existing deployments** where `init-extra-dbs.sh` has already run.
+
+### MinIO setup on an existing stack
+
+If `minio-init` already ran before you added the `market` profile, re-run it
+to create the `octo-marketplace` bucket:
+
+```bash
+docker compose up --force-recreate minio-init
+```
+
+### Skill archive download security
+
+Skill archives (`OSS_DOWNLOAD_SIGNED: "true"`) are served via short-lived
+presigned URLs — they are **not** publicly readable. Only authenticated users
+with appropriate roles can download archives through the marketplace API.
+
+> **HTTP plain-text note:** Skill upload uses MinIO presigned PUT URLs.
+> For **HTTPS deployments** this works out of the box. For **plain-HTTP LAN
+> deployments**, the octo-web frontend validates that the presigned URL
+> hostname matches the current page origin; a fix has been submitted to
+> octo-web (branch `fix/skill-market-http-same-origin`). Until that PR is
+> merged and a new octo-web image released, plain-HTTP operators will see a
+> "URL scheme 不允许" error on skill uploads.
+
+### Verify
+
+```bash
+curl http://127.0.0.1:28080/market/healthz
+# → {"status":"ok"}
+
+docker compose ps octo-marketplace
+```
+
+---
+
 ## Search profile (message-search pipeline)
 
 The message-search pipeline — Kafka + OpenSearch (with the `analysis-ik`

--- a/docker/configs/minio-octo-app-policy.json
+++ b/docker/configs/minio-octo-app-policy.json
@@ -20,7 +20,8 @@
         "arn:aws:s3:::download",
         "arn:aws:s3:::group",
         "arn:aws:s3:::avatar",
-        "arn:aws:s3:::octo-docs-attachments"
+        "arn:aws:s3:::octo-docs-attachments",
+        "arn:aws:s3:::octo-marketplace"
       ]
     },
     {
@@ -44,7 +45,8 @@
         "arn:aws:s3:::download/*",
         "arn:aws:s3:::group/*",
         "arn:aws:s3:::avatar/*",
-        "arn:aws:s3:::octo-docs-attachments/*"
+        "arn:aws:s3:::octo-docs-attachments/*",
+        "arn:aws:s3:::octo-marketplace/*"
       ]
     }
   ]

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -422,7 +422,7 @@ services:
         # CreateBucket privileges (the policy below intentionally omits
         # bucket admin actions). Each `mb` is `--ignore-existing` so the
         # service stays idempotent.
-        for b in file chat moment sticker report chatbg common download group avatar octo-docs-attachments; do
+        for b in file chat moment sticker report chatbg common download group avatar octo-docs-attachments octo-marketplace; do
           mc mb --ignore-existing "local/$$b" >/dev/null
         done
 
@@ -448,7 +448,7 @@ services:
         # Earlier `|| true` silently swallowed permission bugs and API
         # drift — operator saw `minio-init` exit 0 but preview still 403.
         echo "[minio-init] setting anonymous download on content buckets…"
-        for b in chat file moment sticker chatbg common avatar; do
+        for b in chat file moment sticker chatbg common avatar octo-marketplace; do
           attempt=1
           until mc anonymous set download "local/$$b" >/dev/null 2>&1; do
             if [ "$$attempt" -ge 3 ]; then
@@ -897,6 +897,12 @@ services:
     environment:
       API_URL: http://octo-server:8090
       SUMMARY_API_URL: ${OCTO_SUMMARY_API_URL:-http://summary-api:8080}
+      # Marketplace integration: octo-web's built-in nginx proxies
+      # /market/api/v1/ → octo-marketplace:8092 when MARKET_API_URL is set.
+      # Set this only when the `market` profile is active; leave empty to
+      # disable the feature gracefully (octo-web returns 503 for market API
+      # calls, which is the expected "feature not configured" path).
+      MARKET_API_URL: ${OCTO_MARKET_API_URL:-}
     ports:
       # Web SPA is reached through nginx (`/`, see octo.conf.template) by
       # default — keep the direct host port loopback-only so an operator
@@ -1300,6 +1306,84 @@ services:
       timeout: 5s
       retries: 3
       start_period: 30s
+    networks:
+      - octo-net
+
+  # ===========================================================================
+  # Marketplace: octo-marketplace (Skill & MCP market) — opt-in profile
+  # ===========================================================================
+  # Gated behind `profiles: ["market"]` — a vanilla `docker compose up -d`
+  # starts nothing. Opt in with `COMPOSE_PROFILES=market` (combine with other
+  # profiles: `COMPOSE_PROFILES=docs,market`).
+  #
+  # The marketplace provides the Skill archive upload/download and MCP server
+  # icon management backend, accessible through the octo-web sidebar ("工具").
+  #
+  # ISOLATION GUARANTEES:
+  #   - No core service definition is touched beyond MARKET_API_URL on web
+  #     (empty by default; octo-web returns 503 gracefully when unset).
+  #   - Reuses the existing octo-net network, MySQL instance (octo_marketplace
+  #     database created by init-extra-dbs.sh), and MinIO instance.
+  #   - nginx routes /market/api/v1/ and /mcp-market are always present in
+  #     the nginx config (variable proxy_pass defers DNS so nginx starts
+  #     cleanly even when the marketplace container is absent).
+  #
+  # HTTP PRESIGNED URL NOTE:
+  #   Skill archive uploads use MinIO presigned PUT URLs. When the deployment
+  #   serves octo-web over plain HTTP (not HTTPS), the octo-web frontend
+  #   validates that the presigned URL's hostname matches the current page
+  #   origin (window.location.hostname). This works correctly for HTTPS
+  #   deployments. For HTTP deployments on a LAN IP, a fix has been submitted
+  #   to octo-web (PR: fix/skill-market-http-same-origin). Until that PR is
+  #   merged and a new image is released, HTTP LAN deployments need to patch
+  #   the octo-web JS bundle manually — see the PR description for details.
+  # ---------------------------------------------------------------------------
+  octo-marketplace:
+    image: ${OCTO_MARKETPLACE_IMAGE:-mininglamposs/octo-marketplace:latest}
+    restart: unless-stopped
+    profiles: ["market"]
+    depends_on:
+      mysql:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+    environment:
+      API_PORT: "8092"
+      # MySQL — scoped account provisioned by init-extra-dbs.sh
+      MYSQL_DSN: "marketplace:${OCTO_MARKETPLACE_DB_PASSWORD:-}@tcp(mysql:3306)/octo_marketplace?charset=utf8mb4&parseTime=true"
+      # Public base URL: the full origin the browser uses to reach this stack.
+      # Used to build presigned download links for skill archives and MCP icons.
+      # Must be the same origin the browser navigates to (e.g. https://octo.example.com).
+      PUBLIC_BASE_URL: "${OCTO_PUBLIC_BASE_URL:-http://${OCTO_DOMAIN:-localhost}:${OCTO_HTTP_PORT:-28080}}"
+      CORS_ALLOWED_ORIGINS: "${OCTO_PUBLIC_BASE_URL:-http://${OCTO_DOMAIN:-localhost}:${OCTO_HTTP_PORT:-28080}}"
+      OCTO_API_URL: "http://octo-server:8090"
+      AUTH_ENABLED: "true"
+      # Skill archive storage (MinIO, path-style).
+      # OSS_ENDPOINT is the INTERNAL MinIO address used for presigning;
+      # OSS_PUBLIC_ENDPOINT is the browser-reachable URL baked into the links.
+      STORAGE_DRIVER: oss
+      OSS_ENDPOINT: "http://minio:9000"
+      OSS_BUCKET: octo-marketplace
+      OSS_ACCESS_KEY: ${OCTO_MINIO_APP_USER:-octo-app}
+      OSS_SECRET_KEY: ${OCTO_MINIO_APP_PASSWORD:-}
+      OSS_PATH_STYLE: "true"
+      OSS_PUBLIC_ENDPOINT: "${OCTO_PUBLIC_BASE_URL:-http://${OCTO_DOMAIN:-localhost}:${OCTO_HTTP_PORT:-28080}}"
+      OSS_PUBLIC_PATH_STYLE: "true"
+      OSS_DOWNLOAD_SIGNED: "false"
+      # MCP icon storage (same MinIO instance, same bucket)
+      STORAGE_ENDPOINT: "http://minio:9000"
+      STORAGE_BUCKET: octo-marketplace
+      STORAGE_ACCESS_KEY: ${OCTO_MINIO_APP_USER:-octo-app}
+      STORAGE_SECRET_KEY: ${OCTO_MINIO_APP_PASSWORD:-}
+      STORAGE_PUBLIC_BASE_URL: "${OCTO_PUBLIC_BASE_URL:-http://${OCTO_DOMAIN:-localhost}:${OCTO_HTTP_PORT:-28080}}"
+      STORAGE_PATH_STYLE: "true"
+      TZ: ${TZ:-UTC}
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8092/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     networks:
       - octo-net
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -196,6 +196,7 @@ services:
       OCTO_SUMMARY_READER_PASSWORD: ${OCTO_SUMMARY_READER_PASSWORD:-summary_reader}
       SPEECH_DB_PASSWORD: ${SPEECH_DB_PASSWORD:-}
       OCTO_DOCS_DB_PASSWORD: ${OCTO_DOCS_DB_PASSWORD:-}
+      OCTO_MARKETPLACE_DB_PASSWORD: ${OCTO_MARKETPLACE_DB_PASSWORD:-}
     # Backing service: bound to loopback by default so a missed-config moment
     # does not expose MySQL with the placeholder root password to the public
     # internet. Override OCTO_MYSQL_BIND to 0.0.0.0 only when you understand
@@ -1312,6 +1313,55 @@ services:
   # ===========================================================================
   # Marketplace: octo-marketplace (Skill & MCP market) — opt-in profile
   # ===========================================================================
+  # ---------------------------------------------------------------------------
+  # market-preflight: validate required secrets + provision DB on existing vols
+  # ---------------------------------------------------------------------------
+  # Runs before octo-marketplace starts. Two responsibilities:
+  #   1. Fail-fast: OCTO_MARKETPLACE_DB_PASSWORD must be set and non-trivial.
+  #   2. DB provisioning: on an existing mysql-data volume (i.e. when the
+  #      market profile is added to a running stack), init-extra-dbs.sh will
+  #      not re-run (it fires only on first MySQL volume init). This service
+  #      creates octo_marketplace + the marketplace user idempotently via the
+  #      root account, matching what init-extra-dbs.sh would have done on a
+  #      fresh install. On a brand-new install, init-extra-dbs.sh already
+  #      created the DB and user, so the IF NOT EXISTS / IF EXISTS guards make
+  #      re-execution a safe no-op.
+  market-preflight:
+    image: ${OCTO_PREFLIGHT_IMAGE:-busybox:1.36}
+    restart: "no"
+    profiles: ["market"]
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      OCTO_MARKETPLACE_DB_PASSWORD: ${OCTO_MARKETPLACE_DB_PASSWORD:-}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -eu
+        # Validate OCTO_MARKETPLACE_DB_PASSWORD
+        if [ -z "$$OCTO_MARKETPLACE_DB_PASSWORD" ]; then
+          echo "[market-preflight] FATAL: OCTO_MARKETPLACE_DB_PASSWORD is empty — set it in .env (openssl rand -hex 16)" >&2
+          exit 1
+        fi
+        lc=$$(printf %s "$$OCTO_MARKETPLACE_DB_PASSWORD" | tr 'A-Z' 'a-z')
+        case "$$lc" in
+          change_me_*|chg_me*)
+            echo "[market-preflight] FATAL: OCTO_MARKETPLACE_DB_PASSWORD is still a placeholder" >&2
+            exit 1
+            ;;
+        esac
+        # Idempotently provision DB + user (safe on both fresh and existing volumes)
+        MYSQL_PWD="$$MYSQL_ROOT_PASSWORD" mysql -h mysql -u root \
+          -e "CREATE DATABASE IF NOT EXISTS octo_marketplace CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+              CREATE USER IF NOT EXISTS 'marketplace'@'%' IDENTIFIED BY '${OCTO_MARKETPLACE_DB_PASSWORD}';
+              ALTER USER IF EXISTS 'marketplace'@'%' IDENTIFIED BY '${OCTO_MARKETPLACE_DB_PASSWORD}';
+              GRANT ALL PRIVILEGES ON octo_marketplace.* TO 'marketplace'@'%';
+              FLUSH PRIVILEGES;"
+        echo "[market-preflight] octo_marketplace database and user ready"
+    networks:
+      - octo-net
   # Gated behind `profiles: ["market"]` — a vanilla `docker compose up -d`
   # starts nothing. Opt in with `COMPOSE_PROFILES=market` (combine with other
   # profiles: `COMPOSE_PROFILES=docs,market`).
@@ -1343,6 +1393,8 @@ services:
     restart: unless-stopped
     profiles: ["market"]
     depends_on:
+      market-preflight:
+        condition: service_completed_successfully
       mysql:
         condition: service_healthy
       minio-init:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -449,7 +449,7 @@ services:
         # Earlier `|| true` silently swallowed permission bugs and API
         # drift — operator saw `minio-init` exit 0 but preview still 403.
         echo "[minio-init] setting anonymous download on content buckets…"
-        for b in chat file moment sticker chatbg common avatar octo-marketplace; do
+        for b in chat file moment sticker chatbg common avatar; do
           attempt=1
           until mc anonymous set download "local/$$b" >/dev/null 2>&1; do
             if [ "$$attempt" -ge 3 ]; then
@@ -901,8 +901,8 @@ services:
       # Marketplace integration: octo-web's built-in nginx proxies
       # /market/api/v1/ → octo-marketplace:8092 when MARKET_API_URL is set.
       # Set this only when the `market` profile is active; leave empty to
-      # disable the feature gracefully (octo-web returns 503 for market API
-      # calls, which is the expected "feature not configured" path).
+      # disable the feature (the outer nginx returns 502 when the marketplace
+      # container is absent; octo-web itself returns 503 on the direct port).
       MARKET_API_URL: ${OCTO_MARKET_API_URL:-}
     ports:
       # Web SPA is reached through nginx (`/`, see octo.conf.template) by
@@ -1327,7 +1327,7 @@ services:
   #      created the DB and user, so the IF NOT EXISTS / IF EXISTS guards make
   #      re-execution a safe no-op.
   market-preflight:
-    image: ${OCTO_PREFLIGHT_IMAGE:-busybox:1.36}
+    image: mysql:8.0
     restart: "no"
     profiles: ["market"]
     depends_on:
@@ -1340,11 +1340,18 @@ services:
     command:
       - |
         set -eu
-        # Validate OCTO_MARKETPLACE_DB_PASSWORD
+        # Validate OCTO_MARKETPLACE_DB_PASSWORD — same rules as init-extra-dbs.sh:
+        # must be non-empty, match [A-Za-z0-9._-], and not be a CHANGE_ME placeholder.
         if [ -z "$$OCTO_MARKETPLACE_DB_PASSWORD" ]; then
           echo "[market-preflight] FATAL: OCTO_MARKETPLACE_DB_PASSWORD is empty — set it in .env (openssl rand -hex 16)" >&2
           exit 1
         fi
+        case "$$OCTO_MARKETPLACE_DB_PASSWORD" in
+          *[!A-Za-z0-9._-]*)
+            echo "[market-preflight] FATAL: OCTO_MARKETPLACE_DB_PASSWORD contains characters outside [A-Za-z0-9._-]" >&2
+            exit 1
+            ;;
+        esac
         lc=$$(printf %s "$$OCTO_MARKETPLACE_DB_PASSWORD" | tr 'A-Z' 'a-z')
         case "$$lc" in
           change_me_*|chg_me*)
@@ -1352,11 +1359,13 @@ services:
             exit 1
             ;;
         esac
-        # Idempotently provision DB + user (safe on both fresh and existing volumes)
+        # Idempotently provision DB + user (safe on both fresh and existing volumes).
+        # Uses $$ (runtime) not ${} (compose-parse-time) so the password is never
+        # baked into `docker compose config` output and no compose warning is emitted.
         MYSQL_PWD="$$MYSQL_ROOT_PASSWORD" mysql -h mysql -u root \
           -e "CREATE DATABASE IF NOT EXISTS octo_marketplace CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
-              CREATE USER IF NOT EXISTS 'marketplace'@'%' IDENTIFIED BY '${OCTO_MARKETPLACE_DB_PASSWORD}';
-              ALTER USER IF EXISTS 'marketplace'@'%' IDENTIFIED BY '${OCTO_MARKETPLACE_DB_PASSWORD}';
+              CREATE USER IF NOT EXISTS 'marketplace'@'%' IDENTIFIED BY '$$OCTO_MARKETPLACE_DB_PASSWORD';
+              ALTER USER IF EXISTS 'marketplace'@'%' IDENTIFIED BY '$$OCTO_MARKETPLACE_DB_PASSWORD';
               GRANT ALL PRIVILEGES ON octo_marketplace.* TO 'marketplace'@'%';
               FLUSH PRIVILEGES;"
         echo "[market-preflight] octo_marketplace database and user ready"
@@ -1371,7 +1380,7 @@ services:
   #
   # ISOLATION GUARANTEES:
   #   - No core service definition is touched beyond MARKET_API_URL on web
-  #     (empty by default; octo-web returns 503 gracefully when unset).
+  #     (empty by default; outer nginx returns 502 when container is absent).
   #   - Reuses the existing octo-net network, MySQL instance (octo_marketplace
   #     database created by init-extra-dbs.sh), and MinIO instance.
   #   - nginx routes /market/api/v1/ and /mcp-market are always present in
@@ -1421,7 +1430,9 @@ services:
       OSS_PATH_STYLE: "true"
       OSS_PUBLIC_ENDPOINT: "${OCTO_PUBLIC_BASE_URL:-http://${OCTO_DOMAIN:-localhost}:${OCTO_HTTP_PORT:-28080}}"
       OSS_PUBLIC_PATH_STYLE: "true"
-      OSS_DOWNLOAD_SIGNED: "false"
+      # Skill archives contain operator-uploaded code/config; keep downloads
+      # auth-gated via presigned URLs instead of world-readable anonymous access.
+      OSS_DOWNLOAD_SIGNED: "true"
       # MCP icon storage (same MinIO instance, same bucket)
       STORAGE_ENDPOINT: "http://minio:9000"
       STORAGE_BUCKET: octo-marketplace

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -311,6 +311,41 @@ server {
         proxy_send_timeout 86400s;
     }
 
+    # ---------------------------------------------------------------------------
+    # Marketplace: octo-marketplace REST API + SPA routes
+    # ---------------------------------------------------------------------------
+    # Variable proxy_pass + Docker DNS resolver defers DNS lookup to request
+    # time so nginx starts cleanly even when the `market` profile is inactive
+    # (returns 502 instead of crashing with "host not found in upstream").
+    location = /market/api {
+        return 301 /market/api/v1/;
+    }
+    location /market/api/v1/ {
+        limit_req zone=octo_api burst=20 nodelay;
+        set $upstream_market octo-marketplace;
+        resolver 127.0.0.11 ipv6=off valid=30s;
+        rewrite ^/market/api/v1/(.*)$ /api/v1/$1 break;
+        proxy_pass         http://$upstream_market:8092;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        client_max_body_size 100m;
+    }
+
+    # SPA history-mode fallback for marketplace pages (/mcp-market, /mcp-market/*)
+    location /mcp-market {
+        set $upstream_web_market web;
+        rewrite ^ / break;
+        proxy_pass         http://$upstream_web_market;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
     location = /_octo_up {
         default_type text/html;
         return 200 '<!doctype html>
@@ -325,6 +360,7 @@ server {
 <li><a href="/matter/health">Matter · <code>/matter/health</code></a></li>
 <li><a href="/summary/health">Smart-summary · <code>/summary/health</code></a></li>
 <li><a href="/docs-api/healthz">Docs · <code>/docs-api/healthz</code></a></li>
+<li><a href="/market/api/v1/healthz">Marketplace · <code>/market/api/v1/healthz</code></a></li>
 </ul>
 <p>MinIO console is loopback-only (port 29001 on the host). SSH-forward
 to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>
@@ -353,7 +389,7 @@ to reach it (<code>ssh -L 28088:127.0.0.1:28088 user@host</code>).</p>
     # trailing slash) must fall through to the `location /` SPA
     # catch-all instead of being routed at MinIO — otherwise an SPA
     # refresh on `/chat/` would render MinIO's 404 XML.
-    location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar|octo-docs-attachments)/.+ {
+    location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar|octo-docs-attachments|octo-marketplace)/.+ {
         proxy_pass         http://octo_minio_api;
         proxy_http_version 1.1;
         proxy_set_header   Host              $http_host;
@@ -562,7 +598,7 @@ to reach it (<code>ssh -L 28088:127.0.0.1:28088 user@host</code>).</p>
 #     # `/chat/` must fall through to `location /`). Whitelist must stay
 #     # in sync with the `minio-init` `for b in …` list. Must precede
 #     # `location /`.
-#     location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar|octo-docs-attachments)/.+ {
+#     location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar|octo-docs-attachments|octo-marketplace)/.+ {
 #         proxy_pass         http://octo_minio_api;
 #         proxy_http_version 1.1;
 #         proxy_set_header   Host              $http_host;

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -317,6 +317,14 @@ server {
     # Variable proxy_pass + Docker DNS resolver defers DNS lookup to request
     # time so nginx starts cleanly even when the `market` profile is inactive
     # (returns 502 instead of crashing with "host not found in upstream").
+    location = /market/healthz {
+        set $upstream_market_hc octo-marketplace;
+        resolver 127.0.0.11 ipv6=off valid=30s;
+        proxy_pass         http://$upstream_market_hc:8092/healthz;
+        proxy_http_version 1.1;
+        proxy_set_header   Host $host;
+        access_log off;
+    }
     location = /market/api {
         return 301 /market/api/v1/;
     }
@@ -360,7 +368,7 @@ server {
 <li><a href="/matter/health">Matter · <code>/matter/health</code></a></li>
 <li><a href="/summary/health">Smart-summary · <code>/summary/health</code></a></li>
 <li><a href="/docs-api/healthz">Docs · <code>/docs-api/healthz</code></a></li>
-<li><a href="/market/api/v1/healthz">Marketplace · <code>/market/api/v1/healthz</code></a></li>
+<li><a href="/market/healthz">Marketplace · <code>/market/healthz</code></a></li>
 </ul>
 <p>MinIO console is loopback-only (port 29001 on the host). SSH-forward
 to reach it (<code>ssh -L 9001:127.0.0.1:29001 user@host</code>).</p>

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -312,14 +312,16 @@ server {
     }
 
     # ---------------------------------------------------------------------------
-    # Marketplace: octo-marketplace REST API + SPA routes
+    # Marketplace: octo-marketplace REST API
     # ---------------------------------------------------------------------------
     # Variable proxy_pass + Docker DNS resolver defers DNS lookup to request
     # time so nginx starts cleanly even when the `market` profile is inactive
     # (returns 502 instead of crashing with "host not found in upstream").
+    # /mcp-market SPA routes are handled by the catch-all `location /` below
+    # (octo-web serves index.html for all unmatched paths via try_files), so
+    # no dedicated location is needed.
     location = /market/healthz {
         set $upstream_market_hc octo-marketplace;
-        resolver 127.0.0.11 ipv6=off valid=30s;
         proxy_pass         http://$upstream_market_hc:8092/healthz;
         proxy_http_version 1.1;
         proxy_set_header   Host $host;
@@ -331,7 +333,6 @@ server {
     location /market/api/v1/ {
         limit_req zone=octo_api burst=20 nodelay;
         set $upstream_market octo-marketplace;
-        resolver 127.0.0.11 ipv6=off valid=30s;
         rewrite ^/market/api/v1/(.*)$ /api/v1/$1 break;
         proxy_pass         http://$upstream_market:8092;
         proxy_http_version 1.1;
@@ -340,18 +341,6 @@ server {
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header   X-Forwarded-Proto $scheme;
         client_max_body_size 100m;
-    }
-
-    # SPA history-mode fallback for marketplace pages (/mcp-market, /mcp-market/*)
-    location /mcp-market {
-        set $upstream_web_market web;
-        rewrite ^ / break;
-        proxy_pass         http://$upstream_web_market;
-        proxy_http_version 1.1;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
     location = /_octo_up {
@@ -597,6 +586,30 @@ to reach it (<code>ssh -L 28088:127.0.0.1:28088 user@host</code>).</p>
 #     location = /_octo_up {
 #         default_type text/html;
 #         return 200 '<!doctype html><html><body><h1>OCTO Server (HTTPS)</h1></body></html>';
+#     }
+#
+#     # Marketplace — mirrors the HTTP block above.
+#     location = /market/healthz {
+#         set $upstream_market_hc octo-marketplace;
+#         proxy_pass         http://$upstream_market_hc:8092/healthz;
+#         proxy_http_version 1.1;
+#         proxy_set_header   Host $host;
+#         access_log off;
+#     }
+#     location = /market/api {
+#         return 301 /market/api/v1/;
+#     }
+#     location /market/api/v1/ {
+#         limit_req zone=octo_api burst=20 nodelay;
+#         set $upstream_market octo-marketplace;
+#         rewrite ^/market/api/v1/(.*)$ /api/v1/$1 break;
+#         proxy_pass         http://$upstream_market:8092;
+#         proxy_http_version 1.1;
+#         proxy_set_header   Host              $host;
+#         proxy_set_header   X-Real-IP         $remote_addr;
+#         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+#         proxy_set_header   X-Forwarded-Proto $scheme;
+#         client_max_body_size 100m;
 #     }
 #
 #     # MinIO S3 bucket-name routing — see the HTTP server block above

--- a/docker/scripts/init-extra-dbs.sh
+++ b/docker/scripts/init-extra-dbs.sh
@@ -146,6 +146,7 @@ CREATE DATABASE IF NOT EXISTS octo_matter  CHARACTER SET utf8mb4 COLLATE utf8mb4
 CREATE DATABASE IF NOT EXISTS octo_summary CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 CREATE DATABASE IF NOT EXISTS octo_speech  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 CREATE DATABASE IF NOT EXISTS octo_docs    CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+CREATE DATABASE IF NOT EXISTS octo_marketplace CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- Service-scoped read-write accounts -----------------------------------------
 -- CREATE USER IF NOT EXISTS leaves an existing user untouched; the matching
@@ -199,4 +200,18 @@ SQL
   echo "[init-extra-dbs] provisioned docs DB user"
 fi
 
-echo "[init-extra-dbs] created octo_matter + octo_summary + octo_speech + octo_docs + service users (scoped to \`${MYSQL_DATABASE}\`)"
+echo "[init-extra-dbs] created octo_matter + octo_summary + octo_speech + octo_docs + octo_marketplace + service users (scoped to \`${MYSQL_DATABASE}\`)"
+
+# If OCTO_MARKETPLACE_DB_PASSWORD is set, provision the scoped marketplace DB
+# user. The main SQL block above already created octo_marketplace; this
+# separate step is conditional so it is safe to skip on a non-market deployment.
+if [ -n "${OCTO_MARKETPLACE_DB_PASSWORD:-}" ]; then
+  validate_password OCTO_MARKETPLACE_DB_PASSWORD "$OCTO_MARKETPLACE_DB_PASSWORD"
+  MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -u root <<SQL
+CREATE USER IF NOT EXISTS 'marketplace'@'%' IDENTIFIED BY '${OCTO_MARKETPLACE_DB_PASSWORD}';
+ALTER USER IF EXISTS      'marketplace'@'%' IDENTIFIED BY '${OCTO_MARKETPLACE_DB_PASSWORD}';
+GRANT ALL PRIVILEGES ON octo_marketplace.* TO 'marketplace'@'%';
+FLUSH PRIVILEGES;
+SQL
+  echo "[init-extra-dbs] provisioned marketplace DB user"
+fi


### PR DESCRIPTION
## Summary

Adds `octo-marketplace` as an opt-in Docker Compose profile (`market`) providing the Skill archive and MCP server management backend for the octo-web sidebar "工具" (Tools) entry.

## Changes

| File | What changed |
|------|-------------|
| `docker-compose.yaml` | New `octo-marketplace` service under `profiles: ["market"]`; `MARKET_API_URL` env on `web` (empty by default, set when profile is active); `octo-marketplace` added to minio-init bucket loops |
| `nginx/conf.d/octo.conf.template` | `/market/api/v1/` reverse-proxy → octo-marketplace:8092; `/mcp-market` SPA fallback; `octo-marketplace` added to MinIO bucket regex |
| `scripts/init-extra-dbs.sh` | `CREATE DATABASE octo_marketplace`; conditional `marketplace` DB user (gated on `OCTO_MARKETPLACE_DB_PASSWORD`) |
| `configs/minio-octo-app-policy.json` | `octo-marketplace` bucket ARNs added to both statements |

## Isolation guarantees

- Default `docker compose up -d` (no profile) starts zero marketplace services — no change to existing deployments.
- `MARKET_API_URL` on `web` defaults to empty; octo-web returns 503 gracefully when unset.
- nginx uses variable `proxy_pass` + Docker DNS resolver for marketplace locations — nginx starts cleanly even when the container is absent.
- All marketplace env vars default to empty/inert; the stack passes preflight without them.

## Enabling the marketplace

```bash
# In docker/.env — add the required variables:
OCTO_MARKETPLACE_DB_PASSWORD=59843566c0f7343b332a20dd622ee48c
OCTO_PUBLIC_BASE_URL=http://your-host:28080   # or https://your-domain
OCTO_MARKET_API_URL=http://octo-marketplace:8092

# Activate the profile:
# If COMPOSE_PROFILES is not yet set:
echo 'COMPOSE_PROFILES=market' >> .env
# If other profiles are already active:
sed -i 's/^COMPOSE_PROFILES=\(.*\)/COMPOSE_PROFILES=\1,market/' .env

docker compose up -d
```

## Known limitation — HTTP plain-text deployments

Skill archive uploads use MinIO presigned PUT URLs. For **HTTPS deployments** this works out of the box. For **plain-HTTP LAN deployments** (e.g. `http://192.168.x.x`), the octo-web frontend validates that the presigned URL hostname matches the current page origin — a fix has been submitted to octo-web (branch `fix/skill-market-http-same-origin`). Until that PR is merged and a new octo-web image is released, plain-HTTP operators will see a "URL scheme 不允许" error on skill uploads and will need to apply a temporary JS bundle patch described in that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)