### PR TITLE
feat(docs): add octo-docs-backend deployment support

### DIFF
--- a/helm/octo/README.md
+++ b/helm/octo/README.md
@@ -336,6 +336,55 @@ kubectl exec -n <ns> sts/octo-search-kafka -- \
 
 ---
 
+## Docs (optional)
+
+Real-time collaborative documents (Hocuspocus + Yjs) is an **opt-in** component, **default OFF**. With `docs.enabled=false` (the default) the chart renders **zero** docs resources.
+
+```yaml
+docs:
+  enabled: true        # default false → no docs resources rendered
+```
+
+### Enable checklist
+
+Before enabling `docs.enabled=true`:
+
+1. **MySQL database and user must exist.** On a fresh install the `init-extra-dbs.sh` init script creates them automatically. On an **existing cluster**, you must create them manually:
+   ```sql
+   CREATE DATABASE IF NOT EXISTS octo_docs CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+   CREATE USER IF NOT EXISTS 'docs'@'%' IDENTIFIED BY '<DOCS_DB_PASSWORD>';
+   GRANT ALL PRIVILEGES ON octo_docs.* TO 'docs'@'%';
+   FLUSH PRIVILEGES;
+   ```
+2. **MinIO bucket must exist.** On a fresh install the `minio-bootstrap` init container creates `octo-docs-attachments`. On an **existing cluster**, create it manually:
+   ```bash
+   mc mb octo/octo-docs-attachments
+   ```
+3. **Set the docs secrets** in your values file:
+   ```yaml
+   secrets:
+     docsDbPassword: "$(openssl rand -hex 16)"
+     docsCollabSecret: "$(openssl rand -hex 32)"
+     docsAttachmentSecret: "$(openssl rand -hex 32)"
+   ```
+
+### Limitations
+
+- **MinIO required:** Cloud storage providers (tencentCOS, aliOSS, s3, qiniu) are not supported for docs attachments. The chart fails at render time if `docs.enabled=true` with non-MinIO storage.
+- **Redis password not supported:** The octo-docs-backend image does not read `REDIS_PASSWORD`. The chart fails at render time if both `docs.enabled=true` and `secrets.redisPassword` are set. Use a Redis instance without password authentication for docs.
+
+### Verify readiness
+
+```bash
+# Check docs pod is running
+kubectl get pods -n <ns> -l app.kubernetes.io/component=docs
+
+# Check REST API health
+kubectl exec -n <ns> deploy/octo-docs -- curl -s localhost:3000/healthz
+```
+
+---
+
 ## Uninstall
 
 ```bash

--- a/helm/octo/README.md
+++ b/helm/octo/README.md
@@ -360,13 +360,15 @@ Before enabling `docs.enabled=true`:
    ```bash
    mc mb octo/octo-docs-attachments
    ```
-3. **Set the docs secrets** in your values file:
-   ```yaml
-   secrets:
-     docsDbPassword: "$(openssl rand -hex 16)"
-     docsCollabSecret: "$(openssl rand -hex 32)"
-     docsAttachmentSecret: "$(openssl rand -hex 32)"
+3. **Set the docs secrets** via `--set` flags (generate values first, then pass them):
+   ```bash
+   helm upgrade octo ./helm/octo \
+     --set secrets.docsDbPassword="$(openssl rand -hex 16)" \
+     --set secrets.docsCollabSecret="$(openssl rand -hex 32)" \
+     --set secrets.docsAttachmentSecret="$(openssl rand -hex 32)"
    ```
+   
+   > **Warning:** Do NOT put `$(...)` in a YAML values file — Helm does not execute shell commands. Generate the values first, then copy/paste, or use `--set` as shown above.
 
 ### Limitations
 

--- a/helm/octo/README.zh.md
+++ b/helm/octo/README.zh.md
@@ -360,13 +360,15 @@ docs:
    ```bash
    mc mb octo/octo-docs-attachments
    ```
-3. **设置 docs 密钥**在 values 文件中：
-   ```yaml
-   secrets:
-     docsDbPassword: "$(openssl rand -hex 16)"
-     docsCollabSecret: "$(openssl rand -hex 32)"
-     docsAttachmentSecret: "$(openssl rand -hex 32)"
+3. **设置 docs 密钥**通过 `--set` 标志（先生成值，再传入）：
+   ```bash
+   helm upgrade octo ./helm/octo \
+     --set secrets.docsDbPassword="$(openssl rand -hex 16)" \
+     --set secrets.docsCollabSecret="$(openssl rand -hex 32)" \
+     --set secrets.docsAttachmentSecret="$(openssl rand -hex 32)"
    ```
+   
+   > **警告：** 不要在 YAML values 文件中写 `$(...)`  — Helm 不会执行 shell 命令。请先生成值，再复制粘贴，或如上所示使用 `--set`。
 
 ### 限制
 

--- a/helm/octo/README.zh.md
+++ b/helm/octo/README.zh.md
@@ -336,6 +336,55 @@ kubectl exec -n <ns> sts/octo-search-kafka -- \
 
 ---
 
+## 文档协同（可选）
+
+实时协同文档（Hocuspocus + Yjs）是**可选**组件，**默认关闭**。当 `docs.enabled=false`（默认）时，chart 渲染**零**个 docs 资源。
+
+```yaml
+docs:
+  enabled: true        # 默认 false → 不渲染任何 docs 资源
+```
+
+### 启用检查清单
+
+在启用 `docs.enabled=true` 之前：
+
+1. **MySQL 数据库和用户必须存在。** 全新安装时，`init-extra-dbs.sh` 初始化脚本会自动创建。在**现有集群**上，需要手动创建：
+   ```sql
+   CREATE DATABASE IF NOT EXISTS octo_docs CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+   CREATE USER IF NOT EXISTS 'docs'@'%' IDENTIFIED BY '<DOCS_DB_PASSWORD>';
+   GRANT ALL PRIVILEGES ON octo_docs.* TO 'docs'@'%';
+   FLUSH PRIVILEGES;
+   ```
+2. **MinIO bucket 必须存在。** 全新安装时，`minio-bootstrap` init container 会创建 `octo-docs-attachments`。在**现有集群**上，需要手动创建：
+   ```bash
+   mc mb octo/octo-docs-attachments
+   ```
+3. **设置 docs 密钥**在 values 文件中：
+   ```yaml
+   secrets:
+     docsDbPassword: "$(openssl rand -hex 16)"
+     docsCollabSecret: "$(openssl rand -hex 32)"
+     docsAttachmentSecret: "$(openssl rand -hex 32)"
+   ```
+
+### 限制
+
+- **必须使用 MinIO：** 云存储提供商（tencentCOS、aliOSS、s3、qiniu）不支持 docs 附件存储。当 `docs.enabled=true` 且使用非 MinIO 存储时，chart 在渲染时报错。
+- **Redis 密码不支持：** octo-docs-backend 镜像不读取 `REDIS_PASSWORD`。当 `docs.enabled=true` 和 `secrets.redisPassword` 同时设置时，chart 在渲染时报错。请使用无密码认证的 Redis 实例。
+
+### 验证就绪
+
+```bash
+# 检查 docs pod 是否运行
+kubectl get pods -n <ns> -l app.kubernetes.io/component=docs
+
+# 检查 REST API 健康
+kubectl exec -n <ns> deploy/octo-docs -- curl -s localhost:3000/healthz
+```
+
+---
+
 ## 卸载
 
 ```bash

--- a/helm/octo/templates/_helpers.tpl
+++ b/helm/octo/templates/_helpers.tpl
@@ -137,6 +137,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s-speech-admin" (include "octo.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "octo.docs.fullname" -}}
+{{- printf "%s-docs" (include "octo.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 {{- define "octo.nginx.fullname" -}}
 {{- printf "%s-nginx" (include "octo.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}

--- a/helm/octo/templates/configmap-misc.yaml
+++ b/helm/octo/templates/configmap-misc.yaml
@@ -27,8 +27,8 @@ data:
             "arn:aws:s3:::common",
             "arn:aws:s3:::download",
             "arn:aws:s3:::group",
-            "arn:aws:s3:::avatar",
-            "arn:aws:s3:::octo-docs-attachments"
+            "arn:aws:s3:::avatar"{{- if .Values.docs.enabled }},
+            "arn:aws:s3:::octo-docs-attachments"{{- end }}
           ]
         },
         {
@@ -51,8 +51,8 @@ data:
             "arn:aws:s3:::common/*",
             "arn:aws:s3:::download/*",
             "arn:aws:s3:::group/*",
-            "arn:aws:s3:::avatar/*",
-            "arn:aws:s3:::octo-docs-attachments/*"
+            "arn:aws:s3:::avatar/*"{{- if .Values.docs.enabled }},
+            "arn:aws:s3:::octo-docs-attachments/*"{{- end }}
           ]
         }
       ]

--- a/helm/octo/templates/configmap-misc.yaml
+++ b/helm/octo/templates/configmap-misc.yaml
@@ -27,7 +27,8 @@ data:
             "arn:aws:s3:::common",
             "arn:aws:s3:::download",
             "arn:aws:s3:::group",
-            "arn:aws:s3:::avatar"
+            "arn:aws:s3:::avatar",
+            "arn:aws:s3:::octo-docs-attachments"
           ]
         },
         {
@@ -50,7 +51,8 @@ data:
             "arn:aws:s3:::common/*",
             "arn:aws:s3:::download/*",
             "arn:aws:s3:::group/*",
-            "arn:aws:s3:::avatar/*"
+            "arn:aws:s3:::avatar/*",
+            "arn:aws:s3:::octo-docs-attachments/*"
           ]
         }
       ]
@@ -67,6 +69,9 @@ data:
     : "${OCTO_SUMMARY_READER_PASSWORD:=summary_reader}"
     {{- if .Values.speech.enabled }}
     : "${OCTO_SPEECH_DB_PASSWORD:=speech}"
+    {{- end }}
+    {{- if .Values.docs.enabled }}
+    : "${OCTO_DOCS_DB_PASSWORD:=docs}"
     {{- end }}
     : "${MYSQL_DATABASE:=octo}"
 
@@ -110,11 +115,17 @@ data:
     {{- if .Values.speech.enabled }}
     validate_password  OCTO_SPEECH_DB_PASSWORD       "$OCTO_SPEECH_DB_PASSWORD"
     {{- end }}
+    {{- if .Values.docs.enabled }}
+    validate_password  OCTO_DOCS_DB_PASSWORD         "$OCTO_DOCS_DB_PASSWORD"
+    {{- end }}
     reject_literal_default OCTO_MATTER_DB_PASSWORD       "$OCTO_MATTER_DB_PASSWORD"      "matter"
     reject_literal_default OCTO_SUMMARY_DB_PASSWORD      "$OCTO_SUMMARY_DB_PASSWORD"     "summary"
     reject_literal_default OCTO_SUMMARY_READER_PASSWORD  "$OCTO_SUMMARY_READER_PASSWORD" "summary_reader"
     {{- if .Values.speech.enabled }}
     reject_literal_default OCTO_SPEECH_DB_PASSWORD       "$OCTO_SPEECH_DB_PASSWORD"      "speech"
+    {{- end }}
+    {{- if .Values.docs.enabled }}
+    reject_literal_default OCTO_DOCS_DB_PASSWORD         "$OCTO_DOCS_DB_PASSWORD"        "docs"
     {{- end }}
     validate_password  MYSQL_ROOT_PASSWORD            "$MYSQL_ROOT_PASSWORD"
     validate_identifier MYSQL_DATABASE               "$MYSQL_DATABASE"
@@ -124,6 +135,9 @@ data:
     CREATE DATABASE IF NOT EXISTS octo_summary CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
     {{- if .Values.speech.enabled }}
     CREATE DATABASE IF NOT EXISTS octo_speech  CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    {{- end }}
+    {{- if .Values.docs.enabled }}
+    CREATE DATABASE IF NOT EXISTS octo_docs    CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
     {{- end }}
 
     CREATE USER IF NOT EXISTS 'matter'@'%'  IDENTIFIED BY '${OCTO_MATTER_DB_PASSWORD}';
@@ -138,6 +152,11 @@ data:
     CREATE USER IF NOT EXISTS 'speech'@'%' IDENTIFIED BY '${OCTO_SPEECH_DB_PASSWORD}';
     ALTER USER IF EXISTS      'speech'@'%' IDENTIFIED BY '${OCTO_SPEECH_DB_PASSWORD}';
     {{- end }}
+    {{- if .Values.docs.enabled }}
+
+    CREATE USER IF NOT EXISTS 'docs'@'%' IDENTIFIED BY '${OCTO_DOCS_DB_PASSWORD}';
+    ALTER USER IF EXISTS      'docs'@'%' IDENTIFIED BY '${OCTO_DOCS_DB_PASSWORD}';
+    {{- end }}
 
     GRANT ALL PRIVILEGES ON octo_matter.*       TO 'matter'@'%';
     GRANT ALL PRIVILEGES ON octo_summary.*      TO 'summary'@'%';
@@ -145,11 +164,16 @@ data:
     {{- if .Values.speech.enabled }}
     GRANT ALL PRIVILEGES ON octo_speech.*       TO 'speech'@'%';
     {{- end }}
+    {{- if .Values.docs.enabled }}
+    GRANT ALL PRIVILEGES ON octo_docs.*         TO 'docs'@'%';
+    {{- end }}
     FLUSH PRIVILEGES;
     SQL
 
     {{- if .Values.speech.enabled }}
-    echo "[init-extra-dbs] created octo_matter + octo_summary + octo_speech + service users"
+    echo "[init-extra-dbs] created octo_matter + octo_summary + octo_speech{{- if .Values.docs.enabled }} + octo_docs{{- end }} + service users"
+    {{- else if .Values.docs.enabled }}
+    echo "[init-extra-dbs] created octo_matter + octo_summary + octo_docs + service users"
     {{- else }}
     echo "[init-extra-dbs] created octo_matter + octo_summary + service users"
     {{- end }}

--- a/helm/octo/templates/configmap-nginx.yaml
+++ b/helm/octo/templates/configmap-nginx.yaml
@@ -177,13 +177,44 @@ data:
         }
         {{- end }}
 
+        {{- if .Values.docs.enabled }}
+        location /docs-api/ {
+            limit_req zone=octo_api burst=20 nodelay;
+            rewrite ^/docs-api/(.*) /$1 break;
+            proxy_pass         http://{{ include "octo.docs.fullname" . }}:3000;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+        }
+
+        location = /docs-api {
+            return 301 /docs-api/;
+        }
+
+        location /docs-ws/ {
+            rewrite ^/docs-ws/(.*) /$1 break;
+            proxy_pass         http://{{ include "octo.docs.fullname" . }}:1234;
+            proxy_http_version 1.1;
+            proxy_set_header   Upgrade    $http_upgrade;
+            proxy_set_header   Connection "upgrade";
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_read_timeout 86400s;
+            proxy_send_timeout 86400s;
+        }
+        {{- end }}
+
         location = /_octo_up {
             default_type text/html;
             return 200 "OCTO Server is up. Visit /admin/ for the admin console.";
         }
 
         {{- if not (include "octo.isCloudStorage" .) }}
-        location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar)/.+ {
+        location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar|octo-docs-attachments)/.+ {
             proxy_pass         http://octo_minio_api;
             proxy_http_version 1.1;
             proxy_set_header   Host              $http_host;

--- a/helm/octo/templates/configmap-nginx.yaml
+++ b/helm/octo/templates/configmap-nginx.yaml
@@ -214,7 +214,7 @@ data:
         }
 
         {{- if not (include "octo.isCloudStorage" .) }}
-        location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar|octo-docs-attachments)/.+ {
+        location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar{{- if .Values.docs.enabled }}|octo-docs-attachments{{- end }})/.+ {
             proxy_pass         http://octo_minio_api;
             proxy_http_version 1.1;
             proxy_set_header   Host              $http_host;

--- a/helm/octo/templates/deployment-docs.yaml
+++ b/helm/octo/templates/deployment-docs.yaml
@@ -2,6 +2,9 @@
 {{- if include "octo.isCloudStorage" . }}
 {{- fail "docs.enabled=true requires MinIO storage (server.config.fileService=minio). Cloud storage providers (tencentCOS, aliOSS, s3, qiniu) are not supported for docs attachments." }}
 {{- end }}
+{{- if .Values.secrets.redisPassword }}
+{{- fail "docs.enabled=true is incompatible with secrets.redisPassword. The octo-docs-backend image does not support Redis authentication. Either disable docs or use a Redis instance without password authentication." }}
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -146,13 +149,6 @@ spec:
               value: {{ include "octo.redis.port" . | quote }}
             - name: REDIS_PREFIX
               value: "octo-docs"
-            {{- if .Values.secrets.redisPassword }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "octo.secretName" . }}
-                  key: REDIS_PASSWORD
-            {{- end }}
             # Collab token signing
             - name: COLLAB_TOKEN_SECRET
               valueFrom:

--- a/helm/octo/templates/deployment-docs.yaml
+++ b/helm/octo/templates/deployment-docs.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.docs.enabled }}
+{{- if include "octo.isCloudStorage" . }}
+{{- fail "docs.enabled=true requires MinIO storage (server.config.fileService=minio). Cloud storage providers (tencentCOS, aliOSS, s3, qiniu) are not supported for docs attachments." }}
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -143,6 +146,13 @@ spec:
               value: {{ include "octo.redis.port" . | quote }}
             - name: REDIS_PREFIX
               value: "octo-docs"
+            {{- if .Values.secrets.redisPassword }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: REDIS_PASSWORD
+            {{- end }}
             # Collab token signing
             - name: COLLAB_TOKEN_SECRET
               valueFrom:

--- a/helm/octo/templates/deployment-docs.yaml
+++ b/helm/octo/templates/deployment-docs.yaml
@@ -1,0 +1,156 @@
+{{- if .Values.docs.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octo.docs.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: docs
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+    - name: ws
+      port: 1234
+      targetPort: ws
+  selector:
+    {{- include "octo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: docs
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "octo.docs.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: docs
+spec:
+  replicas: {{ .Values.docs.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: docs
+  template:
+    metadata:
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: docs
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      initContainers:
+        - name: wait-for-mysql
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command: ['sh', '-c', 'until nc -z {{ include "octo.mysql.host" . }} {{ include "octo.mysql.port" . }}; do echo waiting for mysql; sleep 2; done']
+        - name: wait-for-redis
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command: ['sh', '-c', 'until nc -z {{ include "octo.redis.host" . }} {{ include "octo.redis.port" . }}; do echo waiting for redis; sleep 2; done']
+      containers:
+        - name: octo-docs-backend
+          image: {{ include "octo.image" (dict "repo" .Values.docs.image.repository "tag" .Values.docs.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.docs.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+            - name: ws
+              containerPort: 1234
+          env:
+            - name: TZ
+              value: {{ .Values.timezone | default "UTC" | quote }}
+            - name: NODE_ENV
+              value: "production"
+            - name: HTTP_PORT
+              value: "3000"
+            - name: HOCUSPOCUS_PORT
+              value: "1234"
+            - name: TRUST_PROXY
+              value: "1"
+            # MySQL connection
+            - name: MYSQL_HOST
+              value: {{ include "octo.mysql.host" . | quote }}
+            - name: MYSQL_PORT
+              value: {{ include "octo.mysql.port" . | quote }}
+            - name: MYSQL_USER
+              value: "docs"
+            - name: MYSQL_DATABASE
+              value: "octo_docs"
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: DOCS_DB_PASSWORD
+            # Redis connection
+            - name: REDIS_HOST
+              value: {{ include "octo.redis.host" . | quote }}
+            - name: REDIS_PORT
+              value: {{ include "octo.redis.port" . | quote }}
+            - name: REDIS_PREFIX
+              value: "octo-docs"
+            # Collab token signing
+            - name: COLLAB_TOKEN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: DOCS_COLLAB_SECRET
+            {{- $baseURL := include "octo.externalBaseURL" . }}
+            {{- $collabWsURL := .Values.docs.config.collabWsURL | default (printf "%s/docs-ws/" ($baseURL | replace "https://" "wss://" | replace "http://" "ws://")) }}
+            - name: COLLAB_TOKEN_PUBLIC_WS_URL
+              value: {{ $collabWsURL | quote }}
+            # Identity — delegate auth to octo-server
+            - name: OCTO_IDENTITY_MODE
+              value: "http"
+            - name: OCTO_SERVER_BASE_URL
+              value: "http://{{ include "octo.server.fullname" . }}:8090"
+            {{- $webOrigin := .Values.docs.config.webOrigin | default $baseURL }}
+            - name: OCTO_WEB_ORIGIN
+              value: {{ $webOrigin | quote }}
+            # Attachments via MinIO (s3 driver)
+            - name: ATTACHMENT_DRIVER
+              value: "s3"
+            - name: ATTACHMENT_BUCKET
+              value: "octo-docs-attachments"
+            {{- $s3Endpoint := .Values.docs.config.s3Endpoint | default $baseURL }}
+            - name: ATTACHMENT_S3_ENDPOINT
+              value: {{ $s3Endpoint | quote }}
+            - name: ATTACHMENT_S3_ACCESS_KEY
+              value: {{ include "octo.minio.appUser" . | quote }}
+            - name: ATTACHMENT_S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_MINIO_APP_PASSWORD
+            - name: ATTACHMENT_S3_FORCE_PATH_STYLE
+              value: "true"
+            - name: ATTACHMENT_SIGNING_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: DOCS_ATTACHMENT_SECRET
+            # CORS
+            {{- $corsOrigins := .Values.docs.config.corsOrigins | default $baseURL }}
+            - name: CORS_ALLOWED_ORIGINS
+              value: {{ $corsOrigins | quote }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.docs.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/helm/octo/templates/deployment-docs.yaml
+++ b/helm/octo/templates/deployment-docs.yaml
@@ -48,6 +48,60 @@ spec:
         - name: wait-for-redis
           image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
           command: ['sh', '-c', 'until nc -z {{ include "octo.redis.host" . }} {{ include "octo.redis.port" . }}; do echo waiting for redis; sleep 2; done']
+        - name: docs-schema-migrate
+          image: {{ include "octo.image" (dict "repo" .Values.docs.image.repository "tag" .Values.docs.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.docs.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              echo "[docs-migrate] Phase 1: checking schema..."
+              node - <<'JS'
+              const mysql = require('mysql2/promise');
+              const fs    = require('fs');
+              async function main() {
+                const conn = await mysql.createConnection({
+                  host:               process.env.MYSQL_HOST,
+                  port:               Number(process.env.MYSQL_PORT) || 3306,
+                  user:               process.env.MYSQL_USER,
+                  password:           process.env.MYSQL_PASSWORD,
+                  database:           process.env.MYSQL_DATABASE,
+                  multipleStatements: true,
+                });
+                const [[row]] = await conn.query(
+                  "SELECT COUNT(*) AS cnt FROM information_schema.tables WHERE table_schema = ? AND table_name = 'doc_meta'",
+                  [process.env.MYSQL_DATABASE]
+                );
+                if (row.cnt === 0) {
+                  console.log('[docs-migrate] doc_meta absent — importing schema.sql');
+                  const sql = fs.readFileSync('/app/migrations/schema.sql', 'utf8');
+                  await conn.query(sql);
+                  console.log('[docs-migrate] schema.sql imported successfully');
+                } else {
+                  console.log('[docs-migrate] schema already present, skipping schema.sql');
+                }
+                await conn.end();
+              }
+              main().catch(err => { console.error('[docs-migrate] FATAL:', err.message); process.exit(1); });
+              JS
+              echo "[docs-migrate] Phase 2: running incremental migrations..."
+              node dist/db/migrate.js
+              echo "[docs-migrate] done"
+          env:
+            - name: MYSQL_HOST
+              value: {{ include "octo.mysql.host" . | quote }}
+            - name: MYSQL_PORT
+              value: {{ include "octo.mysql.port" . | quote }}
+            - name: MYSQL_USER
+              value: "docs"
+            - name: MYSQL_DATABASE
+              value: "octo_docs"
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: DOCS_DB_PASSWORD
       containers:
         - name: octo-docs-backend
           image: {{ include "octo.image" (dict "repo" .Values.docs.image.repository "tag" .Values.docs.image.tag "ctx" .) }}

--- a/helm/octo/templates/deployment-octo-server.yaml
+++ b/helm/octo/templates/deployment-octo-server.yaml
@@ -119,7 +119,7 @@ spec:
               echo "[minio-bootstrap] attaching policy to $OCTO_MINIO_APP_USER..."
               mc admin policy attach local octo-app --user "$OCTO_MINIO_APP_USER" 2>/dev/null || true
 
-              for b in file chat moment sticker report chatbg common download group avatar; do
+              for b in file chat moment sticker report chatbg common download group avatar octo-docs-attachments; do
                 mc mb --ignore-existing "local/$b" >/dev/null
               done
 

--- a/helm/octo/templates/deployment-octo-server.yaml
+++ b/helm/octo/templates/deployment-octo-server.yaml
@@ -119,7 +119,7 @@ spec:
               echo "[minio-bootstrap] attaching policy to $OCTO_MINIO_APP_USER..."
               mc admin policy attach local octo-app --user "$OCTO_MINIO_APP_USER" 2>/dev/null || true
 
-              for b in file chat moment sticker report chatbg common download group avatar octo-docs-attachments; do
+              for b in file chat moment sticker report chatbg common download group avatar{{- if .Values.docs.enabled }} octo-docs-attachments{{- end }}; do
                 mc mb --ignore-existing "local/$b" >/dev/null
               done
 

--- a/helm/octo/templates/secret.yaml
+++ b/helm/octo/templates/secret.yaml
@@ -46,6 +46,11 @@ data:
   SPEECH_ADMIN_PASSWORD:        {{ required "secrets.speechAdminPassword must be set when speech.enabled=true" .Values.secrets.speechAdminPassword | b64enc | quote }}
   SPEECH_ADMIN_JWT_SECRET:      {{ required "secrets.speechAdminJwtSecret must be set when speech.enabled=true" .Values.secrets.speechAdminJwtSecret | b64enc | quote }}
   {{- end }}
+  {{- if .Values.docs.enabled }}
+  DOCS_DB_PASSWORD:             {{ required "secrets.docsDbPassword must be set when docs.enabled=true" .Values.secrets.docsDbPassword | b64enc | quote }}
+  DOCS_COLLAB_SECRET:           {{ required "secrets.docsCollabSecret must be set when docs.enabled=true (min 32 chars)" .Values.secrets.docsCollabSecret | b64enc | quote }}
+  DOCS_ATTACHMENT_SECRET:       {{ required "secrets.docsAttachmentSecret must be set when docs.enabled=true (min 32 chars)" .Values.secrets.docsAttachmentSecret | b64enc | quote }}
+  {{- end }}
   {{- if .Values.secrets.redisPassword }}
   REDIS_PASSWORD:               {{ .Values.secrets.redisPassword | b64enc | quote }}
   {{- end }}

--- a/helm/octo/templates/secret.yaml
+++ b/helm/octo/templates/secret.yaml
@@ -47,9 +47,23 @@ data:
   SPEECH_ADMIN_JWT_SECRET:      {{ required "secrets.speechAdminJwtSecret must be set when speech.enabled=true" .Values.secrets.speechAdminJwtSecret | b64enc | quote }}
   {{- end }}
   {{- if .Values.docs.enabled }}
+  {{- $collabSecret := required "secrets.docsCollabSecret must be set when docs.enabled=true (min 32 chars)" .Values.secrets.docsCollabSecret }}
+  {{- if lt (len $collabSecret) 32 }}
+  {{- fail "secrets.docsCollabSecret must be at least 32 characters for secure JWT signing" }}
+  {{- end }}
+  {{- if hasPrefix "CHANGE_ME" $collabSecret }}
+  {{- fail "secrets.docsCollabSecret is still a placeholder (CHANGE_ME*). Generate a real secret: openssl rand -hex 32" }}
+  {{- end }}
+  {{- $attachSecret := required "secrets.docsAttachmentSecret must be set when docs.enabled=true (min 32 chars)" .Values.secrets.docsAttachmentSecret }}
+  {{- if lt (len $attachSecret) 32 }}
+  {{- fail "secrets.docsAttachmentSecret must be at least 32 characters for secure HMAC signing" }}
+  {{- end }}
+  {{- if hasPrefix "CHANGE_ME" $attachSecret }}
+  {{- fail "secrets.docsAttachmentSecret is still a placeholder (CHANGE_ME*). Generate a real secret: openssl rand -hex 32" }}
+  {{- end }}
   DOCS_DB_PASSWORD:             {{ required "secrets.docsDbPassword must be set when docs.enabled=true" .Values.secrets.docsDbPassword | b64enc | quote }}
-  DOCS_COLLAB_SECRET:           {{ required "secrets.docsCollabSecret must be set when docs.enabled=true (min 32 chars)" .Values.secrets.docsCollabSecret | b64enc | quote }}
-  DOCS_ATTACHMENT_SECRET:       {{ required "secrets.docsAttachmentSecret must be set when docs.enabled=true (min 32 chars)" .Values.secrets.docsAttachmentSecret | b64enc | quote }}
+  DOCS_COLLAB_SECRET:           {{ $collabSecret | b64enc | quote }}
+  DOCS_ATTACHMENT_SECRET:       {{ $attachSecret | b64enc | quote }}
   {{- end }}
   {{- if .Values.secrets.redisPassword }}
   REDIS_PASSWORD:               {{ .Values.secrets.redisPassword | b64enc | quote }}

--- a/helm/octo/templates/statefulset-mysql.yaml
+++ b/helm/octo/templates/statefulset-mysql.yaml
@@ -82,6 +82,13 @@ spec:
                   name: {{ include "octo.secretName" . }}
                   key: SPEECH_DB_PASSWORD
             {{- end }}
+            {{- if .Values.docs.enabled }}
+            - name: OCTO_DOCS_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: DOCS_DB_PASSWORD
+            {{- end }}
           readinessProbe:
             exec:
               command:

--- a/helm/octo/values.yaml
+++ b/helm/octo/values.yaml
@@ -120,6 +120,11 @@ secrets:
   speechAdminPassword: ""
   speechAdminJwtSecret: ""
 
+  # Docs credentials. Required only when docs.enabled=true.
+  docsDbPassword: ""          # Password for the 'docs' MySQL user
+  docsCollabSecret: ""        # JWT signing secret for collab tokens (min 32 chars)
+  docsAttachmentSecret: ""    # HMAC secret for attachment presigned URLs (min 32 chars)
+
   # Inbound webhook HMAC secret (optional).
   webhookSecretKey: ""
 
@@ -488,6 +493,37 @@ speech:
       repository: curlimages/curl
       tag: "8.10.1"
       pullPolicy: IfNotPresent
+
+# =============================================================================
+# Docs (octo-docs-backend: Hocuspocus + Yjs real-time collaborative documents)
+# =============================================================================
+docs:
+  enabled: false
+  image:
+    repository: mininglamposs/octo-docs-backend
+    tag: "0.4.0"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  config:
+    # Public WebSocket URL for Hocuspocus collab (browser-reachable)
+    # Defaults to ws://{{ domain }}:{{ nginx.service.port }}/docs-ws/
+    collabWsURL: ""
+    # Public web origin for shareable doc links
+    # Defaults to http://{{ domain }}:{{ nginx.service.port }}
+    webOrigin: ""
+    # S3 endpoint for attachments (browser-reachable for presigned URLs)
+    # Defaults to http://{{ domain }}:{{ nginx.service.port }}
+    s3Endpoint: ""
+    # CORS allowed origins (comma-separated or *)
+    # Defaults to http://{{ domain }}:{{ nginx.service.port }}
+    corsOrigins: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
 
 # =============================================================================
 # Search pipeline (Kafka + OpenSearch[analysis-ik] + es-indexer) — OPT-IN.

--- a/kustomize/docs/README.md
+++ b/kustomize/docs/README.md
@@ -20,14 +20,18 @@ Before applying this kustomization:
 ## Quick Start
 
 ```bash
-# 1. Create the secret (edit values first!)
+# 1. Create the secret FIRST (required - the kustomization does not include it)
 cp docs-secret.example.yaml docs-secret.yaml
-# Edit docs-secret.yaml with real credentials
+# Edit docs-secret.yaml with real credentials - DO NOT use placeholder values!
 kubectl apply -f docs-secret.yaml -n <namespace>
 
 # 2. Apply the docs kustomization
 kubectl apply -k kustomize/docs -n <namespace>
 ```
+
+> **Important**: The Secret is intentionally NOT included in the kustomization
+> resources to prevent accidental deployment with placeholder credentials.
+> You MUST create the Secret manually before applying.
 
 ## Configuration
 

--- a/kustomize/docs/README.md
+++ b/kustomize/docs/README.md
@@ -84,8 +84,10 @@ images:
 
 ## Database Initialization
 
-The docs-backend image includes migration scripts. On first run:
-1. Base schema is bootstrapped from `schema.sql` when `doc_meta` table is absent
-2. Incremental migrations are applied from `/app/migrations/upgrades/`
+The deployment includes a `docs-schema-migrate` init container that runs before the main container starts:
+1. Phase 1: Checks if `doc_meta` table exists; if absent, imports base schema from `schema.sql`
+2. Phase 2: Runs `node dist/db/migrate.js` for incremental migrations
 
-Minimum image version: `>= 0.3.0` (ships migrate.js and upgrades/).
+This ensures the database schema is ready before the application starts.
+
+Minimum image version: `>= 0.3.0` (ships migrate.js and schema.sql).

--- a/kustomize/docs/README.md
+++ b/kustomize/docs/README.md
@@ -16,6 +16,7 @@ Before applying this kustomization:
 2. **Redis**: Available at `redis:6379` (reuses the existing instance)
 3. **MinIO**: The `octo-docs-attachments` bucket must be created
 4. **Secret**: Create `docs-secret` from the example
+5. **Nginx**: Configure routes for `/docs-api/` and `/docs-ws/` (see [Nginx Routing](#nginx-routing) below)
 
 ## Quick Start
 
@@ -67,7 +68,36 @@ openssl rand -hex 16  # For MYSQL_PASSWORD
 
 ## Nginx Routing
 
-The docs service should be exposed through nginx with these routes:
+**Important**: This kustomization does NOT include nginx configuration. You must manually add the following routes to your nginx ConfigMap or configuration.
+
+Add these location blocks to your nginx server configuration:
+
+```nginx
+# REST API — docs CRUD, collab-token issuance, attachments
+location /docs-api/ {
+    proxy_pass http://octo-docs-backend:3000/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+
+# WebSocket — Hocuspocus real-time Yjs sync
+location /docs-ws/ {
+    proxy_pass http://octo-docs-backend:1234/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 86400s;
+    proxy_send_timeout 86400s;
+}
+```
+
+Routes:
 - `/docs-api/` → `octo-docs-backend:3000` (REST API)
 - `/docs-ws/` → `octo-docs-backend:1234` (WebSocket)
 

--- a/kustomize/docs/README.md
+++ b/kustomize/docs/README.md
@@ -1,0 +1,87 @@
+# Docs Pipeline (Kustomize)
+
+Real-time collaborative document backend (Hocuspocus + Yjs) for OCTO.
+
+## Overview
+
+This kustomization deploys `octo-docs-backend`, a Node.js service that provides:
+- REST API on port 3000 for document CRUD and collab-token issuance
+- Hocuspocus WebSocket server on port 1234 for real-time Yjs sync
+
+## Prerequisites
+
+Before applying this kustomization:
+
+1. **MySQL**: The `octo_docs` database must exist with a `docs` user
+2. **Redis**: Available at `redis:6379` (reuses the existing instance)
+3. **MinIO**: The `octo-docs-attachments` bucket must be created
+4. **Secret**: Create `docs-secret` from the example
+
+## Quick Start
+
+```bash
+# 1. Create the secret (edit values first!)
+cp docs-secret.example.yaml docs-secret.yaml
+# Edit docs-secret.yaml with real credentials
+kubectl apply -f docs-secret.yaml -n <namespace>
+
+# 2. Apply the docs kustomization
+kubectl apply -k kustomize/docs -n <namespace>
+```
+
+## Configuration
+
+### ConfigMap (docs-config)
+
+Non-sensitive configuration in `docs-configmap.yaml`:
+- Database connection settings (host, port, user, database name)
+- Redis connection settings
+- MinIO bucket and driver configuration
+- Identity provider settings (delegates to octo-server)
+
+### Secret (docs-secret)
+
+Sensitive configuration must be created from `docs-secret.example.yaml`:
+
+| Key | Description |
+|-----|-------------|
+| `MYSQL_PASSWORD` | Password for the `docs` MySQL user |
+| `COLLAB_TOKEN_SECRET` | JWT signing secret for Hocuspocus tokens (min 32 chars) |
+| `ATTACHMENT_SIGNING_SECRET` | HMAC secret for attachment presigned URLs (min 32 chars) |
+| `COLLAB_TOKEN_PUBLIC_WS_URL` | Browser-reachable WebSocket URL (e.g. `ws://octo.example.com/docs-ws/`) |
+| `OCTO_WEB_ORIGIN` | Public URL where octo-web is served |
+| `ATTACHMENT_S3_ENDPOINT` | Browser-reachable S3/MinIO endpoint |
+| `ATTACHMENT_S3_ACCESS_KEY` | MinIO access key (use `octo-app`, not root) |
+| `ATTACHMENT_S3_SECRET_KEY` | MinIO secret key |
+| `CORS_ALLOWED_ORIGINS` | CORS allowed origins (comma-separated or `*`) |
+
+Generate secrets with:
+```bash
+openssl rand -hex 32  # For COLLAB_TOKEN_SECRET and ATTACHMENT_SIGNING_SECRET
+openssl rand -hex 16  # For MYSQL_PASSWORD
+```
+
+## Nginx Routing
+
+The docs service should be exposed through nginx with these routes:
+- `/docs-api/` → `octo-docs-backend:3000` (REST API)
+- `/docs-ws/` → `octo-docs-backend:1234` (WebSocket)
+
+## Image Override
+
+To use a different image tag:
+
+```yaml
+# kustomization.yaml
+images:
+  - name: mininglamposs/octo-docs-backend
+    newTag: "0.5.0"  # Your desired version
+```
+
+## Database Initialization
+
+The docs-backend image includes migration scripts. On first run:
+1. Base schema is bootstrapped from `schema.sql` when `doc_meta` table is absent
+2. Incremental migrations are applied from `/app/migrations/upgrades/`
+
+Minimum image version: `>= 0.3.0` (ships migrate.js and upgrades/).

--- a/kustomize/docs/README.zh.md
+++ b/kustomize/docs/README.zh.md
@@ -1,0 +1,90 @@
+# 文档协同服务 (Kustomize)
+
+OCTO 实时协同文档后端（Hocuspocus + Yjs）。
+
+## 概述
+
+此 kustomization 部署 `octo-docs-backend`，一个 Node.js 服务：
+- REST API（端口 3000）：文档 CRUD 与协同令牌签发
+- Hocuspocus WebSocket 服务器（端口 1234）：Yjs 实时同步
+
+## 前置条件
+
+应用此 kustomization 之前：
+
+1. **MySQL**：`octo_docs` 数据库必须存在，并创建 `docs` 用户
+2. **Redis**：可访问 `redis:6379`（复用现有实例）
+3. **MinIO**：`octo-docs-attachments` 存储桶必须创建
+4. **Secret**：从示例文件创建 `docs-secret`
+
+## 快速开始
+
+```bash
+# 1. 首先创建 Secret（必须 - kustomization 中不包含它）
+cp docs-secret.example.yaml docs-secret.yaml
+# 编辑 docs-secret.yaml 填入真实凭据 - 不要使用占位符！
+kubectl apply -f docs-secret.yaml -n <namespace>
+
+# 2. 应用 docs kustomization
+kubectl apply -k kustomize/docs -n <namespace>
+```
+
+> **重要提示**：Secret 未包含在 kustomization resources 中是故意的，
+> 以防止使用占位符凭据意外部署。应用之前**必须**手动创建 Secret。
+
+## 配置项
+
+### ConfigMap (docs-config)
+
+非敏感配置位于 `docs-configmap.yaml`：
+- 数据库连接设置（host、port、user、database）
+- Redis 连接设置
+- MinIO 存储桶和驱动配置
+- 身份认证设置（委托给 octo-server）
+
+### Secret (docs-secret)
+
+敏感配置需从 `docs-secret.example.yaml` 创建：
+
+| 键名 | 说明 |
+|-----|------|
+| `MYSQL_PASSWORD` | `docs` MySQL 用户密码 |
+| `COLLAB_TOKEN_SECRET` | Hocuspocus 令牌签名密钥（至少 32 字符）|
+| `ATTACHMENT_SIGNING_SECRET` | 附件预签名 URL 的 HMAC 密钥（至少 32 字符）|
+| `COLLAB_TOKEN_PUBLIC_WS_URL` | 浏览器可访问的 WebSocket 地址（如 `ws://octo.example.com/docs-ws/`）|
+| `OCTO_WEB_ORIGIN` | octo-web 的公开访问地址 |
+| `ATTACHMENT_S3_ENDPOINT` | 浏览器可访问的 S3/MinIO 端点 |
+| `ATTACHMENT_S3_ACCESS_KEY` | MinIO 访问密钥（使用 `octo-app`，非 root）|
+| `ATTACHMENT_S3_SECRET_KEY` | MinIO 密钥 |
+| `CORS_ALLOWED_ORIGINS` | CORS 允许的来源（逗号分隔或 `*`）|
+
+生成密钥：
+```bash
+openssl rand -hex 32  # 用于 COLLAB_TOKEN_SECRET 和 ATTACHMENT_SIGNING_SECRET
+openssl rand -hex 16  # 用于 MYSQL_PASSWORD
+```
+
+## Nginx 路由
+
+docs 服务需通过 nginx 暴露以下路由：
+- `/docs-api/` → `octo-docs-backend:3000`（REST API）
+- `/docs-ws/` → `octo-docs-backend:1234`（WebSocket）
+
+## 镜像版本
+
+使用不同镜像版本：
+
+```yaml
+# kustomization.yaml
+images:
+  - name: mininglamposs/octo-docs-backend
+    newTag: "0.5.0"  # 指定版本
+```
+
+## 数据库初始化
+
+docs-backend 镜像内置迁移脚本。首次启动时：
+1. 当 `doc_meta` 表不存在时，从 `schema.sql` 导入基础 schema
+2. 从 `/app/migrations/upgrades/` 执行增量迁移
+
+最低镜像版本要求：`>= 0.3.0`（包含 migrate.js 和 upgrades/）。

--- a/kustomize/docs/README.zh.md
+++ b/kustomize/docs/README.zh.md
@@ -16,6 +16,7 @@ OCTO 实时协同文档后端（Hocuspocus + Yjs）。
 2. **Redis**：可访问 `redis:6379`（复用现有实例）
 3. **MinIO**：`octo-docs-attachments` 存储桶必须创建
 4. **Secret**：从示例文件创建 `docs-secret`
+5. **Nginx**：配置 `/docs-api/` 和 `/docs-ws/` 路由（见下方 [Nginx 路由](#nginx-路由)）
 
 ## 快速开始
 
@@ -66,7 +67,36 @@ openssl rand -hex 16  # 用于 MYSQL_PASSWORD
 
 ## Nginx 路由
 
-docs 服务需通过 nginx 暴露以下路由：
+**重要提示**：此 kustomization 不包含 nginx 配置。您必须手动将以下路由添加到 nginx ConfigMap 或配置中。
+
+将以下 location 块添加到 nginx server 配置：
+
+```nginx
+# REST API — 文档 CRUD、协同令牌签发、附件
+location /docs-api/ {
+    proxy_pass http://octo-docs-backend:3000/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+
+# WebSocket — Hocuspocus 实时 Yjs 同步
+location /docs-ws/ {
+    proxy_pass http://octo-docs-backend:1234/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 86400s;
+    proxy_send_timeout 86400s;
+}
+```
+
+路由说明：
 - `/docs-api/` → `octo-docs-backend:3000`（REST API）
 - `/docs-ws/` → `octo-docs-backend:1234`（WebSocket）
 

--- a/kustomize/docs/README.zh.md
+++ b/kustomize/docs/README.zh.md
@@ -83,8 +83,10 @@ images:
 
 ## 数据库初始化
 
-docs-backend 镜像内置迁移脚本。首次启动时：
-1. 当 `doc_meta` 表不存在时，从 `schema.sql` 导入基础 schema
-2. 从 `/app/migrations/upgrades/` 执行增量迁移
+部署包含 `docs-schema-migrate` init container，在主容器启动前运行：
+1. 阶段 1：检查 `doc_meta` 表是否存在，不存在则从 `schema.sql` 导入基础 schema
+2. 阶段 2：执行 `node dist/db/migrate.js` 增量迁移
 
-最低镜像版本要求：`>= 0.3.0`（包含 migrate.js 和 upgrades/）。
+这确保数据库 schema 在应用启动前已就绪。
+
+最低镜像版本要求：`>= 0.3.0`（包含 migrate.js 和 schema.sql）。

--- a/kustomize/docs/docs-backend.yaml
+++ b/kustomize/docs/docs-backend.yaml
@@ -50,6 +50,51 @@ spec:
         - name: wait-for-redis
           image: busybox:1.36
           command: ['sh', '-c', 'until nc -z redis 6379; do echo waiting for redis; sleep 2; done']
+        - name: docs-schema-migrate
+          image: mininglamposs/octo-docs-backend:0.4.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              echo "[docs-migrate] Phase 1: checking schema..."
+              node - <<'JS'
+              const mysql = require('mysql2/promise');
+              const fs    = require('fs');
+              async function main() {
+                const conn = await mysql.createConnection({
+                  host:               process.env.MYSQL_HOST,
+                  port:               Number(process.env.MYSQL_PORT) || 3306,
+                  user:               process.env.MYSQL_USER,
+                  password:           process.env.MYSQL_PASSWORD,
+                  database:           process.env.MYSQL_DATABASE,
+                  multipleStatements: true,
+                });
+                const [[row]] = await conn.query(
+                  "SELECT COUNT(*) AS cnt FROM information_schema.tables WHERE table_schema = ? AND table_name = 'doc_meta'",
+                  [process.env.MYSQL_DATABASE]
+                );
+                if (row.cnt === 0) {
+                  console.log('[docs-migrate] doc_meta absent — importing schema.sql');
+                  const sql = fs.readFileSync('/app/migrations/schema.sql', 'utf8');
+                  await conn.query(sql);
+                  console.log('[docs-migrate] schema.sql imported successfully');
+                } else {
+                  console.log('[docs-migrate] schema already present, skipping schema.sql');
+                }
+                await conn.end();
+              }
+              main().catch(err => { console.error('[docs-migrate] FATAL:', err.message); process.exit(1); });
+              JS
+              echo "[docs-migrate] Phase 2: running incremental migrations..."
+              node dist/db/migrate.js
+              echo "[docs-migrate] done"
+          envFrom:
+            - configMapRef:
+                name: docs-config
+            - secretRef:
+                name: docs-secret
       containers:
         - name: octo-docs-backend
           image: mininglamposs/octo-docs-backend:0.4.0

--- a/kustomize/docs/docs-backend.yaml
+++ b/kustomize/docs/docs-backend.yaml
@@ -1,0 +1,89 @@
+# octo-docs-backend: Hocuspocus + Yjs real-time collaborative document backend
+#
+# Two listeners in one process:
+#   REST API   :3000  — docs CRUD, collab-token issuance, attachments
+#   Hocuspocus :1234  — real-time Yjs WebSocket sync
+#
+# Prerequisites:
+#   - MySQL with `octo_docs` database created
+#   - Redis available at redis:6379
+#   - MinIO with `octo-docs-attachments` bucket created
+#   - docs-secret created with required credentials
+apiVersion: v1
+kind: Service
+metadata:
+  name: octo-docs-backend
+  labels:
+    app: octo-docs-backend
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+    - name: ws
+      port: 1234
+      targetPort: ws
+  selector:
+    app: octo-docs-backend
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: octo-docs-backend
+  labels:
+    app: octo-docs-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: octo-docs-backend
+  template:
+    metadata:
+      labels:
+        app: octo-docs-backend
+    spec:
+      initContainers:
+        - name: wait-for-mysql
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z mysql 3306; do echo waiting for mysql; sleep 2; done']
+        - name: wait-for-redis
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z redis 6379; do echo waiting for redis; sleep 2; done']
+      containers:
+        - name: octo-docs-backend
+          image: mininglamposs/octo-docs-backend:0.4.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+            - name: ws
+              containerPort: 1234
+          envFrom:
+            - configMapRef:
+                name: docs-config
+            - secretRef:
+                name: docs-secret
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi

--- a/kustomize/docs/docs-configmap.yaml
+++ b/kustomize/docs/docs-configmap.yaml
@@ -22,7 +22,7 @@ data:
   REDIS_PREFIX: "octo-docs"
   # Identity — delegate auth to octo-server
   OCTO_IDENTITY_MODE: "http"
-  OCTO_SERVER_BASE_URL: "http://octo-server:8090"
+  OCTO_SERVER_BASE_URL: "http://octo-server:80"
   # Attachments via MinIO (s3 driver)
   ATTACHMENT_DRIVER: "s3"
   ATTACHMENT_BUCKET: "octo-docs-attachments"

--- a/kustomize/docs/docs-configmap.yaml
+++ b/kustomize/docs/docs-configmap.yaml
@@ -1,0 +1,29 @@
+# ConfigMap for octo-docs-backend configuration
+# Non-sensitive environment variables for the docs service.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: docs-config
+  labels:
+    app: octo-docs-backend
+data:
+  NODE_ENV: "production"
+  HTTP_PORT: "3000"
+  HOCUSPOCUS_PORT: "1234"
+  TRUST_PROXY: "1"
+  # MySQL connection (password comes from Secret)
+  MYSQL_HOST: "mysql"
+  MYSQL_PORT: "3306"
+  MYSQL_USER: "docs"
+  MYSQL_DATABASE: "octo_docs"
+  # Redis connection (reuses existing instance)
+  REDIS_HOST: "redis"
+  REDIS_PORT: "6379"
+  REDIS_PREFIX: "octo-docs"
+  # Identity — delegate auth to octo-server
+  OCTO_IDENTITY_MODE: "http"
+  OCTO_SERVER_BASE_URL: "http://octo-server:8090"
+  # Attachments via MinIO (s3 driver)
+  ATTACHMENT_DRIVER: "s3"
+  ATTACHMENT_BUCKET: "octo-docs-attachments"
+  ATTACHMENT_S3_FORCE_PATH_STYLE: "true"

--- a/kustomize/docs/docs-secret.example.yaml
+++ b/kustomize/docs/docs-secret.example.yaml
@@ -1,0 +1,59 @@
+# Example Secret for octo-docs-backend
+#
+# Copy this file to docs-secret.yaml and fill in real values, then apply:
+#   kubectl create secret generic docs-secret --from-file=docs-secret.yaml
+#
+# Or create directly with kubectl:
+#   kubectl create secret generic docs-secret \
+#     --from-literal=MYSQL_PASSWORD='<your-docs-db-password>' \
+#     --from-literal=COLLAB_TOKEN_SECRET='<openssl rand -hex 32>' \
+#     --from-literal=ATTACHMENT_SIGNING_SECRET='<openssl rand -hex 32>' \
+#     --from-literal=COLLAB_TOKEN_PUBLIC_WS_URL='ws://your-domain:port/docs-ws/' \
+#     --from-literal=OCTO_WEB_ORIGIN='http://your-domain:port' \
+#     --from-literal=ATTACHMENT_S3_ENDPOINT='http://your-domain:port' \
+#     --from-literal=ATTACHMENT_S3_ACCESS_KEY='<minio-app-user>' \
+#     --from-literal=ATTACHMENT_S3_SECRET_KEY='<minio-app-password>' \
+#     --from-literal=CORS_ALLOWED_ORIGINS='http://your-domain:port' \
+#     -n <namespace>
+#
+# Required values:
+#   MYSQL_PASSWORD             — Password for the 'docs' MySQL user
+#   COLLAB_TOKEN_SECRET        — JWT signing secret for Hocuspocus tokens (min 32 chars)
+#   ATTACHMENT_SIGNING_SECRET  — HMAC secret for attachment presigned URLs (min 32 chars)
+#   COLLAB_TOKEN_PUBLIC_WS_URL — Browser-reachable WebSocket URL for Hocuspocus
+#   OCTO_WEB_ORIGIN            — Public URL where octo-web is served from
+#   ATTACHMENT_S3_ENDPOINT     — Browser-reachable S3/MinIO endpoint for attachments
+#   ATTACHMENT_S3_ACCESS_KEY   — MinIO/S3 access key (e.g. octo-app user)
+#   ATTACHMENT_S3_SECRET_KEY   — MinIO/S3 secret key
+#   CORS_ALLOWED_ORIGINS       — CORS allowed origins (comma-separated or *)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: docs-secret
+  labels:
+    app: octo-docs-backend
+type: Opaque
+stringData:
+  # MySQL password for the 'docs' user
+  MYSQL_PASSWORD: "CHANGE_ME_docs_db_password"
+  # JWT signing secret for short-lived Hocuspocus collab tokens (min 32 chars)
+  # Generate with: openssl rand -hex 32
+  COLLAB_TOKEN_SECRET: "CHANGE_ME_collab_token_secret_min_32_chars"
+  # HMAC signing secret for attachment presigned URLs (min 32 chars)
+  # Generate with: openssl rand -hex 32
+  ATTACHMENT_SIGNING_SECRET: "CHANGE_ME_attachment_signing_secret"
+  # Browser-reachable WebSocket URL for Hocuspocus collab WS
+  # Example: ws://octo.example.com/docs-ws/ (nginx proxies /docs-ws/ → :1234)
+  COLLAB_TOKEN_PUBLIC_WS_URL: "ws://localhost:28080/docs-ws/"
+  # Public web origin (the URL users open octo-web from)
+  # Used to build shareable doc links returned to callers
+  OCTO_WEB_ORIGIN: "http://localhost:28080"
+  # S3-compatible endpoint for attachment storage (MinIO)
+  # Must be browser-reachable for presigned URL PUT/GET
+  ATTACHMENT_S3_ENDPOINT: "http://localhost:28080"
+  # MinIO/S3 credentials (use octo-app user, not root)
+  ATTACHMENT_S3_ACCESS_KEY: "octo-app"
+  ATTACHMENT_S3_SECRET_KEY: "CHANGE_ME_minio_app_password"
+  # CORS allowed origins for the docs REST API
+  # Comma-separated exact origins, or * to allow all
+  CORS_ALLOWED_ORIGINS: "http://localhost:28080"

--- a/kustomize/docs/kustomization.yaml
+++ b/kustomize/docs/kustomization.yaml
@@ -1,0 +1,28 @@
+# Docs pipeline (octo-docs-backend: Hocuspocus + Yjs real-time collaborative documents)
+#
+# This kustomization is INTENTIONALLY NOT referenced by kustomize/base or any
+# overlay (dev/prod). Applying the default base/overlays deploys ZERO docs
+# resources. An operator opts in explicitly and on a separate, owner-gated
+# action, e.g.:
+#
+#   kubectl apply -k kustomize/docs -n <ns>
+#
+# Everything here is additive: it adds new workloads, services, and ConfigMaps
+# and does not modify any core OCTO resource. See README.md in this directory.
+#
+# Prerequisites:
+#   - MySQL must be running with the `octo_docs` database created
+#   - Redis must be available (reuses the existing instance)
+#   - MinIO must be running with the `octo-docs-attachments` bucket created
+#   - Create the docs-secret from docs-secret.example.yaml with real credentials
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - docs-configmap.yaml
+  - docs-backend.yaml
+  - docs-secret.example.yaml
+
+images:
+  - name: mininglamposs/octo-docs-backend
+    newTag: "0.4.0"

--- a/kustomize/docs/kustomization.yaml
+++ b/kustomize/docs/kustomization.yaml
@@ -21,7 +21,9 @@ kind: Kustomization
 resources:
   - docs-configmap.yaml
   - docs-backend.yaml
-  - docs-secret.example.yaml
+  # NOTE: docs-secret.example.yaml is NOT included here intentionally.
+  # Operators must create their own Secret with real credentials before applying.
+  # See docs-secret.example.yaml for the required keys and README.md for instructions.
 
 images:
   - name: mininglamposs/octo-docs-backend


### PR DESCRIPTION
## Summary
Add Kustomize and Helm deployment support for octo-docs-backend (real-time collaborative documents using Hocuspocus + Yjs).

### Kustomize (`kustomize/docs/`)
- `kustomization.yaml` — Resource manifest and image tag management
- `docs-configmap.yaml` — Non-sensitive configuration
- `docs-backend.yaml` — Deployment + Service (ports 3000 REST, 1234 WebSocket)
- `docs-secret.example.yaml` — Secret template (NOT included in resources)
- `README.md` — Usage documentation

### Helm Chart
- Add `docs:` section to `values.yaml` (disabled by default)
- Add `templates/deployment-docs.yaml` template
- Update `configmap-nginx.yaml` with `/docs-api/` and `/docs-ws/` routes
- Update `configmap-misc.yaml` for MinIO policy and MySQL init
- Update `deployment-octo-server.yaml` for conditional bucket creation
- Update `secret.yaml` with docs secrets

### Excluded (per scope)
- No octo-docs-html components

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #173