### PR TITLE
feat(marketplace): add Kustomize and Helm deployment configs

### DIFF
--- a/helm/octo/Chart.yaml
+++ b/helm/octo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: octo
 description: OCTO Server — self-hosted enterprise messaging platform (IM + AI)
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "latest"
 keywords:
   - octo

--- a/helm/octo/README.md
+++ b/helm/octo/README.md
@@ -387,6 +387,55 @@ kubectl exec -n <ns> deploy/octo-docs -- curl -s localhost:3000/healthz
 
 ---
 
+## Marketplace (optional)
+
+Skill / bot / MCP catalog service is an **opt-in** component, **default OFF**. With `marketplace.enabled=false` (the default) the chart renders **zero** marketplace resources.
+
+```yaml
+marketplace:
+  enabled: true        # default false → no marketplace resources rendered
+```
+
+### Enable checklist
+
+Before enabling `marketplace.enabled=true`:
+
+1. **MySQL database and user must exist.** On a fresh install the `init-extra-dbs.sh` init script creates them automatically. On an **existing cluster**, you must create them manually:
+   ```sql
+   CREATE DATABASE IF NOT EXISTS octo_marketplace CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+   CREATE USER IF NOT EXISTS 'marketplace'@'%' IDENTIFIED BY '<MARKETPLACE_DB_PASSWORD>';
+   GRANT ALL PRIVILEGES ON octo_marketplace.* TO 'marketplace'@'%';
+   FLUSH PRIVILEGES;
+   ```
+2. **MinIO bucket must exist.** On a fresh install the `minio-bootstrap` init container creates `marketplace`. On an **existing cluster**, create it manually:
+   ```bash
+   mc mb octo/marketplace
+   ```
+3. **Set the marketplace secret** via `--set` flag (generate value first, then pass it):
+   ```bash
+   helm upgrade octo ./helm/octo \
+     --set secrets.marketplaceDbPassword="$(openssl rand -hex 16)"
+   ```
+   
+   > **Warning:** Do NOT put `$(...)` in a YAML values file — Helm does not execute shell commands. Generate the value first, then copy/paste, or use `--set` as shown above.
+
+### Limitations
+
+- **MinIO required:** Cloud storage providers (tencentCOS, aliOSS, s3, qiniu) are not supported for marketplace. The chart fails at render time if `marketplace.enabled=true` with non-MinIO storage.
+- **Redis password not supported:** The octo-marketplace image uses `REDIS_URL` without password authentication. The chart fails at render time if both `marketplace.enabled=true` and `secrets.redisPassword` are set. Use a Redis instance without password authentication for marketplace.
+
+### Verify readiness
+
+```bash
+# Check marketplace pod is running
+kubectl get pods -n <ns> -l app.kubernetes.io/component=marketplace
+
+# Check REST API health
+kubectl exec -n <ns> deploy/octo-marketplace -- wget -qO- localhost:8092/healthz
+```
+
+---
+
 ## Uninstall
 
 ```bash

--- a/helm/octo/README.zh.md
+++ b/helm/octo/README.zh.md
@@ -387,6 +387,55 @@ kubectl exec -n <ns> deploy/octo-docs -- curl -s localhost:3000/healthz
 
 ---
 
+## 技能市场（可选）
+
+技能/机器人/MCP 市场服务是**可选**组件，**默认关闭**。当 `marketplace.enabled=false`（默认）时，chart 渲染**零**个 marketplace 资源。
+
+```yaml
+marketplace:
+  enabled: true        # 默认 false → 不渲染任何 marketplace 资源
+```
+
+### 启用检查清单
+
+在启用 `marketplace.enabled=true` 之前：
+
+1. **MySQL 数据库和用户必须存在。** 全新安装时，`init-extra-dbs.sh` 初始化脚本会自动创建。在**现有集群**上，需要手动创建：
+   ```sql
+   CREATE DATABASE IF NOT EXISTS octo_marketplace CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+   CREATE USER IF NOT EXISTS 'marketplace'@'%' IDENTIFIED BY '<MARKETPLACE_DB_PASSWORD>';
+   GRANT ALL PRIVILEGES ON octo_marketplace.* TO 'marketplace'@'%';
+   FLUSH PRIVILEGES;
+   ```
+2. **MinIO bucket 必须存在。** 全新安装时，`minio-bootstrap` init container 会创建 `marketplace`。在**现有集群**上，需要手动创建：
+   ```bash
+   mc mb octo/marketplace
+   ```
+3. **设置 marketplace 密钥**通过 `--set` 标志（先生成值，再传入）：
+   ```bash
+   helm upgrade octo ./helm/octo \
+     --set secrets.marketplaceDbPassword="$(openssl rand -hex 16)"
+   ```
+   
+   > **警告：** 不要在 YAML values 文件中写 `$(...)`  — Helm 不会执行 shell 命令。请先生成值，再复制粘贴，或如上所示使用 `--set`。
+
+### 限制
+
+- **必须使用 MinIO：** 云存储提供商（tencentCOS、aliOSS、s3、qiniu）不支持 marketplace。当 `marketplace.enabled=true` 且使用非 MinIO 存储时，chart 在渲染时报错。
+- **Redis 密码不支持：** octo-marketplace 镜像使用 `REDIS_URL` 但不支持密码认证。当 `marketplace.enabled=true` 和 `secrets.redisPassword` 同时设置时，chart 在渲染时报错。请使用无密码认证的 Redis 实例。
+
+### 验证就绪
+
+```bash
+# 检查 marketplace pod 是否运行
+kubectl get pods -n <ns> -l app.kubernetes.io/component=marketplace
+
+# 检查 REST API 健康
+kubectl exec -n <ns> deploy/octo-marketplace -- wget -qO- localhost:8092/healthz
+```
+
+---
+
 ## 卸载
 
 ```bash

--- a/helm/octo/templates/_helpers.tpl
+++ b/helm/octo/templates/_helpers.tpl
@@ -141,6 +141,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s-docs" (include "octo.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "octo.marketplace.fullname" -}}
+{{- printf "%s-marketplace" (include "octo.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 {{- define "octo.nginx.fullname" -}}
 {{- printf "%s-nginx" (include "octo.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
@@ -268,6 +272,32 @@ Returns empty when cloud storage is active (endpoint is irrelevant).
 {{- printf "%s:%v" (include "octo.minio.fullname" .) (.Values.minio.service.apiPort | default 9000) }}
 {{- else }}
 {{- required "externalMinio.endpoint is required when minio.enabled=false" .Values.externalMinio.endpoint }}
+{{- end }}
+{{- end }}
+
+{{/*
+MinIO host (without port).
+*/}}
+{{- define "octo.minio.host" -}}
+{{- if .Values.minio.enabled }}
+{{- include "octo.minio.fullname" . }}
+{{- else if include "octo.isCloudStorage" . }}
+{{- "" }}
+{{- else }}
+{{- (split ":" (required "externalMinio.endpoint is required when minio.enabled=false" .Values.externalMinio.endpoint))._0 }}
+{{- end }}
+{{- end }}
+
+{{/*
+MinIO port.
+*/}}
+{{- define "octo.minio.port" -}}
+{{- if .Values.minio.enabled }}
+{{- .Values.minio.service.apiPort | default 9000 }}
+{{- else if include "octo.isCloudStorage" . }}
+{{- "" }}
+{{- else }}
+{{- (split ":" (required "externalMinio.endpoint is required when minio.enabled=false" .Values.externalMinio.endpoint))._1 | default "9000" }}
 {{- end }}
 {{- end }}
 

--- a/helm/octo/templates/configmap-misc.yaml
+++ b/helm/octo/templates/configmap-misc.yaml
@@ -28,7 +28,8 @@ data:
             "arn:aws:s3:::download",
             "arn:aws:s3:::group",
             "arn:aws:s3:::avatar"{{- if .Values.docs.enabled }},
-            "arn:aws:s3:::octo-docs-attachments"{{- end }}
+            "arn:aws:s3:::octo-docs-attachments"{{- end }}{{- if .Values.marketplace.enabled }},
+            "arn:aws:s3:::marketplace"{{- end }}
           ]
         },
         {
@@ -52,7 +53,8 @@ data:
             "arn:aws:s3:::download/*",
             "arn:aws:s3:::group/*",
             "arn:aws:s3:::avatar/*"{{- if .Values.docs.enabled }},
-            "arn:aws:s3:::octo-docs-attachments/*"{{- end }}
+            "arn:aws:s3:::octo-docs-attachments/*"{{- end }}{{- if .Values.marketplace.enabled }},
+            "arn:aws:s3:::marketplace/*"{{- end }}
           ]
         }
       ]
@@ -72,6 +74,9 @@ data:
     {{- end }}
     {{- if .Values.docs.enabled }}
     : "${OCTO_DOCS_DB_PASSWORD:=docs}"
+    {{- end }}
+    {{- if .Values.marketplace.enabled }}
+    : "${OCTO_MARKETPLACE_DB_PASSWORD:=marketplace}"
     {{- end }}
     : "${MYSQL_DATABASE:=octo}"
 
@@ -118,6 +123,9 @@ data:
     {{- if .Values.docs.enabled }}
     validate_password  OCTO_DOCS_DB_PASSWORD         "$OCTO_DOCS_DB_PASSWORD"
     {{- end }}
+    {{- if .Values.marketplace.enabled }}
+    validate_password  OCTO_MARKETPLACE_DB_PASSWORD  "$OCTO_MARKETPLACE_DB_PASSWORD"
+    {{- end }}
     reject_literal_default OCTO_MATTER_DB_PASSWORD       "$OCTO_MATTER_DB_PASSWORD"      "matter"
     reject_literal_default OCTO_SUMMARY_DB_PASSWORD      "$OCTO_SUMMARY_DB_PASSWORD"     "summary"
     reject_literal_default OCTO_SUMMARY_READER_PASSWORD  "$OCTO_SUMMARY_READER_PASSWORD" "summary_reader"
@@ -126,6 +134,9 @@ data:
     {{- end }}
     {{- if .Values.docs.enabled }}
     reject_literal_default OCTO_DOCS_DB_PASSWORD         "$OCTO_DOCS_DB_PASSWORD"        "docs"
+    {{- end }}
+    {{- if .Values.marketplace.enabled }}
+    reject_literal_default OCTO_MARKETPLACE_DB_PASSWORD  "$OCTO_MARKETPLACE_DB_PASSWORD" "marketplace"
     {{- end }}
     validate_password  MYSQL_ROOT_PASSWORD            "$MYSQL_ROOT_PASSWORD"
     validate_identifier MYSQL_DATABASE               "$MYSQL_DATABASE"
@@ -138,6 +149,9 @@ data:
     {{- end }}
     {{- if .Values.docs.enabled }}
     CREATE DATABASE IF NOT EXISTS octo_docs    CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+    {{- end }}
+    {{- if .Values.marketplace.enabled }}
+    CREATE DATABASE IF NOT EXISTS octo_marketplace CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
     {{- end }}
 
     CREATE USER IF NOT EXISTS 'matter'@'%'  IDENTIFIED BY '${OCTO_MATTER_DB_PASSWORD}';
@@ -157,6 +171,11 @@ data:
     CREATE USER IF NOT EXISTS 'docs'@'%' IDENTIFIED BY '${OCTO_DOCS_DB_PASSWORD}';
     ALTER USER IF EXISTS      'docs'@'%' IDENTIFIED BY '${OCTO_DOCS_DB_PASSWORD}';
     {{- end }}
+    {{- if .Values.marketplace.enabled }}
+
+    CREATE USER IF NOT EXISTS 'marketplace'@'%' IDENTIFIED BY '${OCTO_MARKETPLACE_DB_PASSWORD}';
+    ALTER USER IF EXISTS      'marketplace'@'%' IDENTIFIED BY '${OCTO_MARKETPLACE_DB_PASSWORD}';
+    {{- end }}
 
     GRANT ALL PRIVILEGES ON octo_matter.*       TO 'matter'@'%';
     GRANT ALL PRIVILEGES ON octo_summary.*      TO 'summary'@'%';
@@ -167,13 +186,10 @@ data:
     {{- if .Values.docs.enabled }}
     GRANT ALL PRIVILEGES ON octo_docs.*         TO 'docs'@'%';
     {{- end }}
+    {{- if .Values.marketplace.enabled }}
+    GRANT ALL PRIVILEGES ON octo_marketplace.*  TO 'marketplace'@'%';
+    {{- end }}
     FLUSH PRIVILEGES;
     SQL
 
-    {{- if .Values.speech.enabled }}
-    echo "[init-extra-dbs] created octo_matter + octo_summary + octo_speech{{- if .Values.docs.enabled }} + octo_docs{{- end }} + service users"
-    {{- else if .Values.docs.enabled }}
-    echo "[init-extra-dbs] created octo_matter + octo_summary + octo_docs + service users"
-    {{- else }}
-    echo "[init-extra-dbs] created octo_matter + octo_summary + service users"
-    {{- end }}
+    echo "[init-extra-dbs] created octo_matter + octo_summary{{- if .Values.speech.enabled }} + octo_speech{{- end }}{{- if .Values.docs.enabled }} + octo_docs{{- end }}{{- if .Values.marketplace.enabled }} + octo_marketplace{{- end }} + service users"

--- a/helm/octo/templates/configmap-nginx.yaml
+++ b/helm/octo/templates/configmap-nginx.yaml
@@ -216,9 +216,9 @@ data:
         {{- end }}
 
         {{- if .Values.marketplace.enabled }}
-        location /marketplace-api/ {
+        location /market/api/ {
             limit_req zone=octo_api burst=20 nodelay;
-            rewrite ^/marketplace-api/(.*) /$1 break;
+            rewrite ^/market/api/(.*) /$1 break;
             proxy_pass         http://octo_marketplace_api;
             proxy_http_version 1.1;
             proxy_set_header   Host              $host;
@@ -229,8 +229,8 @@ data:
             client_max_body_size 20m;
         }
 
-        location = /marketplace-api {
-            return 301 /marketplace-api/;
+        location = /market/api {
+            return 301 /market/api/;
         }
         {{- end }}
 

--- a/helm/octo/templates/configmap-nginx.yaml
+++ b/helm/octo/templates/configmap-nginx.yaml
@@ -218,7 +218,7 @@ data:
         {{- if .Values.marketplace.enabled }}
         location /market/api/ {
             limit_req zone=octo_api burst=20 nodelay;
-            rewrite ^/market/api/(.*) /$1 break;
+            rewrite ^/market/api/(.*) /api/$1 break;
             proxy_pass         http://octo_marketplace_api;
             proxy_http_version 1.1;
             proxy_set_header   Host              $host;
@@ -226,7 +226,7 @@ data:
             proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Proto $scheme;
             proxy_read_timeout 300s;
-            client_max_body_size 20m;
+            client_max_body_size {{ add (.Values.marketplace.config.maxUploadMB | default 20) 5 }}m;
         }
 
         location = /market/api {

--- a/helm/octo/templates/configmap-nginx.yaml
+++ b/helm/octo/templates/configmap-nginx.yaml
@@ -65,6 +65,13 @@ data:
     }
     {{- end }}
 
+    {{- if .Values.marketplace.enabled }}
+    upstream octo_marketplace_api {
+        server {{ include "octo.marketplace.fullname" . }}:8092;
+        keepalive 8;
+    }
+    {{- end }}
+
     server {
         listen       80 default_server;
         listen       [::]:80 default_server;
@@ -208,13 +215,32 @@ data:
         }
         {{- end }}
 
+        {{- if .Values.marketplace.enabled }}
+        location /marketplace-api/ {
+            limit_req zone=octo_api burst=20 nodelay;
+            rewrite ^/marketplace-api/(.*) /$1 break;
+            proxy_pass         http://octo_marketplace_api;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_read_timeout 300s;
+            client_max_body_size 20m;
+        }
+
+        location = /marketplace-api {
+            return 301 /marketplace-api/;
+        }
+        {{- end }}
+
         location = /_octo_up {
             default_type text/html;
             return 200 "OCTO Server is up. Visit /admin/ for the admin console.";
         }
 
         {{- if not (include "octo.isCloudStorage" .) }}
-        location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar{{- if .Values.docs.enabled }}|octo-docs-attachments{{- end }})/.+ {
+        location ~ ^/(file|chat|moment|sticker|report|chatbg|common|download|group|avatar{{- if .Values.docs.enabled }}|octo-docs-attachments{{- end }}{{- if .Values.marketplace.enabled }}|marketplace{{- end }})/.+ {
             proxy_pass         http://octo_minio_api;
             proxy_http_version 1.1;
             proxy_set_header   Host              $http_host;

--- a/helm/octo/templates/deployment-frontend.yaml
+++ b/helm/octo/templates/deployment-frontend.yaml
@@ -53,6 +53,10 @@ spec:
             - name: SUMMARY_API_URL
               value: "http://{{ include "octo.summaryApi.fullname" . }}:8080"
             {{- end }}
+            {{- if .Values.marketplace.enabled }}
+            - name: MARKET_API_URL
+              value: "http://{{ include "octo.marketplace.fullname" . }}:8092"
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /

--- a/helm/octo/templates/deployment-marketplace.yaml
+++ b/helm/octo/templates/deployment-marketplace.yaml
@@ -72,15 +72,15 @@ spec:
             - name: API_PORT
               value: "8092"
             - name: AUTH_ENABLED
-              value: {{ .Values.marketplace.config.authEnabled | default true | quote }}
-            # MySQL DSN (built from components)
-            - name: MYSQL_DSN
-              value: "marketplace:$(MARKETPLACE_DB_PASSWORD)@tcp({{ include "octo.mysql.host" . }}:{{ include "octo.mysql.port" . }})/octo_marketplace?charset=utf8mb4&parseTime=true"
+              value: {{ .Values.marketplace.config.authEnabled | default "true" | quote }}
+            # MySQL connection - password must be defined before DSN references it
             - name: MARKETPLACE_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "octo.secretName" . }}
                   key: MARKETPLACE_DB_PASSWORD
+            - name: MYSQL_DSN
+              value: "marketplace:$(MARKETPLACE_DB_PASSWORD)@tcp({{ include "octo.mysql.host" . }}:{{ include "octo.mysql.port" . }})/octo_marketplace?charset=utf8mb4&parseTime=true"
             # Redis URL
             - name: REDIS_URL
               value: "redis://{{ include "octo.redis.host" . }}:{{ include "octo.redis.port" . }}/0"

--- a/helm/octo/templates/deployment-marketplace.yaml
+++ b/helm/octo/templates/deployment-marketplace.yaml
@@ -30,7 +30,7 @@ metadata:
     {{- include "octo.labels" . | nindent 4 }}
     app.kubernetes.io/component: marketplace
 spec:
-  replicas: {{ .Values.marketplace.replicas | default 1 }}
+  replicas: {{ .Values.marketplace.replicas }}
   selector:
     matchLabels:
       {{- include "octo.selectorLabels" . | nindent 6 }}
@@ -72,7 +72,7 @@ spec:
             - name: API_PORT
               value: "8092"
             - name: AUTH_ENABLED
-              value: {{ .Values.marketplace.config.authEnabled | default "true" | quote }}
+              value: {{ ternary "true" "false" .Values.marketplace.config.authEnabled | quote }}
             # MySQL connection - password must be defined before DSN references it
             - name: MARKETPLACE_DB_PASSWORD
               valueFrom:

--- a/helm/octo/templates/deployment-marketplace.yaml
+++ b/helm/octo/templates/deployment-marketplace.yaml
@@ -1,0 +1,135 @@
+{{- if .Values.marketplace.enabled }}
+{{- if include "octo.isCloudStorage" . }}
+{{- fail "marketplace.enabled=true requires MinIO storage (server.config.fileService=minio). Cloud storage providers (tencentCOS, aliOSS, s3, qiniu) are not supported for marketplace." }}
+{{- end }}
+{{- if .Values.secrets.redisPassword }}
+{{- fail "marketplace.enabled=true is incompatible with secrets.redisPassword. The octo-marketplace image uses REDIS_URL without password authentication. Either disable marketplace or use a Redis instance without password authentication." }}
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octo.marketplace.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: marketplace
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8092
+      targetPort: http
+  selector:
+    {{- include "octo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: marketplace
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "octo.marketplace.fullname" . }}
+  labels:
+    {{- include "octo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: marketplace
+spec:
+  replicas: {{ .Values.marketplace.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "octo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: marketplace
+  template:
+    metadata:
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "octo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: marketplace
+    spec:
+      {{- include "octo.imagePullSecrets" . | nindent 6 }}
+      initContainers:
+        - name: wait-for-mysql
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command: ['sh', '-c', 'until nc -z {{ include "octo.mysql.host" . }} {{ include "octo.mysql.port" . }}; do echo waiting for mysql; sleep 2; done']
+        - name: wait-for-redis
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command: ['sh', '-c', 'until nc -z {{ include "octo.redis.host" . }} {{ include "octo.redis.port" . }}; do echo waiting for redis; sleep 2; done']
+        - name: wait-for-minio
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command: ['sh', '-c', 'until nc -z {{ include "octo.minio.host" . }} {{ include "octo.minio.port" . }}; do echo waiting for minio; sleep 2; done']
+        - name: wait-for-server
+          image: {{ include "octo.image" (dict "repo" .Values.busybox.image.repository "tag" .Values.busybox.image.tag "ctx" .) }}
+          command: ['sh', '-c', 'until wget -q -O- http://{{ include "octo.server.fullname" . }}:8090/v1/ping >/dev/null 2>&1; do echo waiting for octo-server; sleep 5; done']
+      containers:
+        - name: octo-marketplace
+          image: {{ include "octo.image" (dict "repo" .Values.marketplace.image.repository "tag" .Values.marketplace.image.tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.marketplace.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8092
+          env:
+            - name: TZ
+              value: {{ .Values.timezone | default "UTC" | quote }}
+            - name: APP_ENV
+              value: "prod"
+            - name: API_PORT
+              value: "8092"
+            - name: AUTH_ENABLED
+              value: {{ .Values.marketplace.config.authEnabled | default true | quote }}
+            # MySQL DSN (built from components)
+            - name: MYSQL_DSN
+              value: "marketplace:$(MARKETPLACE_DB_PASSWORD)@tcp({{ include "octo.mysql.host" . }}:{{ include "octo.mysql.port" . }})/octo_marketplace?charset=utf8mb4&parseTime=true"
+            - name: MARKETPLACE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: MARKETPLACE_DB_PASSWORD
+            # Redis URL
+            - name: REDIS_URL
+              value: "redis://{{ include "octo.redis.host" . }}:{{ include "octo.redis.port" . }}/0"
+            # OCTO server for auth delegation
+            - name: OCTO_API_URL
+              value: "http://{{ include "octo.server.fullname" . }}:8090"
+            # Storage configuration
+            - name: STORAGE_DRIVER
+              value: {{ .Values.marketplace.config.storageDriver | default "oss" | quote }}
+            - name: OSS_ENDPOINT
+              value: "http://{{ include "octo.minio.endpoint" . }}"
+            - name: OSS_BUCKET
+              value: "marketplace"
+            - name: OSS_ACCESS_KEY
+              value: {{ include "octo.minio.appUser" . | quote }}
+            - name: OSS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: OCTO_MINIO_APP_PASSWORD
+            - name: OSS_REGION
+              value: "us-east-1"
+            - name: OSS_PATH_STYLE
+              value: "true"
+            {{- $baseURL := include "octo.externalBaseURL" . }}
+            - name: OSS_PUBLIC_ENDPOINT
+              value: {{ .Values.marketplace.config.ossPublicEndpoint | default $baseURL | quote }}
+            - name: OSS_DOWNLOAD_SIGNED
+              value: "true"
+            - name: MAX_UPLOAD_MB
+              value: {{ .Values.marketplace.config.maxUploadMB | default 20 | quote }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.marketplace.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/helm/octo/templates/deployment-octo-server.yaml
+++ b/helm/octo/templates/deployment-octo-server.yaml
@@ -119,7 +119,7 @@ spec:
               echo "[minio-bootstrap] attaching policy to $OCTO_MINIO_APP_USER..."
               mc admin policy attach local octo-app --user "$OCTO_MINIO_APP_USER" 2>/dev/null || true
 
-              for b in file chat moment sticker report chatbg common download group avatar{{- if .Values.docs.enabled }} octo-docs-attachments{{- end }}; do
+              for b in file chat moment sticker report chatbg common download group avatar{{- if .Values.docs.enabled }} octo-docs-attachments{{- end }}{{- if .Values.marketplace.enabled }} marketplace{{- end }}; do
                 mc mb --ignore-existing "local/$b" >/dev/null
               done
 
@@ -338,6 +338,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "octo.secretName" . }}
                   key: TS_SUPPORT_EMAILPWD
+            {{- end }}
+            {{- if .Values.marketplace.enabled }}
+            - name: MARKET_API_URL
+              value: "http://{{ include "octo.marketplace.fullname" . }}:8092"
             {{- end }}
           readinessProbe:
             httpGet:

--- a/helm/octo/templates/deployment-octo-server.yaml
+++ b/helm/octo/templates/deployment-octo-server.yaml
@@ -339,10 +339,6 @@ spec:
                   name: {{ include "octo.secretName" . }}
                   key: TS_SUPPORT_EMAILPWD
             {{- end }}
-            {{- if .Values.marketplace.enabled }}
-            - name: MARKET_API_URL
-              value: "http://{{ include "octo.marketplace.fullname" . }}:8092"
-            {{- end }}
           readinessProbe:
             httpGet:
               path: /v1/ping

--- a/helm/octo/templates/secret.yaml
+++ b/helm/octo/templates/secret.yaml
@@ -65,6 +65,9 @@ data:
   DOCS_COLLAB_SECRET:           {{ $collabSecret | b64enc | quote }}
   DOCS_ATTACHMENT_SECRET:       {{ $attachSecret | b64enc | quote }}
   {{- end }}
+  {{- if .Values.marketplace.enabled }}
+  MARKETPLACE_DB_PASSWORD:      {{ required "secrets.marketplaceDbPassword must be set when marketplace.enabled=true" .Values.secrets.marketplaceDbPassword | b64enc | quote }}
+  {{- end }}
   {{- if .Values.secrets.redisPassword }}
   REDIS_PASSWORD:               {{ .Values.secrets.redisPassword | b64enc | quote }}
   {{- end }}

--- a/helm/octo/templates/statefulset-mysql.yaml
+++ b/helm/octo/templates/statefulset-mysql.yaml
@@ -89,6 +89,13 @@ spec:
                   name: {{ include "octo.secretName" . }}
                   key: DOCS_DB_PASSWORD
             {{- end }}
+            {{- if .Values.marketplace.enabled }}
+            - name: OCTO_MARKETPLACE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "octo.secretName" . }}
+                  key: MARKETPLACE_DB_PASSWORD
+            {{- end }}
           readinessProbe:
             exec:
               command:

--- a/helm/octo/values.yaml
+++ b/helm/octo/values.yaml
@@ -125,6 +125,9 @@ secrets:
   docsCollabSecret: ""        # JWT signing secret for collab tokens (min 32 chars)
   docsAttachmentSecret: ""    # HMAC secret for attachment presigned URLs (min 32 chars)
 
+  # Marketplace credentials. Required only when marketplace.enabled=true.
+  marketplaceDbPassword: ""   # Password for the 'marketplace' MySQL user
+
   # Inbound webhook HMAC secret (optional).
   webhookSecretKey: ""
 
@@ -517,6 +520,35 @@ docs:
     # CORS allowed origins (comma-separated or *)
     # Defaults to http://{{ domain }}:{{ nginx.service.port }}
     corsOrigins: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+# =============================================================================
+# Marketplace (skill / bot / MCP catalog) — OPT-IN.
+# Default OFF: with marketplace.enabled=false NO marketplace resources are rendered.
+# =============================================================================
+marketplace:
+  enabled: false
+  image:
+    repository: mininglamposs/octo-marketplace
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  config:
+    # Whether to require authentication for API calls
+    authEnabled: true
+    # Storage driver (oss = MinIO-compatible S3)
+    storageDriver: oss
+    # Public endpoint for presigned URL downloads (browser-reachable)
+    # Defaults to http://{{ domain }}:{{ nginx.service.port }}
+    ossPublicEndpoint: ""
+    # Maximum upload size in MB
+    maxUploadMB: 20
   resources:
     requests:
       cpu: 100m

--- a/kustomize/marketplace/README.md
+++ b/kustomize/marketplace/README.md
@@ -14,7 +14,7 @@ Before applying this kustomization:
 1. **MySQL**: The `octo_marketplace` database must exist with a `marketplace` user
 2. **Redis**: Available at `redis:6379` (reuses the existing instance)
 3. **MinIO**: The `marketplace` bucket must be created
-4. **OCTO Server**: Running at `octo-server:8090` (required for auth delegation)
+4. **OCTO Server**: Running at `octo-server` (required for auth delegation)
 5. **Secret**: Create `marketplace-secret` from the example
 6. **Nginx**: Configure route for `/market/api/` (see [Nginx Routing](#nginx-routing) below)
 
@@ -86,7 +86,7 @@ Add this location block to your nginx server configuration:
 ```nginx
 # Marketplace API — skill/bot/MCP catalog
 location /market/api/ {
-    rewrite ^/market/api/(.*) /$1 break;
+    rewrite ^/market/api/(.*) /api/$1 break;
     proxy_pass http://octo-marketplace:8092;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;

--- a/kustomize/marketplace/README.md
+++ b/kustomize/marketplace/README.md
@@ -16,7 +16,7 @@ Before applying this kustomization:
 3. **MinIO**: The `marketplace` bucket must be created
 4. **OCTO Server**: Running at `octo-server:8090` (required for auth delegation)
 5. **Secret**: Create `marketplace-secret` from the example
-6. **Nginx**: Configure route for `/marketplace-api/` (see [Nginx Routing](#nginx-routing) below)
+6. **Nginx**: Configure route for `/market/api/` (see [Nginx Routing](#nginx-routing) below)
 
 ### Existing Cluster Database Setup
 
@@ -85,8 +85,9 @@ Add this location block to your nginx server configuration:
 
 ```nginx
 # Marketplace API — skill/bot/MCP catalog
-location /marketplace-api/ {
-    proxy_pass http://octo-marketplace:8092/;
+location /market/api/ {
+    rewrite ^/market/api/(.*) /$1 break;
+    proxy_pass http://octo-marketplace:8092;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -97,7 +98,7 @@ location /marketplace-api/ {
 ```
 
 Route:
-- `/marketplace-api/` → `octo-marketplace:8092` (REST API)
+- `/market/api/` → `octo-marketplace:8092` (REST API)
 
 ## Image Override
 

--- a/kustomize/marketplace/README.md
+++ b/kustomize/marketplace/README.md
@@ -1,0 +1,115 @@
+# Marketplace Service (Kustomize)
+
+OCTO skill / bot / MCP catalog service.
+
+## Overview
+
+This kustomization deploys `octo-marketplace`, a Go service that provides:
+- REST API on port 8092 for skill, bot, and MCP marketplace operations
+
+## Prerequisites
+
+Before applying this kustomization:
+
+1. **MySQL**: The `octo_marketplace` database must exist with a `marketplace` user
+2. **Redis**: Available at `redis:6379` (reuses the existing instance)
+3. **MinIO**: The `marketplace` bucket must be created
+4. **OCTO Server**: Running at `octo-server:8090` (required for auth delegation)
+5. **Secret**: Create `marketplace-secret` from the example
+6. **Nginx**: Configure route for `/marketplace-api/` (see [Nginx Routing](#nginx-routing) below)
+
+### Existing Cluster Database Setup
+
+If you are enabling marketplace on an **existing cluster** where MySQL was already initialized, you must manually create the database and user:
+
+```sql
+CREATE DATABASE IF NOT EXISTS octo_marketplace CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+CREATE USER IF NOT EXISTS 'marketplace'@'%' IDENTIFIED BY '<your-password>';
+GRANT ALL PRIVILEGES ON octo_marketplace.* TO 'marketplace'@'%';
+FLUSH PRIVILEGES;
+```
+
+Replace `<your-password>` with a strong password matching the one in your Secret.
+
+## Quick Start
+
+```bash
+# 1. Create the secret FIRST (required - the kustomization does not include it)
+cp marketplace-secret.example.yaml marketplace-secret.yaml
+# Edit marketplace-secret.yaml with real credentials - DO NOT use placeholder values!
+kubectl apply -f marketplace-secret.yaml -n <namespace>
+
+# 2. Apply the marketplace kustomization
+kubectl apply -k kustomize/marketplace -n <namespace>
+```
+
+> **Important**: The Secret is intentionally NOT included in the kustomization
+> resources to prevent accidental deployment with placeholder credentials.
+> You MUST create the Secret manually before applying.
+
+## Configuration
+
+### ConfigMap (marketplace-config)
+
+Non-sensitive configuration in `marketplace-configmap.yaml`:
+- API port and environment settings
+- Storage driver configuration (OSS)
+- MySQL and Redis connection host/port
+- OCTO server URL for auth delegation
+
+### Secret (marketplace-secret)
+
+Sensitive configuration must be created from `marketplace-secret.example.yaml`:
+
+| Key | Description |
+|-----|-------------|
+| `MYSQL_DSN` | Full MySQL DSN with password |
+| `REDIS_URL` | Redis connection URL (e.g. `redis://redis:6379/0`) |
+| `OSS_ENDPOINT` | Internal MinIO endpoint (service DNS) |
+| `OSS_PUBLIC_ENDPOINT` | Browser-reachable MinIO endpoint for presigned URLs |
+| `OSS_ACCESS_KEY` | MinIO access key (use `octo-app`, not root) |
+| `OSS_SECRET_KEY` | MinIO secret key |
+| `OSS_ENDPOINT_HOST` | MinIO host for init container wait probe |
+| `OSS_ENDPOINT_PORT` | MinIO port for init container wait probe |
+
+Generate password with:
+```bash
+openssl rand -hex 16  # For MySQL password
+```
+
+## Nginx Routing
+
+**Important**: This kustomization does NOT include nginx configuration. You must manually add the following route to your nginx ConfigMap or configuration.
+
+Add this location block to your nginx server configuration:
+
+```nginx
+# Marketplace API — skill/bot/MCP catalog
+location /marketplace-api/ {
+    proxy_pass http://octo-marketplace:8092/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 300s;
+    client_max_body_size 20m;
+}
+```
+
+Route:
+- `/marketplace-api/` → `octo-marketplace:8092` (REST API)
+
+## Image Override
+
+To use a different image tag:
+
+```yaml
+# kustomization.yaml
+images:
+  - name: mininglamposs/octo-marketplace
+    newTag: "1.0.0"  # Your desired version
+```
+
+## Health Check
+
+The service exposes `/healthz` endpoint for liveness and readiness probes.

--- a/kustomize/marketplace/README.zh.md
+++ b/kustomize/marketplace/README.zh.md
@@ -14,7 +14,7 @@ OCTO 技能/机器人/MCP 市场服务。
 1. **MySQL**：`octo_marketplace` 数据库必须存在，并创建 `marketplace` 用户
 2. **Redis**：可访问 `redis:6379`（复用现有实例）
 3. **MinIO**：`marketplace` 存储桶必须创建
-4. **OCTO Server**：运行在 `octo-server:8090`（身份认证委托）
+4. **OCTO Server**：运行在 `octo-server`（身份认证委托）
 5. **Secret**：从示例文件创建 `marketplace-secret`
 6. **Nginx**：配置 `/market/api/` 路由（见下方 [Nginx 路由](#nginx-路由)）
 
@@ -85,7 +85,7 @@ openssl rand -hex 16  # 用于 MySQL 密码
 ```nginx
 # Marketplace API — 技能/机器人/MCP 市场
 location /market/api/ {
-    rewrite ^/market/api/(.*) /$1 break;
+    rewrite ^/market/api/(.*) /api/$1 break;
     proxy_pass http://octo-marketplace:8092;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;

--- a/kustomize/marketplace/README.zh.md
+++ b/kustomize/marketplace/README.zh.md
@@ -1,0 +1,114 @@
+# 技能市场服务 (Kustomize)
+
+OCTO 技能/机器人/MCP 市场服务。
+
+## 概述
+
+此 kustomization 部署 `octo-marketplace`，一个 Go 服务：
+- REST API（端口 8092）：技能、机器人和 MCP 市场操作
+
+## 前置条件
+
+应用此 kustomization 之前：
+
+1. **MySQL**：`octo_marketplace` 数据库必须存在，并创建 `marketplace` 用户
+2. **Redis**：可访问 `redis:6379`（复用现有实例）
+3. **MinIO**：`marketplace` 存储桶必须创建
+4. **OCTO Server**：运行在 `octo-server:8090`（身份认证委托）
+5. **Secret**：从示例文件创建 `marketplace-secret`
+6. **Nginx**：配置 `/marketplace-api/` 路由（见下方 [Nginx 路由](#nginx-路由)）
+
+### 现有集群数据库设置
+
+如果在 **已有集群**（MySQL 已初始化完成）上启用 marketplace，必须手动创建数据库和用户：
+
+```sql
+CREATE DATABASE IF NOT EXISTS octo_marketplace CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+CREATE USER IF NOT EXISTS 'marketplace'@'%' IDENTIFIED BY '<your-password>';
+GRANT ALL PRIVILEGES ON octo_marketplace.* TO 'marketplace'@'%';
+FLUSH PRIVILEGES;
+```
+
+将 `<your-password>` 替换为与 Secret 中一致的强密码。
+
+## 快速开始
+
+```bash
+# 1. 首先创建 Secret（必须 - kustomization 中不包含它）
+cp marketplace-secret.example.yaml marketplace-secret.yaml
+# 编辑 marketplace-secret.yaml 填入真实凭据 - 不要使用占位符！
+kubectl apply -f marketplace-secret.yaml -n <namespace>
+
+# 2. 应用 marketplace kustomization
+kubectl apply -k kustomize/marketplace -n <namespace>
+```
+
+> **重要提示**：Secret 未包含在 kustomization resources 中是故意的，
+> 以防止使用占位符凭据意外部署。应用之前**必须**手动创建 Secret。
+
+## 配置项
+
+### ConfigMap (marketplace-config)
+
+非敏感配置位于 `marketplace-configmap.yaml`：
+- API 端口和环境设置
+- 存储驱动配置（OSS）
+- MySQL 和 Redis 连接主机/端口
+- OCTO 服务器地址（身份认证委托）
+
+### Secret (marketplace-secret)
+
+敏感配置需从 `marketplace-secret.example.yaml` 创建：
+
+| 键名 | 说明 |
+|-----|------|
+| `MYSQL_DSN` | 完整 MySQL DSN（包含密码）|
+| `REDIS_URL` | Redis 连接 URL（如 `redis://redis:6379/0`）|
+| `OSS_ENDPOINT` | MinIO 内部端点（服务 DNS）|
+| `OSS_PUBLIC_ENDPOINT` | 浏览器可访问的 MinIO 端点（预签名 URL）|
+| `OSS_ACCESS_KEY` | MinIO 访问密钥（使用 `octo-app`，非 root）|
+| `OSS_SECRET_KEY` | MinIO 密钥 |
+| `OSS_ENDPOINT_HOST` | init container 等待探测的 MinIO 主机 |
+| `OSS_ENDPOINT_PORT` | init container 等待探测的 MinIO 端口 |
+
+生成密码：
+```bash
+openssl rand -hex 16  # 用于 MySQL 密码
+```
+
+## Nginx 路由
+
+**重要提示**：此 kustomization 不包含 nginx 配置。您必须手动将以下路由添加到 nginx ConfigMap 或配置中。
+
+将以下 location 块添加到 nginx server 配置：
+
+```nginx
+# Marketplace API — 技能/机器人/MCP 市场
+location /marketplace-api/ {
+    proxy_pass http://octo-marketplace:8092/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 300s;
+    client_max_body_size 20m;
+}
+```
+
+路由说明：
+- `/marketplace-api/` → `octo-marketplace:8092`（REST API）
+
+## 镜像版本
+
+使用不同镜像版本：
+
+```yaml
+# kustomization.yaml
+images:
+  - name: mininglamposs/octo-marketplace
+    newTag: "1.0.0"  # 指定版本
+```
+
+## 健康检查
+
+服务暴露 `/healthz` 端点用于存活和就绪探测。

--- a/kustomize/marketplace/README.zh.md
+++ b/kustomize/marketplace/README.zh.md
@@ -16,7 +16,7 @@ OCTO 技能/机器人/MCP 市场服务。
 3. **MinIO**：`marketplace` 存储桶必须创建
 4. **OCTO Server**：运行在 `octo-server:8090`（身份认证委托）
 5. **Secret**：从示例文件创建 `marketplace-secret`
-6. **Nginx**：配置 `/marketplace-api/` 路由（见下方 [Nginx 路由](#nginx-路由)）
+6. **Nginx**：配置 `/market/api/` 路由（见下方 [Nginx 路由](#nginx-路由)）
 
 ### 现有集群数据库设置
 
@@ -84,8 +84,9 @@ openssl rand -hex 16  # 用于 MySQL 密码
 
 ```nginx
 # Marketplace API — 技能/机器人/MCP 市场
-location /marketplace-api/ {
-    proxy_pass http://octo-marketplace:8092/;
+location /market/api/ {
+    rewrite ^/market/api/(.*) /$1 break;
+    proxy_pass http://octo-marketplace:8092;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -96,7 +97,7 @@ location /marketplace-api/ {
 ```
 
 路由说明：
-- `/marketplace-api/` → `octo-marketplace:8092`（REST API）
+- `/market/api/` → `octo-marketplace:8092`（REST API）
 
 ## 镜像版本
 

--- a/kustomize/marketplace/kustomization.yaml
+++ b/kustomize/marketplace/kustomization.yaml
@@ -1,0 +1,30 @@
+# Marketplace service (skill / bot / MCP catalog)
+#
+# This kustomization is INTENTIONALLY NOT referenced by kustomize/base or any
+# overlay (dev/prod). Applying the default base/overlays deploys ZERO marketplace
+# resources. An operator opts in explicitly and on a separate, owner-gated
+# action, e.g.:
+#
+#   kubectl apply -k kustomize/marketplace -n <ns>
+#
+# Everything here is additive: it adds new workloads, services, and ConfigMaps
+# and does not modify any core OCTO resource. See README.md in this directory.
+#
+# Prerequisites:
+#   - MySQL must be running with the `octo_marketplace` database created
+#   - Redis must be available (reuses the existing instance)
+#   - MinIO must be running with the `marketplace` bucket created
+#   - Create the marketplace-secret from marketplace-secret.example.yaml with real credentials
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - marketplace-configmap.yaml
+  - marketplace-deployment.yaml
+  # NOTE: marketplace-secret.example.yaml is NOT included here intentionally.
+  # Operators must create their own Secret with real credentials before applying.
+  # See marketplace-secret.example.yaml for the required keys and README.md for instructions.
+
+images:
+  - name: mininglamposs/octo-marketplace
+    newTag: "latest"

--- a/kustomize/marketplace/marketplace-configmap.yaml
+++ b/kustomize/marketplace/marketplace-configmap.yaml
@@ -24,6 +24,6 @@ data:
   REDIS_HOST: "redis"
   REDIS_PORT: "6379"
   # OCTO server for auth delegation
-  OCTO_API_URL: "http://octo-server:8090"
+  OCTO_API_URL: "http://octo-server"
   # MinIO config (secrets via Secret)
   OSS_BUCKET: "marketplace"

--- a/kustomize/marketplace/marketplace-configmap.yaml
+++ b/kustomize/marketplace/marketplace-configmap.yaml
@@ -1,0 +1,29 @@
+# ConfigMap for octo-marketplace configuration
+# Non-sensitive environment variables for the marketplace service.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: marketplace-config
+  labels:
+    app: octo-marketplace
+data:
+  APP_ENV: "prod"
+  API_PORT: "8092"
+  AUTH_ENABLED: "true"
+  STORAGE_DRIVER: "oss"
+  OSS_REGION: "us-east-1"
+  OSS_PATH_STYLE: "true"
+  OSS_DOWNLOAD_SIGNED: "true"
+  MAX_UPLOAD_MB: "20"
+  # MySQL connection (password comes from Secret via MYSQL_DSN)
+  MYSQL_HOST: "mysql"
+  MYSQL_PORT: "3306"
+  MYSQL_USER: "marketplace"
+  MYSQL_DATABASE: "octo_marketplace"
+  # Redis connection
+  REDIS_HOST: "redis"
+  REDIS_PORT: "6379"
+  # OCTO server for auth delegation
+  OCTO_API_URL: "http://octo-server:8090"
+  # MinIO config (secrets via Secret)
+  OSS_BUCKET: "marketplace"

--- a/kustomize/marketplace/marketplace-deployment.yaml
+++ b/kustomize/marketplace/marketplace-deployment.yaml
@@ -1,0 +1,100 @@
+# octo-marketplace: Skill / Bot / MCP catalog service
+#
+# HTTP API on port 8092 for skill/bot/MCP marketplace operations.
+#
+# Prerequisites:
+#   - MySQL with `octo_marketplace` database created
+#   - Redis available at redis:6379
+#   - MinIO with `marketplace` bucket created
+#   - marketplace-secret created with required credentials
+apiVersion: v1
+kind: Service
+metadata:
+  name: octo-marketplace
+  labels:
+    app: octo-marketplace
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8092
+      targetPort: http
+  selector:
+    app: octo-marketplace
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: octo-marketplace
+  labels:
+    app: octo-marketplace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: octo-marketplace
+  template:
+    metadata:
+      labels:
+        app: octo-marketplace
+    spec:
+      initContainers:
+        - name: wait-for-mysql
+          image: busybox:1.36
+          envFrom:
+            - configMapRef:
+                name: marketplace-config
+          command: ['sh', '-c', 'until nc -z $MYSQL_HOST $MYSQL_PORT; do echo waiting for mysql; sleep 2; done']
+        - name: wait-for-redis
+          image: busybox:1.36
+          envFrom:
+            - configMapRef:
+                name: marketplace-config
+          command: ['sh', '-c', 'until nc -z $REDIS_HOST $REDIS_PORT; do echo waiting for redis; sleep 2; done']
+        - name: wait-for-minio
+          image: busybox:1.36
+          envFrom:
+            - secretRef:
+                name: marketplace-secret
+          command: ['sh', '-c', 'until nc -z $OSS_ENDPOINT_HOST $OSS_ENDPOINT_PORT; do echo waiting for minio; sleep 2; done']
+        - name: wait-for-server
+          image: busybox:1.36
+          envFrom:
+            - configMapRef:
+                name: marketplace-config
+          command: ['sh', '-c', 'until wget -q -O- $OCTO_API_URL/v1/ping >/dev/null 2>&1; do echo waiting for octo-server; sleep 5; done']
+      containers:
+        - name: octo-marketplace
+          image: mininglamposs/octo-marketplace:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8092
+          envFrom:
+            - configMapRef:
+                name: marketplace-config
+            - secretRef:
+                name: marketplace-secret
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi

--- a/kustomize/marketplace/marketplace-secret.example.yaml
+++ b/kustomize/marketplace/marketplace-secret.example.yaml
@@ -1,0 +1,49 @@
+# Example Secret for octo-marketplace
+#
+# Copy this file to marketplace-secret.yaml and fill in real values, then apply:
+#   kubectl apply -f marketplace-secret.yaml -n <namespace>
+#
+# Or create directly with kubectl:
+#   kubectl create secret generic marketplace-secret \
+#     --from-literal=MYSQL_DSN='marketplace:<password>@tcp(mysql:3306)/octo_marketplace?charset=utf8mb4&parseTime=true' \
+#     --from-literal=REDIS_URL='redis://redis:6379/0' \
+#     --from-literal=OSS_ENDPOINT='http://minio:9000' \
+#     --from-literal=OSS_PUBLIC_ENDPOINT='http://your-domain:port' \
+#     --from-literal=OSS_ACCESS_KEY='octo-app' \
+#     --from-literal=OSS_SECRET_KEY='<minio-app-password>' \
+#     --from-literal=OSS_ENDPOINT_HOST='minio' \
+#     --from-literal=OSS_ENDPOINT_PORT='9000' \
+#     -n <namespace>
+#
+# Required values:
+#   MYSQL_DSN           — Full MySQL DSN with password
+#   REDIS_URL           — Redis connection URL
+#   OSS_ENDPOINT        — Internal MinIO endpoint (service DNS)
+#   OSS_PUBLIC_ENDPOINT — Browser-reachable MinIO/S3 endpoint for presigned URLs
+#   OSS_ACCESS_KEY      — MinIO access key (use octo-app, not root)
+#   OSS_SECRET_KEY      — MinIO secret key
+#   OSS_ENDPOINT_HOST   — MinIO host for init container wait probe
+#   OSS_ENDPOINT_PORT   — MinIO port for init container wait probe
+apiVersion: v1
+kind: Secret
+metadata:
+  name: marketplace-secret
+  labels:
+    app: octo-marketplace
+type: Opaque
+stringData:
+  # MySQL DSN (includes password)
+  # Format: marketplace:<password>@tcp(mysql:3306)/octo_marketplace?charset=utf8mb4&parseTime=true
+  MYSQL_DSN: "marketplace:CHANGE_ME_marketplace_db_password@tcp(mysql:3306)/octo_marketplace?charset=utf8mb4&parseTime=true"
+  # Redis URL
+  REDIS_URL: "redis://redis:6379/0"
+  # MinIO/S3 internal endpoint (for server-side operations)
+  OSS_ENDPOINT: "http://minio:9000"
+  # MinIO/S3 public endpoint (for presigned URL downloads — browser-reachable)
+  OSS_PUBLIC_ENDPOINT: "http://localhost:28080"
+  # MinIO credentials (use octo-app user, not root)
+  OSS_ACCESS_KEY: "octo-app"
+  OSS_SECRET_KEY: "CHANGE_ME_minio_app_password"
+  # Init container wait probe targets (extracted from OSS_ENDPOINT)
+  OSS_ENDPOINT_HOST: "minio"
+  OSS_ENDPOINT_PORT: "9000"


### PR DESCRIPTION
## Summary

- Add octo-marketplace (skill/bot/MCP catalog) deployment support for Kustomize and Helm
- Kustomize: `kustomize/marketplace/` with ConfigMap, Deployment, Service, Secret example, bilingual README
- Helm: `deployment-marketplace.yaml` with fail guards, MySQL/MinIO/nginx integration, Chart version 0.3.1 → 0.3.2

## Test plan

- [x] `helm template` with `marketplace.enabled=true` renders correctly
- [x] `helm template` with `marketplace.enabled=false` produces no marketplace resources
- [x] Cloud storage mode (`fileService=tencentCOS`) fails as expected
- [x] Redis password mode fails as expected
- [x] `kubectl kustomize ./kustomize/marketplace` renders correctly

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)