### PR TITLE
feat(docker): enable sub-zone (thread) feature by default

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -426,6 +426,10 @@ LLM_MODEL=claude-sonnet-4-6
 # `docker compose up -d`). `setup.sh --https` prints the same checklist.
 
 # --- Optional services -----------------------------------------------------
+# Sub-zone (thread) feature toggle. Enabled by default (true). Set to false
+# to hide the thread entry point from clients that do not need sub-zones.
+# DM_THREAD_ON=true
+
 # Summary services are gated by Docker Compose profiles. To enable them,
 # uncomment COMPOSE_PROFILES below (setup.sh --summary does this for you).
 # COMPOSE_PROFILES=summary

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -757,6 +757,10 @@ services:
       # deployment boots cleanly without these vars set.
       SPEECH_SERVICE_URL: ${SPEECH_SERVICE_URL:-}
       SPEECH_API_KEY:     ${SPEECH_API_KEY:-}
+      # Sub-zone (thread) feature. Defaults to true so new deployments have
+      # threads enabled out of the box. Set DM_THREAD_ON=false in .env to
+      # disable threads for environments that do not need them.
+      DM_THREAD_ON: ${DM_THREAD_ON:-true}
       # octo-docs-backend notification token wiring. Empty by default so a
       # non-docs deployment boots cleanly without this var set.
       OCTO_DOCS_NOTIFY_TOKEN: ${OCTO_DOCS_NOTIFY_TOKEN:-}


### PR DESCRIPTION
## Summary

Add `DM_THREAD_ON` env var to octo-server with a default of `true` so the thread (sub-zone) feature is enabled out of the box for all new Docker Compose deployments.

Previously the variable was undocumented in this repo and defaulted to `false` inside octo-server, meaning threads were hidden unless an operator manually added `DM_THREAD_ON=true` to their `.env`. This is a commonly requested feature and the correct default for new installs.

## Changes

| File | What changed |
|---|---|
| `docker/docker-compose.yaml` | Add `DM_THREAD_ON: ${DM_THREAD_ON:-true}` to octo-server environment |
| `docker/.env.example` | Document the variable with a commented-out example |

## Backward compatibility

- Existing deployments that do **not** have `DM_THREAD_ON` in their `.env` will now have threads **enabled** after restarting octo-server — this is intentional and the desired default.
- Operators who want to keep threads hidden can explicitly set `DM_THREAD_ON=false` in their `docker/.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)