### PR TITLE
feat(docker): integrate docs profile into setup.sh + fix nginx routing

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1350,7 +1350,7 @@ services:
       - octo-net
 
   octo-docs-backend:
-    image: ${OCTO_DOCS_IMAGE:-mininglamposs/octo-docs-backend:0.4.0}
+    image: ${OCTO_DOCS_IMAGE:-mininglamposs/octo-docs-backend:0.6.0}
     restart: unless-stopped
     profiles: ["docs"]
     depends_on:
@@ -1368,8 +1368,9 @@ services:
     #   2. Incremental upgrades — runs dist/db/migrate.js (advisory lock +
     #      schema_migrations ledger; idempotent on every restart)
     #   3. exec the API server — replaces shell so SIGTERM reaches Node directly
-    # MINIMUM IMAGE VERSION: >= 0.3.0 (ships dist/db/migrate.js + upgrades/).
-    # Default tag is pinned to 0.4.0; override with OCTO_DOCS_IMAGE.
+    # MINIMUM IMAGE VERSION: >= 0.6.0 (ships ATTACHMENT_S3_INTERNAL_ENDPOINT
+    # support for server-side MinIO access; required for PDF export to preserve
+    # embedded images). Default tag is pinned to 0.6.0; override with OCTO_DOCS_IMAGE.
     environment:
       NODE_ENV: production
       HTTP_PORT: "3000"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1403,6 +1403,13 @@ services:
       ATTACHMENT_S3_SECRET_KEY: ${OCTO_MINIO_APP_PASSWORD:-}
       ATTACHMENT_S3_FORCE_PATH_STYLE: "true"
       ATTACHMENT_SIGNING_SECRET: ${OCTO_DOCS_ATTACHMENT_SECRET:-}
+      # Internal MinIO endpoint for server-side operations (schema migrations,
+      # export PDF image download). Must be the container-network address so
+      # docs-backend can reach MinIO directly without going through nginx.
+      # Without this, PDF exports lose embedded images because docs-backend
+      # tries to download them via the public ATTACHMENT_S3_ENDPOINT URL which
+      # is unreachable from inside the Docker network.
+      ATTACHMENT_S3_INTERNAL_ENDPOINT: "http://minio:9000"
       # CORS — allow requests from the web frontend
       CORS_ALLOWED_ORIGINS: "${OCTO_DOCS_CORS_ORIGINS:-}"
       TZ: ${TZ:-UTC}

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -390,6 +390,8 @@ server {
         proxy_read_timeout 86400s;
         proxy_send_timeout 86400s;
     }
+
+    location = /_octo_up {
         default_type text/html;
         return 200 '<!doctype html>
 <html><head><meta charset="utf-8"><title>OCTO Server</title>

--- a/docker/nginx/conf.d/octo.conf.template
+++ b/docker/nginx/conf.d/octo.conf.template
@@ -104,8 +104,45 @@ server {
         # Rate limit + small burst — same shape applied to /v1/. Keeps a
         # rogue client from exhausting octo-server while still passing
         # bursty page loads. zone= names are declared in nginx.conf.
+        #
+        # NOTE: /api/v1/docs* is intercepted BEFORE this block by the
+        # `location ^~ /api/v1/docs` rule below — see that block.
         limit_req zone=octo_api burst=60 nodelay;
         proxy_pass         http://octo_api/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Connection        "";
+        proxy_read_timeout 600s;
+    }
+
+    # Docs REST API (human sessions) — must precede the generic /api/ block
+    # so /api/v1/docs* routes to octo-docs-backend instead of octo-server.
+    # octo-web ≤ 1.12 calls /api/v1/docs directly; the ^~ prefix modifier
+    # ensures this rule wins over the longer /api/ match.
+    location ^~ /api/v1/docs {
+        limit_req zone=octo_api burst=30 nodelay;
+        set $upstream_docs octo-docs-backend;
+        proxy_pass         http://$upstream_docs:3000;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Connection        "";
+        proxy_read_timeout 600s;
+    }
+
+    # Docs Bot API — octo-cli and OpenClaw call /v1/bot/docs/* with a bot
+    # token; must precede the generic /v1/ block so requests reach
+    # octo-docs-backend rather than octo-server (which has no /v1/bot/docs
+    # handler and would return 404).
+    location ^~ /v1/bot/docs {
+        limit_req zone=octo_api burst=30 nodelay;
+        set $upstream_docs octo-docs-backend;
+        proxy_pass         http://$upstream_docs:3000;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
@@ -333,7 +370,26 @@ server {
         proxy_send_timeout 86400s;
     }
 
-    location = /_octo_up {
+    # /docs-ws without trailing slash — browsers connect to exactly this
+    # path; the /docs-ws/ block above does not match it, so without this
+    # rule the WebSocket upgrade falls through to the SPA catch-all and
+    # returns 200 HTML instead of 101 Switching Protocols. The result is
+    # that every document stays in "document_not_connected" state and PDF
+    # exports fail. This exact-match rule forwards bare /docs-ws to
+    # Hocuspocus the same way /docs-ws/ does.
+    location = /docs-ws {
+        set $upstream_docs_ws octo-docs-backend;
+        proxy_pass         http://$upstream_docs_ws:1234/;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade    $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+    }
         default_type text/html;
         return 200 '<!doctype html>
 <html><head><meta charset="utf-8"><title>OCTO Server</title>

--- a/setup.sh
+++ b/setup.sh
@@ -54,6 +54,7 @@ IP_SET_VIA_CLI=false
 HTTPS_SET_VIA_CLI=false
 SUMMARY_SET_VIA_CLI=false
 SEARCH_SET_VIA_CLI=false
+DOCS_SET_VIA_CLI=false
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_EXAMPLE="${SCRIPT_DIR}/docker/.env.example"
@@ -1576,7 +1577,8 @@ if [[ "${NON_INTERACTIVE}" == "false" ]]; then
      || "${IP_SET_VIA_CLI}" == "true" \
      || "${HTTPS_SET_VIA_CLI}" == "true" \
      || "${SUMMARY_SET_VIA_CLI}" == "true" \
-     || "${SEARCH_SET_VIA_CLI}" == "true" ]]; then
+     || "${SEARCH_SET_VIA_CLI}" == "true" \
+     || "${DOCS_SET_VIA_CLI}" == "true" ]]; then
     info "CLI flags supplied; switching to non-interactive mode."
     info "(Pass no flags, or only --force, to get the interactive prompts.)"
     NON_INTERACTIVE=true
@@ -1976,11 +1978,13 @@ if [[ "${NON_INTERACTIVE}" == "false" ]]; then
   esac
 
   # Docs (collaborative document backend)
-  read -rp "Enable collaborative document backend (octo-docs-backend)? [y/N]: " user_docs
-  case "${user_docs}" in
-    [yY]|[yY][eE][sS]) ENABLE_DOCS=true ;;
-    *) ENABLE_DOCS=false ;;
-  esac
+  if [[ "${DOCS_SET_VIA_CLI}" != "true" ]]; then
+    read -rp "Enable collaborative document backend (octo-docs-backend)? [y/N]: " user_docs
+    case "${user_docs}" in
+      [yY]|[yY][eE][sS]) ENABLE_DOCS=true ;;
+      *) ENABLE_DOCS=false ;;
+    esac
+  fi
 else
   # Non-interactive: auto-detect IP if not provided via --ip
   if [[ -z "${EXTERNAL_IP}" ]]; then
@@ -2084,15 +2088,31 @@ if [[ "${ENABLE_DOCS}"    == "true" ]]; then
   sed_inplace "s|^# *OCTO_DOCS_COLLAB_SECRET=.*|OCTO_DOCS_COLLAB_SECRET=${OCTO_DOCS_COLLAB_SECRET}|" "${ENV_OUT}"
   sed_inplace "s|^# *OCTO_DOCS_ATTACHMENT_SECRET=.*|OCTO_DOCS_ATTACHMENT_SECRET=${OCTO_DOCS_ATTACHMENT_SECRET}|" "${ENV_OUT}"
   sed_inplace "s|^# *OCTO_DOCS_NOTIFY_TOKEN=.*|OCTO_DOCS_NOTIFY_TOKEN=${OCTO_DOCS_NOTIFY_TOKEN}|" "${ENV_OUT}"
-  # Derive the docs-specific URLs from the stack's public address.
-  local_scheme="http"
-  [[ "${ENABLE_HTTPS}" == "true" ]] && local_scheme="wss" || local_scheme="ws"
-  OCTO_DOCS_COLLAB_WS_URL="${local_scheme}://${DOMAIN}:${OCTO_HTTP_PORT:-28080}/docs-ws/"
+  # Derive the docs-specific public URLs. Mirror the S1 rule (GH#41/GH#49):
+  # when OCTO_DOMAIN is a placeholder AND a non-loopback --ip was supplied,
+  # use EXTERNAL_IP so remote browsers get a reachable address instead of
+  # localhost. When a real domain is set (or HTTPS is enabled), derive from
+  # the domain directly. This must be consistent with the S1 block below
+  # which materialises MINIO_SERVER_URL / TS_EXTERNAL_BASEURL the same way.
+  if is_placeholder_domain && [[ -n "${EXTERNAL_IP}" ]] && ! is_loopback_ip "${EXTERNAL_IP}"; then
+    _docs_host="${EXTERNAL_IP}"
+    _docs_base_url="http://${EXTERNAL_IP}:${HTTP_PORT}"
+    _docs_ws_scheme="ws"
+  elif [[ "${ENABLE_HTTPS}" == "true" ]]; then
+    _docs_host="${DOMAIN}"
+    _docs_base_url="https://${DOMAIN}"
+    _docs_ws_scheme="wss"
+  else
+    _docs_host="${DOMAIN}"
+    _docs_base_url="http://${DOMAIN}:${HTTP_PORT}"
+    _docs_ws_scheme="ws"
+  fi
+  OCTO_DOCS_COLLAB_WS_URL="${_docs_ws_scheme}://${_docs_host}:${HTTP_PORT}/docs-ws/"
   [[ "${ENABLE_HTTPS}" == "true" ]] && \
-    OCTO_DOCS_S3_ENDPOINT="https://${DOMAIN}" || \
-    OCTO_DOCS_S3_ENDPOINT="http://${DOMAIN}:${OCTO_HTTP_PORT:-28080}"
-  OCTO_DOCS_WEB_ORIGIN="${OCTO_DOCS_S3_ENDPOINT}"
-  OCTO_DOCS_CORS_ORIGINS="${OCTO_DOCS_S3_ENDPOINT}"
+    OCTO_DOCS_COLLAB_WS_URL="${_docs_ws_scheme}://${_docs_host}/docs-ws/"
+  OCTO_DOCS_S3_ENDPOINT="${_docs_base_url}"
+  OCTO_DOCS_WEB_ORIGIN="${_docs_base_url}"
+  OCTO_DOCS_CORS_ORIGINS="${_docs_base_url}"
   sed_inplace "s|^# *OCTO_DOCS_COLLAB_WS_URL=.*|OCTO_DOCS_COLLAB_WS_URL=${OCTO_DOCS_COLLAB_WS_URL}|" "${ENV_OUT}"
   sed_inplace "s|^# *OCTO_DOCS_S3_ENDPOINT=.*|OCTO_DOCS_S3_ENDPOINT=${OCTO_DOCS_S3_ENDPOINT}|" "${ENV_OUT}"
   sed_inplace "s|^# *OCTO_DOCS_WEB_ORIGIN=.*|OCTO_DOCS_WEB_ORIGIN=${OCTO_DOCS_WEB_ORIGIN}|" "${ENV_OUT}"

--- a/setup.sh
+++ b/setup.sh
@@ -32,6 +32,7 @@ EXTERNAL_IP=""
 ENABLE_HTTPS=false
 ENABLE_SUMMARY=false
 ENABLE_SEARCH=false
+ENABLE_DOCS=false
 NON_INTERACTIVE=false
 FORCE_OVERWRITE=false
 RUN_UP=false
@@ -820,6 +821,7 @@ while [[ $# -gt 0 ]]; do
     --https)    ENABLE_HTTPS=true;   HTTPS_SET_VIA_CLI=true;   shift ;;
     --summary)  ENABLE_SUMMARY=true; SUMMARY_SET_VIA_CLI=true; shift ;;
     --search)   ENABLE_SEARCH=true;  SEARCH_SET_VIA_CLI=true;  shift ;;
+    --docs)     ENABLE_DOCS=true;    DOCS_SET_VIA_CLI=true;    shift ;;
     --up)         RUN_UP=true; shift ;;
     --smoke-test) RUN_VERIFY=true; shift ;;
     # `--verify` is the original spelling, retained as a deprecated alias
@@ -859,6 +861,11 @@ Generation:
                       run `cd docker && scripts/search-upgrade.sh` after
                       the stack is up (see docker/README.md "Search
                       profile" / "Turn search on").
+  --docs              Enable the collaborative document backend
+                      (COMPOSE_PROFILES=docs): octo-docs-backend (Hocuspocus
+                      + Yjs real-time sync). All required secrets are
+                      generated automatically. Can be combined with other
+                      profiles, e.g. --summary --docs.
   --up                START-ONLY subcommand (peer of --smoke-test /
                       --uninstall): requires an existing docker/.env and
                       runs `docker compose up -d --wait --wait-timeout
@@ -1967,6 +1974,13 @@ if [[ "${NON_INTERACTIVE}" == "false" ]]; then
     [yY]|[yY][eE][sS]) ENABLE_SEARCH=true ;;
     *) ENABLE_SEARCH=false ;;
   esac
+
+  # Docs (collaborative document backend)
+  read -rp "Enable collaborative document backend (octo-docs-backend)? [y/N]: " user_docs
+  case "${user_docs}" in
+    [yY]|[yY][eE][sS]) ENABLE_DOCS=true ;;
+    *) ENABLE_DOCS=false ;;
+  esac
 else
   # Non-interactive: auto-detect IP if not provided via --ip
   if [[ -z "${EXTERNAL_IP}" ]]; then
@@ -1980,6 +1994,7 @@ info "External IP: ${EXTERNAL_IP}"
 info "HTTPS:      ${ENABLE_HTTPS}"
 info "Summary:    ${ENABLE_SUMMARY}"
 info "Search:     ${ENABLE_SEARCH}"
+info "Docs:       ${ENABLE_DOCS}"
 
 # ── Generate secrets ────────────────────────────────────────────────────────
 info "Generating random secrets…"
@@ -2058,6 +2073,31 @@ sed_inplace "s|^# *OCTO_ADMIN_PWD=.*|OCTO_ADMIN_PWD=${OCTO_ADMIN_PWD}|" "${ENV_O
 # Optional compose profiles (merge, not clobber — summary + search coexist).
 if [[ "${ENABLE_SUMMARY}" == "true" ]]; then add_compose_profile summary; fi
 if [[ "${ENABLE_SEARCH}"  == "true" ]]; then add_compose_profile search;  fi
+if [[ "${ENABLE_DOCS}"    == "true" ]]; then
+  add_compose_profile docs
+  # Generate docs secrets and write them into .env.
+  OCTO_DOCS_DB_PASSWORD="$(openssl rand -hex 16)"
+  OCTO_DOCS_COLLAB_SECRET="$(openssl rand -hex 32)"
+  OCTO_DOCS_ATTACHMENT_SECRET="$(openssl rand -hex 32)"
+  OCTO_DOCS_NOTIFY_TOKEN="$(openssl rand -hex 32)"
+  sed_inplace "s|^# *OCTO_DOCS_DB_PASSWORD=.*|OCTO_DOCS_DB_PASSWORD=${OCTO_DOCS_DB_PASSWORD}|" "${ENV_OUT}"
+  sed_inplace "s|^# *OCTO_DOCS_COLLAB_SECRET=.*|OCTO_DOCS_COLLAB_SECRET=${OCTO_DOCS_COLLAB_SECRET}|" "${ENV_OUT}"
+  sed_inplace "s|^# *OCTO_DOCS_ATTACHMENT_SECRET=.*|OCTO_DOCS_ATTACHMENT_SECRET=${OCTO_DOCS_ATTACHMENT_SECRET}|" "${ENV_OUT}"
+  sed_inplace "s|^# *OCTO_DOCS_NOTIFY_TOKEN=.*|OCTO_DOCS_NOTIFY_TOKEN=${OCTO_DOCS_NOTIFY_TOKEN}|" "${ENV_OUT}"
+  # Derive the docs-specific URLs from the stack's public address.
+  local_scheme="http"
+  [[ "${ENABLE_HTTPS}" == "true" ]] && local_scheme="wss" || local_scheme="ws"
+  OCTO_DOCS_COLLAB_WS_URL="${local_scheme}://${DOMAIN}:${OCTO_HTTP_PORT:-28080}/docs-ws/"
+  [[ "${ENABLE_HTTPS}" == "true" ]] && \
+    OCTO_DOCS_S3_ENDPOINT="https://${DOMAIN}" || \
+    OCTO_DOCS_S3_ENDPOINT="http://${DOMAIN}:${OCTO_HTTP_PORT:-28080}"
+  OCTO_DOCS_WEB_ORIGIN="${OCTO_DOCS_S3_ENDPOINT}"
+  OCTO_DOCS_CORS_ORIGINS="${OCTO_DOCS_S3_ENDPOINT}"
+  sed_inplace "s|^# *OCTO_DOCS_COLLAB_WS_URL=.*|OCTO_DOCS_COLLAB_WS_URL=${OCTO_DOCS_COLLAB_WS_URL}|" "${ENV_OUT}"
+  sed_inplace "s|^# *OCTO_DOCS_S3_ENDPOINT=.*|OCTO_DOCS_S3_ENDPOINT=${OCTO_DOCS_S3_ENDPOINT}|" "${ENV_OUT}"
+  sed_inplace "s|^# *OCTO_DOCS_WEB_ORIGIN=.*|OCTO_DOCS_WEB_ORIGIN=${OCTO_DOCS_WEB_ORIGIN}|" "${ENV_OUT}"
+  sed_inplace "s|^# *OCTO_DOCS_CORS_ORIGINS=.*|OCTO_DOCS_CORS_ORIGINS=${OCTO_DOCS_CORS_ORIGINS}|" "${ENV_OUT}"
+fi
 
 # ── Persist COMPOSE_PROJECT_NAME into .env ─────────────────────────────────
 # INCIDENT-2026-05-16-001 follow-up: the interactive preflight may
@@ -2262,6 +2302,11 @@ if [[ "${ENABLE_SEARCH}" == "true" ]]; then
   info "onto OpenSearch, run the zero-downtime upgrade after the stack is up:"
   info "  cd docker && scripts/search-upgrade.sh"
   info "See docker/README.md \"Search profile\" / \"Turn search on\"."
+fi
+
+if [[ "${ENABLE_DOCS}" == "true" ]]; then
+  info "Docs profile enabled. octo-docs-backend (Hocuspocus + Yjs) will start"
+  info "with the stack. All required secrets have been generated into docker/.env."
 fi
 
 # R6 (YUJ-1020): we are always on the generation path here (--up exits


### PR DESCRIPTION
## Summary

Wire the `octo-docs-backend` (Hocuspocus + Yjs collaborative documents) profile into the OOTB Docker Compose stack. Discovered via customer deployments where running `./setup.sh --up` never started docs even when desired, and several nginx routing bugs that broke bot API and WebSocket.

## Changes

### 1. `setup.sh` — docs profile opt-in

Add `--docs` CLI flag and an interactive prompt (parallel to the existing `--summary` / `--search` flow). When enabled:
- Merges `docs` into `COMPOSE_PROFILES`
- Auto-generates all required secrets (`OCTO_DOCS_DB_PASSWORD`, `OCTO_DOCS_COLLAB_SECRET`, `OCTO_DOCS_ATTACHMENT_SECRET`, `OCTO_DOCS_NOTIFY_TOKEN`)
- Derives `OCTO_DOCS_COLLAB_WS_URL` / `OCTO_DOCS_S3_ENDPOINT` / `OCTO_DOCS_WEB_ORIGIN` / `OCTO_DOCS_CORS_ORIGINS` from the stack's public address (respecting `--https` for `wss://` vs `ws://`)
- Prints a post-generation notice

### 2. `docker-compose.yaml` — `ATTACHMENT_S3_INTERNAL_ENDPOINT`

Add `ATTACHMENT_S3_INTERNAL_ENDPOINT: http://minio:9000` to the `octo-docs-backend` service. Without this, docs-backend uses the public `ATTACHMENT_S3_ENDPOINT` for server-side operations (PDF export image download). The public URL is unreachable from inside the Docker network, so **PDF exports silently lose embedded images**. The internal endpoint lets docs-backend reach MinIO directly.

### 3. `nginx/conf.d/octo.conf.template` — three missing routes

| Route | Problem without it |
|---|---|
| `location ^~ /api/v1/docs` | octo-web ≤ 1.12 calls `/api/v1/docs` directly; falls through to octo-server → 404 |
| `location ^~ /v1/bot/docs` | octo-cli / OpenClaw bot API → octo-server → 404 |
| `location = /docs-ws` | Browsers connect to `ws://host/docs-ws` (no slash); fell through to SPA catch-all → 200 HTML instead of 101, every document stuck in `document_not_connected`, PDF exports fail |

## Testing

- [ ] `./setup.sh --docs` generates secrets and writes `COMPOSE_PROFILES=docs` into `.env`
- [ ] `docker compose --profile docs up -d` starts `octo-docs-backend` healthy
- [ ] `GET /api/v1/docs` reaches docs-backend (not octo-server)
- [ ] `GET /v1/bot/docs` reaches docs-backend with bot token
- [ ] `ws://host/docs-ws` upgrades to 101 (no trailing slash)
- [ ] PDF export preserves embedded images

🤖 Generated with [Claude Code](https://claude.com/claude-code)